### PR TITLE
feat(study): study service + user.db migration v25 (study_plans, study_plan_items) — #1831

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -29,12 +29,14 @@ import { pruneEvents } from './src/services/analytics';
 import { checkAndScheduleReengagement } from './src/services/reengagement';
 import { rescheduleIfStale } from './src/services/notifications';
 import { initializePurchases, syncPremiumStatus } from './src/services/purchases';
+import { migrateLegacyPlans } from './src/services/study';
 import { flushQueue } from './src/services/syncQueue';
 import { RootNavigator } from './src/navigation';
 import type { TabParamList } from './src/navigation/types';
 import { useNotificationRouter } from './src/hooks/useNotificationRouter';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { closeAllTranslationDbs } from './src/db/translationManager';
+import { logger } from './src/utils/logger';
 import { ContentUpdateProvider } from './src/providers/ContentUpdateProvider';
 import { AmicusConsentProvider } from './src/services/amicus/consent';
 import type { PromotePeekResult } from './src/services/amicus';
@@ -208,6 +210,14 @@ function AppShell() {
  */
 async function hydrateAppState(): Promise<void> {
   await initUserDatabase(); // User DB (user.db) — never replaced, migrated
+  // One-time seed of legacy reading plans into the unified study-plan
+  // tables (#1831). Best-effort: on failure the app_meta guard stays
+  // unset and the seed retries on the next launch.
+  try {
+    await migrateLegacyPlans();
+  } catch (err) {
+    logger.error('studyPlans', 'migrateLegacyPlans failed — will retry next launch', err);
+  }
   // Bind an anonymous identifier to Sentry so crashes from a single
   // install roll up under one user. Best-effort — if it fails we
   // just don't get per-user grouping this session.

--- a/app/__tests__/db/migrationV24.test.ts
+++ b/app/__tests__/db/migrationV24.test.ts
@@ -54,15 +54,16 @@ describe('migration v24 — captured_inputs columns on guided_study_sessions', (
     expect(mockWithTransactionAsync).not.toHaveBeenCalled();
   });
 
-  it('applies exactly one transaction when only versions 1..23 have run (v24 is the only pending one)', async () => {
+  it('runs v24 (and any later migrations) when only versions 1..23 have run', async () => {
     jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
     jest.resetModules();
-    const { initUserDatabase } = require('@/db/userDatabase');
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
     mockGetAllAsync.mockResolvedValueOnce(
       Array.from({ length: 23 }, (_, i) => ({ version: i + 1 })),
     );
     await initUserDatabase();
-    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(1);
+    // v24 plus whatever has been appended since — one transaction each.
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT - 23);
   });
 
   it("v24's SQL adds the three captured-inputs columns to guided_study_sessions", async () => {

--- a/app/__tests__/db/migrationV25.test.ts
+++ b/app/__tests__/db/migrationV25.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #1831 — focused test for migration v25 (unified study plans:
+ * study_plans, study_plan_items, plan_id on guided_study_sessions).
+ *
+ * Mirrors __tests__/db/migrationV24.test.ts so the migration-runner
+ * mocks are reused. NOT mocking @/db/userDatabase — the point is to
+ * exercise the real migration loop on a fresh install and on a v24 DB.
+ */
+const mockExecAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllAsync = jest.fn().mockResolvedValue([]);
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 0 });
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+const mockOpenDatabaseAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: unknown[]) => mockOpenDatabaseAsync(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  mockOpenDatabaseAsync.mockResolvedValue({
+    execAsync: mockExecAsync,
+    getAllAsync: mockGetAllAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  });
+});
+
+describe('migration v25 — unified study plans', () => {
+  it('the migration count includes v25', () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT } = require('@/db/userDatabase');
+    expect(MIGRATION_COUNT).toBeGreaterThanOrEqual(25);
+  });
+
+  it('applies cleanly on a fresh install (no versions applied → every migration runs)', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce([]);
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT);
+  });
+
+  it('runs v25 (and any later migrations) on a v24 DB', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 24 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    // v25 plus whatever gets appended later — one transaction each.
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT - 24);
+  });
+
+  it('skips every migration when v25 (and all earlier versions) are already applied', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: MIGRATION_COUNT }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).not.toHaveBeenCalled();
+  });
+
+  it("v25's SQL creates both plan tables and adds plan_id to guided_study_sessions", async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 24 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    const allSql = mockExecAsync.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('\n');
+    expect(allSql).toContain('CREATE TABLE IF NOT EXISTS study_plans');
+    expect(allSql).toContain('CREATE TABLE IF NOT EXISTS study_plan_items');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN plan_id TEXT');
+    // Append-only contract: v25 must not drop or rewrite legacy tables.
+    expect(allSql).not.toMatch(/DROP TABLE/i);
+    expect(allSql).not.toMatch(/ALTER TABLE reading_plans/i);
+    expect(allSql).not.toMatch(/ALTER TABLE plan_progress/i);
+  });
+});

--- a/app/__tests__/services/study/migrateLegacyPlans.test.ts
+++ b/app/__tests__/services/study/migrateLegacyPlans.test.ts
@@ -1,0 +1,200 @@
+/**
+ * #1831 — legacy reading-plan seed (services/study/migrateLegacyPlans).
+ *
+ * Uses a targeted in-memory fake of the user.db surface the seed
+ * touches (app_meta guard, reading_plans/plan_progress reads,
+ * INSERT OR IGNORE writes) so idempotency is exercised for real:
+ * both the app_meta short-circuit and the deterministic-id/OR-IGNORE
+ * layer that protects a retry after a mid-flight failure.
+ */
+import type { PlanProgress, ReadingPlan } from '@/db/userQueries';
+
+interface FakeDb {
+  appMeta: Map<string, string>;
+  studyPlans: Map<string, unknown[]>;
+  planItems: Map<string, unknown[]>;
+  getFirstAsync: jest.Mock;
+  getAllAsync: jest.Mock;
+  runAsync: jest.Mock;
+  withTransactionAsync: jest.Mock;
+}
+
+const LEGACY_PLANS: ReadingPlan[] = [
+  {
+    id: 'psalms_of_lament',
+    name: 'Psalms of Lament',
+    description: 'Seven lament psalms.',
+    total_days: 2,
+    chapters_json: JSON.stringify([
+      { day: 1, chapters: ['psalms_13'] },
+      { day: 2, chapters: ['psalms_22', 'psalms_42'] },
+    ]),
+  },
+  {
+    id: 'life_of_david',
+    name: 'The Life of David',
+    description: 'David from shepherd to king.',
+    total_days: 1,
+    chapters_json: JSON.stringify([{ day: 1, chapters: ['1_samuel_16', '1_samuel_17'] }]),
+  },
+];
+
+const LEGACY_PROGRESS: PlanProgress[] = [
+  { plan_id: 'psalms_of_lament', day_num: 1, completed_at: '2026-06-01 09:00:00' },
+  { plan_id: 'psalms_of_lament', day_num: 2, completed_at: null },
+  { plan_id: 'life_of_david', day_num: 1, completed_at: '2026-06-15 20:30:00' },
+];
+
+function makeFakeDb(plans: ReadingPlan[], progress: PlanProgress[]): FakeDb {
+  const appMeta = new Map<string, string>();
+  const studyPlans = new Map<string, unknown[]>();
+  const planItems = new Map<string, unknown[]>();
+
+  const db: FakeDb = {
+    appMeta,
+    studyPlans,
+    planItems,
+    getFirstAsync: jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('FROM app_meta')) {
+        const value = appMeta.get(params[0] as string);
+        return value != null ? { value } : null;
+      }
+      return null;
+    }),
+    getAllAsync: jest.fn(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM reading_plans')) return plans;
+      if (sql.includes('FROM plan_progress')) {
+        return progress.filter((p) => p.plan_id === (params?.[0] as string));
+      }
+      return [];
+    }),
+    runAsync: jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('INTO study_plans')) {
+        // INSERT OR IGNORE on PRIMARY KEY (id)
+        const id = params[0] as string;
+        if (!studyPlans.has(id)) studyPlans.set(id, params);
+      } else if (sql.includes('INTO study_plan_items')) {
+        // INSERT OR IGNORE on PRIMARY KEY (plan_id, item_num)
+        const key = `${params[0]}:${params[1]}`;
+        if (!planItems.has(key)) planItems.set(key, params);
+      } else if (sql.includes('INTO app_meta')) {
+        appMeta.set(params[0] as string, '1');
+      }
+      return { changes: 1 };
+    }),
+    withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  };
+  return db;
+}
+
+let mockDb: FakeDb;
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => mockDb,
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { migrateLegacyPlans } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb = makeFakeDb(LEGACY_PLANS, LEGACY_PROGRESS);
+});
+
+describe('migrateLegacyPlans (#1831)', () => {
+  it('seeds one custom study plan per legacy reading plan', async () => {
+    await migrateLegacyPlans();
+
+    expect(mockDb.studyPlans.size).toBe(2);
+    const psalms = mockDb.studyPlans.get('legacy_psalms_of_lament');
+    // params: [id, source_id, title] — plan_type/default_mode are inline SQL
+    expect(psalms).toEqual(['legacy_psalms_of_lament', 'psalms_of_lament', 'Psalms of Lament']);
+    const insertPlanSql = mockDb.runAsync.mock.calls.find((c) =>
+      (c[0] as string).includes('INTO study_plans'),
+    )?.[0] as string;
+    expect(insertPlanSql).toContain("'custom'");
+    expect(insertPlanSql).toContain("'quick'");
+  });
+
+  it('expands chapters_json into reading items and copies day completion onto them', async () => {
+    await migrateLegacyPlans();
+
+    // psalms_of_lament: day 1 = 1 chapter, day 2 = 2 chapters → items 1..3
+    expect(mockDb.planItems.get('legacy_psalms_of_lament:1')).toEqual([
+      'legacy_psalms_of_lament',
+      1,
+      JSON.stringify({ bookId: 'psalms', chapterNum: 13 }),
+      '2026-06-01 09:00:00', // day 1 completed
+    ]);
+    expect(mockDb.planItems.get('legacy_psalms_of_lament:2')).toEqual([
+      'legacy_psalms_of_lament',
+      2,
+      JSON.stringify({ bookId: 'psalms', chapterNum: 22 }),
+      null, // day 2 not completed
+    ]);
+    expect(mockDb.planItems.get('legacy_psalms_of_lament:3')?.[3]).toBeNull();
+
+    // Multi-underscore book ids parse correctly and inherit day completion.
+    expect(mockDb.planItems.get('legacy_life_of_david:1')).toEqual([
+      'legacy_life_of_david',
+      1,
+      JSON.stringify({ bookId: '1_samuel', chapterNum: 16 }),
+      '2026-06-15 20:30:00',
+    ]);
+    expect(mockDb.planItems.get('legacy_life_of_david:2')?.[3]).toBe('2026-06-15 20:30:00');
+    expect(mockDb.planItems.size).toBe(5);
+  });
+
+  it('sets the app_meta guard so the second run is a no-op', async () => {
+    await migrateLegacyPlans();
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
+
+    const writesAfterFirstRun = mockDb.runAsync.mock.calls.length;
+    await migrateLegacyPlans();
+
+    expect(mockDb.runAsync.mock.calls.length).toBe(writesAfterFirstRun);
+    expect(mockDb.withTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(mockDb.studyPlans.size).toBe(2);
+    expect(mockDb.planItems.size).toBe(5);
+  });
+
+  it('is idempotent on retry even when the guard was never written (OR IGNORE layer)', async () => {
+    await migrateLegacyPlans();
+    // Simulate a run where everything inserted but the guard write was lost.
+    mockDb.appMeta.delete('legacy_plans_migrated');
+
+    await migrateLegacyPlans();
+
+    expect(mockDb.studyPlans.size).toBe(2);
+    expect(mockDb.planItems.size).toBe(5);
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
+  });
+
+  it('skips unparseable chapter ids without aborting the seed', async () => {
+    mockDb = makeFakeDb(
+      [
+        {
+          id: 'broken',
+          name: 'Broken',
+          description: '',
+          total_days: 1,
+          chapters_json: JSON.stringify([{ day: 1, chapters: ['???', 'genesis_1'] }]),
+        },
+      ],
+      [],
+    );
+
+    await migrateLegacyPlans();
+
+    expect(mockDb.studyPlans.size).toBe(1);
+    // item_num 1 was consumed by the skipped id; genesis_1 lands at 2.
+    expect(mockDb.planItems.size).toBe(1);
+    expect(mockDb.planItems.get('legacy_broken:2')?.[2]).toBe(
+      JSON.stringify({ bookId: 'genesis', chapterNum: 1 }),
+    );
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
+  });
+});

--- a/app/__tests__/services/study/planTemplates.test.ts
+++ b/app/__tests__/services/study/planTemplates.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #1831 — plan template builders (services/study/planTemplates).
+ * Items must be derived from content queries only, so every builder is
+ * exercised against mocked content-DB rows.
+ */
+import type { JourneyStop } from '@/types';
+
+const mockGetBook = jest.fn();
+const mockGetJourneyStops = jest.fn();
+const mockGetTopic = jest.fn();
+
+jest.mock('@/db/content', () => ({
+  getBook: (...args: unknown[]) => mockGetBook(...args),
+}));
+
+jest.mock('@/db/content/features', () => ({
+  getJourneyStops: (...args: unknown[]) => mockGetJourneyStops(...args),
+}));
+
+jest.mock('@/db/content/reference', () => ({
+  getTopic: (...args: unknown[]) => mockGetTopic(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import {
+  buildBookPlanItems,
+  buildJourneyPlanItems,
+  buildTopicPlanItems,
+  parseChapterId,
+} from '@/services/study';
+
+function makeStop(overrides: Partial<JourneyStop>): JourneyStop {
+  return {
+    id: 1,
+    journey_id: 'j1',
+    stop_order: 1,
+    stop_type: 'passage' as JourneyStop['stop_type'],
+    label: null,
+    ref: null,
+    book_id: null,
+    chapter_num: null,
+    verse_start: null,
+    verse_end: null,
+    development: null,
+    what_changes: null,
+    linked_journey_id: null,
+    linked_journey_intro: null,
+    bridge_to_next: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('parseChapterId', () => {
+  it('parses simple and multi-underscore chapter ids', () => {
+    expect(parseChapterId('genesis_1')).toEqual({ bookId: 'genesis', chapterNum: 1 });
+    expect(parseChapterId('1_samuel_16')).toEqual({ bookId: '1_samuel', chapterNum: 16 });
+    expect(parseChapterId('song_of_solomon_4')).toEqual({
+      bookId: 'song_of_solomon',
+      chapterNum: 4,
+    });
+  });
+
+  it('returns null on unrecognized input', () => {
+    expect(parseChapterId('genesis')).toBeNull();
+    expect(parseChapterId('')).toBeNull();
+  });
+});
+
+describe('buildBookPlanItems', () => {
+  it('emits one session item per chapter in order', async () => {
+    mockGetBook.mockResolvedValue({ id: 'jonah', total_chapters: 4 });
+
+    const items = await buildBookPlanItems('jonah');
+
+    expect(mockGetBook).toHaveBeenCalledWith('jonah');
+    expect(items).toHaveLength(4);
+    expect(items[0]).toEqual({ kind: 'session', ref: { bookId: 'jonah', chapterNum: 1 } });
+    expect(items[3]).toEqual({ kind: 'session', ref: { bookId: 'jonah', chapterNum: 4 } });
+  });
+
+  it('returns [] for an unknown book', async () => {
+    mockGetBook.mockResolvedValue(null);
+    expect(await buildBookPlanItems('atlantis')).toEqual([]);
+  });
+});
+
+describe('buildJourneyPlanItems', () => {
+  it('emits session items for scripture-anchored stops, keeping stop order and verse anchors', async () => {
+    mockGetJourneyStops.mockResolvedValue([
+      makeStop({ id: 11, stop_order: 1, book_id: 'genesis', chapter_num: 9 }),
+      makeStop({ id: 12, stop_order: 2, book_id: null, chapter_num: null }), // interlude
+      makeStop({ id: 13, stop_order: 3, book_id: 'jeremiah', chapter_num: 31, verse_start: 31 }),
+    ]);
+
+    const items = await buildJourneyPlanItems('covenant');
+
+    expect(mockGetJourneyStops).toHaveBeenCalledWith('covenant');
+    expect(items).toEqual([
+      { kind: 'session', ref: { bookId: 'genesis', chapterNum: 9, stopId: 11 } },
+      {
+        kind: 'session',
+        ref: { bookId: 'jeremiah', chapterNum: 31, verseStart: 31, stopId: 13 },
+      },
+    ]);
+  });
+
+  it('returns [] for a journey with no stops', async () => {
+    mockGetJourneyStops.mockResolvedValue([]);
+    expect(await buildJourneyPlanItems('empty')).toEqual([]);
+  });
+});
+
+describe('buildTopicPlanItems', () => {
+  it('emits deduped session items from relevant_chapters_json in curated order', async () => {
+    mockGetTopic.mockResolvedValue({
+      id: 'covenant',
+      relevant_chapters_json: JSON.stringify([
+        'genesis_15',
+        'exodus_19',
+        'genesis_15', // duplicate — dropped
+        'not-a-chapter', // unparseable — dropped
+        '2_samuel_7',
+      ]),
+    });
+
+    const items = await buildTopicPlanItems('covenant');
+
+    expect(items).toEqual([
+      { kind: 'session', ref: { bookId: 'genesis', chapterNum: 15 } },
+      { kind: 'session', ref: { bookId: 'exodus', chapterNum: 19 } },
+      { kind: 'session', ref: { bookId: '2_samuel', chapterNum: 7 } },
+    ]);
+  });
+
+  it('returns [] for an unknown topic, a null chapter list, or bad JSON', async () => {
+    mockGetTopic.mockResolvedValueOnce(null);
+    expect(await buildTopicPlanItems('missing')).toEqual([]);
+
+    mockGetTopic.mockResolvedValueOnce({ id: 't', relevant_chapters_json: null });
+    expect(await buildTopicPlanItems('t')).toEqual([]);
+
+    mockGetTopic.mockResolvedValueOnce({ id: 't', relevant_chapters_json: '{oops' });
+    expect(await buildTopicPlanItems('t')).toEqual([]);
+  });
+});

--- a/app/__tests__/services/study/progression.test.ts
+++ b/app/__tests__/services/study/progression.test.ts
@@ -1,0 +1,156 @@
+/**
+ * #1831 — progression helpers (services/study/progression).
+ */
+import type { StudyPlan, StudyPlanItem } from '@/types';
+
+const mockGetStudyPlans = jest.fn();
+const mockGetStudyPlanItems = jest.fn();
+const mockGetGuidedStudySession = jest.fn();
+
+jest.mock('@/db/userQueries', () => ({
+  getStudyPlans: (...args: unknown[]) => mockGetStudyPlans(...args),
+  getStudyPlanItems: (...args: unknown[]) => mockGetStudyPlanItems(...args),
+  getGuidedStudySession: (...args: unknown[]) => mockGetGuidedStudySession(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { getActivePlan, getNextItem, percentComplete, resumeTarget } from '@/services/study';
+
+function makePlan(id: string): StudyPlan {
+  return {
+    id,
+    plan_type: 'book',
+    source_id: 'genesis',
+    title: 'Genesis',
+    default_mode: 'quick',
+    created_at: '2026-06-01 00:00:00',
+    archived_at: null,
+  };
+}
+
+function makeItem(
+  planId: string,
+  itemNum: number,
+  overrides: Partial<StudyPlanItem> = {},
+): StudyPlanItem {
+  return {
+    plan_id: planId,
+    item_num: itemNum,
+    kind: 'session',
+    ref_json: JSON.stringify({ bookId: 'genesis', chapterNum: itemNum }),
+    session_id: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getActivePlan', () => {
+  it('returns the newest plan that still has an incomplete item', async () => {
+    mockGetStudyPlans.mockResolvedValue([makePlan('newest'), makePlan('older')]);
+    mockGetStudyPlanItems.mockImplementation(async (planId: string) =>
+      planId === 'newest'
+        ? [makeItem('newest', 1, { completed_at: '2026-06-02 08:00:00' })] // fully done
+        : [makeItem('older', 1)],
+    );
+
+    const active = await getActivePlan();
+    expect(active?.id).toBe('older');
+  });
+
+  it('returns null when every plan is complete or there are no plans', async () => {
+    mockGetStudyPlans.mockResolvedValue([makePlan('done')]);
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('done', 1, { completed_at: '2026-06-02 08:00:00' }),
+    ]);
+    expect(await getActivePlan()).toBeNull();
+
+    mockGetStudyPlans.mockResolvedValue([]);
+    expect(await getActivePlan()).toBeNull();
+  });
+});
+
+describe('getNextItem', () => {
+  it('returns the first incomplete item', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('p', 1, { completed_at: '2026-06-02 08:00:00' }),
+      makeItem('p', 2),
+      makeItem('p', 3),
+    ]);
+    const next = await getNextItem('p');
+    expect(next?.item_num).toBe(2);
+  });
+
+  it('returns null when the plan is complete or empty', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('p', 1, { completed_at: '2026-06-02 08:00:00' }),
+    ]);
+    expect(await getNextItem('p')).toBeNull();
+
+    mockGetStudyPlanItems.mockResolvedValue([]);
+    expect(await getNextItem('p')).toBeNull();
+  });
+});
+
+describe('percentComplete', () => {
+  it('rounds to a whole percentage', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('p', 1, { completed_at: 'x' }),
+      makeItem('p', 2),
+      makeItem('p', 3),
+    ]);
+    expect(await percentComplete('p')).toBe(33);
+  });
+
+  it('reads empty plans as 0 and finished plans as 100', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([]);
+    expect(await percentComplete('p')).toBe(0);
+
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 1, { completed_at: 'x' })]);
+    expect(await percentComplete('p')).toBe(100);
+  });
+});
+
+describe('resumeTarget', () => {
+  it('returns the next item’s chapter without a step when no session is attached', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 5)]);
+    expect(await resumeTarget('p')).toEqual({ bookId: 'genesis', chapterNum: 5 });
+    expect(mockGetGuidedStudySession).not.toHaveBeenCalled();
+  });
+
+  it('includes the current step when the linked session is still active', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 2, { session_id: '42' })]);
+    mockGetGuidedStudySession.mockResolvedValue({ id: 42, status: 'active', current_step: 'explore' });
+
+    expect(await resumeTarget('p')).toEqual({
+      bookId: 'genesis',
+      chapterNum: 2,
+      step: 'explore',
+    });
+    expect(mockGetGuidedStudySession).toHaveBeenCalledWith(42);
+  });
+
+  it('omits the step when the linked session is completed', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 2, { session_id: '42' })]);
+    mockGetGuidedStudySession.mockResolvedValue({
+      id: 42,
+      status: 'completed',
+      current_step: 'review',
+    });
+    expect(await resumeTarget('p')).toEqual({ bookId: 'genesis', chapterNum: 2 });
+  });
+
+  it('returns null for a finished plan or an unparseable ref', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 1, { completed_at: 'x' })]);
+    expect(await resumeTarget('p')).toBeNull();
+
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 1, { ref_json: '{broken' })]);
+    expect(await resumeTarget('p')).toBeNull();
+  });
+});

--- a/app/__tests__/services/study/rhythm.test.ts
+++ b/app/__tests__/services/study/rhythm.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #1831 — weekly rhythm (services/study/rhythm). Derived only:
+ * counts come straight from guided_study_sessions / guided_review_items.
+ */
+const mockGetAllAsync = jest.fn();
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({ getAllAsync: mockGetAllAsync }),
+}));
+
+import { getWeeklyRhythm, isoWeekKey, isoWeekStart, parseSqliteUtc } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isoWeekKey', () => {
+  it('follows ISO-8601 week-year boundaries', () => {
+    // 2026-01-01 is a Thursday → W01 of 2026.
+    expect(isoWeekKey(new Date(Date.UTC(2026, 0, 1)))).toBe('2026-W01');
+    // 2025-12-29 (Mon) belongs to the same ISO week → 2026-W01.
+    expect(isoWeekKey(new Date(Date.UTC(2025, 11, 29)))).toBe('2026-W01');
+    // 2027-01-01 is a Friday whose week's Thursday is 2026-12-31 → 2026-W53.
+    expect(isoWeekKey(new Date(Date.UTC(2027, 0, 1)))).toBe('2026-W53');
+    expect(isoWeekKey(new Date(Date.UTC(2026, 6, 2)))).toBe('2026-W27');
+  });
+});
+
+describe('isoWeekStart', () => {
+  it('returns the Monday of the containing ISO week', () => {
+    // 2026-07-02 is a Thursday; its week starts Monday 2026-06-29.
+    expect(isoWeekStart(new Date(Date.UTC(2026, 6, 2))).toISOString().slice(0, 10)).toBe(
+      '2026-06-29',
+    );
+    // A Monday maps to itself; a Sunday maps back six days.
+    expect(isoWeekStart(new Date(Date.UTC(2026, 5, 29))).toISOString().slice(0, 10)).toBe(
+      '2026-06-29',
+    );
+    expect(isoWeekStart(new Date(Date.UTC(2026, 6, 5))).toISOString().slice(0, 10)).toBe(
+      '2026-06-29',
+    );
+  });
+});
+
+describe('parseSqliteUtc', () => {
+  it('parses SQLite datetime strings as UTC and rejects garbage', () => {
+    const parsed = parseSqliteUtc('2026-07-02 08:30:00');
+    expect(parsed?.toISOString()).toBe('2026-07-02T08:30:00.000Z');
+    expect(parseSqliteUtc('not a date')).toBeNull();
+  });
+});
+
+describe('getWeeklyRhythm', () => {
+  const NOW = new Date(Date.UTC(2026, 6, 2, 12, 0, 0)); // Thu 2026-07-02, week 2026-W27
+
+  it('zero-fills the trailing window and buckets completions per ISO week', async () => {
+    mockGetAllAsync
+      .mockResolvedValueOnce([
+        // sessions
+        { completed_at: '2026-07-01 09:00:00' }, // W27
+        { completed_at: '2026-06-24 21:00:00' }, // W26
+        { completed_at: '2026-06-23 07:15:00' }, // W26
+      ])
+      .mockResolvedValueOnce([
+        // reviews
+        { updated_at: '2026-06-29 06:00:00' }, // W27
+        { updated_at: '2026-05-20 06:00:00' }, // W21 — inside a 8-week window
+      ]);
+
+    const rhythm = await getWeeklyRhythm(8, NOW);
+
+    expect(rhythm).toHaveLength(8);
+    expect(rhythm[0].week).toBe('2026-W20'); // oldest first
+    expect(rhythm[7]).toEqual({
+      week: '2026-W27',
+      weekStart: '2026-06-29',
+      sessions: 1,
+      reviews: 1,
+    });
+    const w26 = rhythm.find((r) => r.week === '2026-W26');
+    expect(w26).toMatchObject({ sessions: 2, reviews: 0 });
+    const w21 = rhythm.find((r) => r.week === '2026-W21');
+    expect(w21).toMatchObject({ sessions: 0, reviews: 1 });
+    // Untouched weeks stay zero-filled.
+    expect(rhythm.find((r) => r.week === '2026-W24')).toMatchObject({ sessions: 0, reviews: 0 });
+  });
+
+  it('ignores rows outside the window and unparseable timestamps', async () => {
+    mockGetAllAsync
+      .mockResolvedValueOnce([
+        { completed_at: '2020-01-01 00:00:00' }, // ancient — no bucket
+        { completed_at: 'garbage' },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const rhythm = await getWeeklyRhythm(4, NOW);
+
+    expect(rhythm).toHaveLength(4);
+    expect(rhythm.every((r) => r.sessions === 0 && r.reviews === 0)).toBe(true);
+  });
+
+  it('queries only completed sessions and completed reviews', async () => {
+    mockGetAllAsync.mockResolvedValue([]);
+    await getWeeklyRhythm(8, NOW);
+
+    const [sessionSql] = mockGetAllAsync.mock.calls[0];
+    const [reviewSql] = mockGetAllAsync.mock.calls[1];
+    expect(sessionSql).toContain('FROM guided_study_sessions');
+    expect(sessionSql).toContain("status = 'completed'");
+    expect(reviewSql).toContain('FROM guided_review_items');
+    expect(reviewSql).toContain("status = 'completed'");
+  });
+});

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -772,6 +772,34 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE guided_study_sessions ADD COLUMN synthesis_strategy TEXT;
     `,
   },
+  {
+    version: 25,
+    description:
+      'Unified study plans (#1831) — study_plans + study_plan_items, plan_id on guided_study_sessions. Legacy reading_plans/plan_progress stay untouched (read-only).',
+    sql: `
+      CREATE TABLE IF NOT EXISTS study_plans (
+        id TEXT PRIMARY KEY,
+        plan_type TEXT NOT NULL,          -- 'book' | 'journey' | 'topical' | 'custom'
+        source_id TEXT NOT NULL,          -- book_id | journey_id | topic_id
+        title TEXT NOT NULL,
+        default_mode TEXT NOT NULL,       -- GuidedStudyMode
+        created_at TEXT NOT NULL,
+        archived_at TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS study_plan_items (
+        plan_id TEXT NOT NULL REFERENCES study_plans(id),
+        item_num INTEGER NOT NULL,
+        kind TEXT NOT NULL,               -- 'session' | 'reading'
+        ref_json TEXT NOT NULL,           -- {"bookId","chapterNum","verseStart"?,"stopId"?}
+        session_id TEXT,
+        completed_at TEXT,
+        PRIMARY KEY (plan_id, item_num)
+      );
+
+      ALTER TABLE guided_study_sessions ADD COLUMN plan_id TEXT;
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -5,6 +5,7 @@
  * via getUserDb().
  */
 
+import * as Crypto from 'expo-crypto';
 import { serializeAmicusChapterRef, type AmicusEntryPoint } from '../services/amicus/context';
 import { emitAmicusUsageChanged } from '../services/amicus/usageEvents';
 import {
@@ -14,7 +15,7 @@ import {
 } from '../services/guidedStudy/capturedInputs';
 import { logger } from '../utils/logger';
 import { nextIntervalAfter } from '../services/guidedStudy/review';
-import type { GuidedStudyStep } from '../types';
+import type { GuidedStudyStep, StudyPlanItemDraft, StudyPlanType } from '../types';
 import { getUserDb } from './userDatabase';
 import type { ReadingPlan } from './userQueries';
 
@@ -191,6 +192,78 @@ export async function abandonPlan(planId: string): Promise<void> {
     await getUserDb().runAsync(
       "INSERT OR REPLACE INTO user_preferences (key, value) VALUES ('active_plan', '')",
     );
+  });
+}
+
+// ── Unified Study Plans (write) — #1831, migration v25 ───────────
+
+export interface CreateStudyPlanArgs {
+  /** Optional stable id — generated (UUID v4) when omitted. */
+  id?: string;
+  planType: StudyPlanType;
+  sourceId: string;
+  title: string;
+  defaultMode: string;
+  items: StudyPlanItemDraft[];
+}
+
+/**
+ * Insert a study plan and its items in one transaction.
+ * Items receive sequential `item_num` values starting at 1.
+ * Returns the plan id.
+ */
+export async function createStudyPlan(args: CreateStudyPlanArgs): Promise<string> {
+  const planId = args.id ?? Crypto.randomUUID();
+  await getUserDb().withTransactionAsync(async () => {
+    await getUserDb().runAsync(
+      `INSERT INTO study_plans (id, plan_type, source_id, title, default_mode, created_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      [planId, args.planType, args.sourceId, args.title, args.defaultMode],
+    );
+    for (let i = 0; i < args.items.length; i++) {
+      const item = args.items[i];
+      await getUserDb().runAsync(
+        'INSERT INTO study_plan_items (plan_id, item_num, kind, ref_json) VALUES (?, ?, ?, ?)',
+        [planId, i + 1, item.kind, JSON.stringify(item.ref)],
+      );
+    }
+  });
+  return planId;
+}
+
+export async function completeStudyPlanItem(planId: string, itemNum: number): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE study_plan_items SET completed_at = datetime('now')
+     WHERE plan_id = ? AND item_num = ? AND completed_at IS NULL`,
+    [planId, itemNum],
+  );
+}
+
+export async function archiveStudyPlan(planId: string): Promise<void> {
+  await getUserDb().runAsync(
+    "UPDATE study_plans SET archived_at = datetime('now') WHERE id = ? AND archived_at IS NULL",
+    [planId],
+  );
+}
+
+/**
+ * Attach a guided study session to a plan item (both directions:
+ * `study_plan_items.session_id` and `guided_study_sessions.plan_id`).
+ */
+export async function linkSessionToPlanItem(
+  planId: string,
+  itemNum: number,
+  sessionId: number,
+): Promise<void> {
+  await getUserDb().withTransactionAsync(async () => {
+    await getUserDb().runAsync(
+      'UPDATE study_plan_items SET session_id = ? WHERE plan_id = ? AND item_num = ?',
+      [String(sessionId), planId, itemNum],
+    );
+    await getUserDb().runAsync('UPDATE guided_study_sessions SET plan_id = ? WHERE id = ?', [
+      planId,
+      sessionId,
+    ]);
   });
 }
 

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -27,6 +27,8 @@ import type {
   GuidedStudySession,
   GuidedStudySynthesis,
   GuidedStudyTakeawaySummary,
+  StudyPlan,
+  StudyPlanItem,
 } from '../types';
 import {
   emptyCapturedInputs,
@@ -234,6 +236,30 @@ export async function getPlanProgress(planId: string): Promise<PlanProgress[]> {
 export async function getActivePlanId(): Promise<string | null> {
   const id = await getPreference('active_plan');
   return id && id.length > 0 ? id : null;
+}
+
+// ── Unified Study Plans (read) — #1831, migration v25 ─────────────
+
+/**
+ * All study plans, newest first. Archived plans are excluded unless
+ * `includeArchived` is set.
+ */
+export async function getStudyPlans(includeArchived = false): Promise<StudyPlan[]> {
+  if (includeArchived) {
+    return getUserDb().getAllAsync<StudyPlan>(
+      'SELECT * FROM study_plans ORDER BY created_at DESC, id DESC',
+    );
+  }
+  return getUserDb().getAllAsync<StudyPlan>(
+    'SELECT * FROM study_plans WHERE archived_at IS NULL ORDER BY created_at DESC, id DESC',
+  );
+}
+
+export async function getStudyPlanItems(planId: string): Promise<StudyPlanItem[]> {
+  return getUserDb().getAllAsync<StudyPlanItem>(
+    'SELECT * FROM study_plan_items WHERE plan_id = ? ORDER BY item_num',
+    [planId],
+  );
 }
 
 // ── Reading Stats ─────────────────────────────────────────────────

--- a/app/src/services/study/index.ts
+++ b/app/src/services/study/index.ts
@@ -1,0 +1,29 @@
+/**
+ * services/study — Unified study-plan service layer (#1831).
+ *
+ * Data model lives in user.db (migration v25: `study_plans`,
+ * `study_plan_items`); CRUD lives in db/userQueries + db/userMutations.
+ * This barrel exposes the derived helpers: template builders,
+ * progression, weekly rhythm, and the one-time legacy seed.
+ */
+export {
+  buildBookPlanItems,
+  buildJourneyPlanItems,
+  buildTopicPlanItems,
+  parseChapterId,
+} from './planTemplates';
+export {
+  getActivePlan,
+  getNextItem,
+  percentComplete,
+  resumeTarget,
+  type ResumeTarget,
+} from './progression';
+export {
+  getWeeklyRhythm,
+  isoWeekKey,
+  isoWeekStart,
+  parseSqliteUtc,
+  type WeeklyRhythm,
+} from './rhythm';
+export { migrateLegacyPlans } from './migrateLegacyPlans';

--- a/app/src/services/study/migrateLegacyPlans.ts
+++ b/app/src/services/study/migrateLegacyPlans.ts
@@ -1,0 +1,114 @@
+/**
+ * services/study/migrateLegacyPlans.ts — One-time seed of legacy
+ * reading plans into the unified study-plan tables (#1831).
+ *
+ * Runs once at startup after migrations, guarded by the `app_meta`
+ * key `legacy_plans_migrated = '1'`. Every `reading_plans` row becomes
+ * a `study_plans` row (plan_type 'custom', source_id = legacy id,
+ * default_mode 'quick'); its `chapters_json` days become
+ * `study_plan_items` rows (kind 'reading', one per chapter); and
+ * `plan_progress.completed_at` is copied onto the matching items.
+ *
+ * The legacy tables are never dropped or altered — they stay readable
+ * until #1838 retires the write paths. Idempotency comes from three
+ * layers: the app_meta guard, deterministic plan ids
+ * (`legacy_<reading_plan id>`), and INSERT OR IGNORE on every row.
+ */
+import { getUserDb } from '../../db/userDatabase';
+import type { PlanProgress, ReadingPlan } from '../../db/userQueries';
+import { logger } from '../../utils/logger';
+import { parseChapterId } from './planTemplates';
+
+const GUARD_KEY = 'legacy_plans_migrated';
+
+interface LegacyPlanDay {
+  day: number;
+  chapters: string[];
+}
+
+function parseChaptersJson(chaptersJson: string, planId: string): LegacyPlanDay[] {
+  try {
+    const parsed: unknown = JSON.parse(chaptersJson);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (d): d is LegacyPlanDay =>
+        typeof d === 'object' &&
+        d !== null &&
+        typeof (d as LegacyPlanDay).day === 'number' &&
+        Array.isArray((d as LegacyPlanDay).chapters),
+    );
+  } catch (err) {
+    logger.warn('studyPlans', `migrateLegacyPlans: bad chapters_json on "${planId}"`, err);
+    return [];
+  }
+}
+
+/**
+ * Seed `study_plans` / `study_plan_items` from the legacy reading-plan
+ * tables. Safe to call on every launch — after the first successful
+ * run the app_meta guard makes it a no-op. Runs in one transaction, so
+ * a mid-flight failure leaves the guard unset and the seed retries on
+ * the next launch (deterministic ids + INSERT OR IGNORE make the retry
+ * safe).
+ */
+export async function migrateLegacyPlans(): Promise<void> {
+  const db = getUserDb();
+
+  const guard = await db.getFirstAsync<{ value: string }>(
+    'SELECT value FROM app_meta WHERE key = ?',
+    [GUARD_KEY],
+  );
+  if (guard?.value === '1') return;
+
+  const legacyPlans = await db.getAllAsync<ReadingPlan>('SELECT * FROM reading_plans');
+
+  await db.withTransactionAsync(async () => {
+    for (const legacy of legacyPlans) {
+      const planId = `legacy_${legacy.id}`;
+      await db.runAsync(
+        `INSERT OR IGNORE INTO study_plans
+           (id, plan_type, source_id, title, default_mode, created_at)
+         VALUES (?, 'custom', ?, ?, 'quick', datetime('now'))`,
+        [planId, legacy.id, legacy.name],
+      );
+
+      const progress = await db.getAllAsync<PlanProgress>(
+        'SELECT * FROM plan_progress WHERE plan_id = ?',
+        [legacy.id],
+      );
+      const completedByDay = new Map<number, string>();
+      for (const p of progress) {
+        if (p.completed_at) completedByDay.set(p.day_num, p.completed_at);
+      }
+
+      let itemNum = 0;
+      for (const day of parseChaptersJson(legacy.chapters_json, legacy.id)) {
+        for (const chapterId of day.chapters) {
+          itemNum++;
+          const ref = parseChapterId(chapterId);
+          if (!ref) {
+            logger.warn(
+              'studyPlans',
+              `migrateLegacyPlans: unparseable chapter "${chapterId}" in "${legacy.id}"`,
+            );
+            continue;
+          }
+          await db.runAsync(
+            `INSERT OR IGNORE INTO study_plan_items
+               (plan_id, item_num, kind, ref_json, completed_at)
+             VALUES (?, ?, 'reading', ?, ?)`,
+            [planId, itemNum, JSON.stringify(ref), completedByDay.get(day.day) ?? null],
+          );
+        }
+      }
+    }
+
+    await db.runAsync(
+      `INSERT OR REPLACE INTO app_meta (key, value, updated_at)
+       VALUES (?, '1', datetime('now'))`,
+      [GUARD_KEY],
+    );
+  });
+
+  logger.info('studyPlans', `migrateLegacyPlans: seeded ${legacyPlans.length} legacy plan(s)`);
+}

--- a/app/src/services/study/planTemplates.ts
+++ b/app/src/services/study/planTemplates.ts
@@ -1,0 +1,102 @@
+/**
+ * services/study/planTemplates.ts — Item builders for unified study
+ * plans (#1831).
+ *
+ * Each builder derives its items from content-DB queries only — there
+ * are no hardcoded book/chapter lists here. Builders return
+ * `StudyPlanItemDraft[]`; `createStudyPlan` (db/userMutations) assigns
+ * `item_num` on insert.
+ */
+import { getBook } from '../../db/content';
+import { getJourneyStops } from '../../db/content/features';
+import { getTopic } from '../../db/content/reference';
+import type { StudyPlanItemDraft } from '../../types';
+import { logger } from '../../utils/logger';
+
+/**
+ * Parse a content chapter id ("genesis_1", "1_samuel_16") into its
+ * book id and chapter number. Returns null on unrecognized input.
+ */
+export function parseChapterId(
+  chapterId: string,
+): { bookId: string; chapterNum: number } | null {
+  const m = chapterId.match(/^(.+)_(\d+)$/);
+  if (!m) return null;
+  return { bookId: m[1], chapterNum: parseInt(m[2], 10) };
+}
+
+/**
+ * One guided session per chapter of the book, in canonical order.
+ * Returns [] when the book id is unknown.
+ */
+export async function buildBookPlanItems(bookId: string): Promise<StudyPlanItemDraft[]> {
+  const book = await getBook(bookId);
+  if (!book) {
+    logger.warn('studyPlans', `buildBookPlanItems: unknown book "${bookId}"`);
+    return [];
+  }
+  const items: StudyPlanItemDraft[] = [];
+  for (let ch = 1; ch <= book.total_chapters; ch++) {
+    items.push({ kind: 'session', ref: { bookId, chapterNum: ch } });
+  }
+  return items;
+}
+
+/**
+ * One guided session per scripture-anchored journey stop, in stop
+ * order. Stops without a book/chapter anchor (narrative interludes)
+ * are skipped — a session needs a chapter to open on.
+ */
+export async function buildJourneyPlanItems(journeyId: string): Promise<StudyPlanItemDraft[]> {
+  const stops = await getJourneyStops(journeyId);
+  const items: StudyPlanItemDraft[] = [];
+  for (const stop of stops) {
+    if (!stop.book_id || stop.chapter_num == null) continue;
+    items.push({
+      kind: 'session',
+      ref: {
+        bookId: stop.book_id,
+        chapterNum: stop.chapter_num,
+        ...(stop.verse_start != null ? { verseStart: stop.verse_start } : {}),
+        stopId: stop.id,
+      },
+    });
+  }
+  return items;
+}
+
+/**
+ * One guided session per chapter in the topic's
+ * `relevant_chapters_json`, preserving the curated order and skipping
+ * duplicates/unparseable ids. Returns [] when the topic is unknown or
+ * has no relevant chapters.
+ */
+export async function buildTopicPlanItems(topicId: string): Promise<StudyPlanItemDraft[]> {
+  const topic = await getTopic(topicId);
+  if (!topic) {
+    logger.warn('studyPlans', `buildTopicPlanItems: unknown topic "${topicId}"`);
+    return [];
+  }
+
+  let chapterIds: string[] = [];
+  try {
+    const parsed: unknown = JSON.parse(topic.relevant_chapters_json ?? '[]');
+    if (Array.isArray(parsed)) {
+      chapterIds = parsed.filter((c): c is string => typeof c === 'string');
+    }
+  } catch (err) {
+    logger.warn('studyPlans', `buildTopicPlanItems: bad relevant_chapters_json on "${topicId}"`, err);
+    return [];
+  }
+
+  const items: StudyPlanItemDraft[] = [];
+  const seen = new Set<string>();
+  for (const chapterId of chapterIds) {
+    if (seen.has(chapterId)) continue;
+    seen.add(chapterId);
+    const ref = parseChapterId(chapterId);
+    if (!ref) continue;
+    items.push({ kind: 'session', ref });
+  }
+  return items;
+}

--- a/app/src/services/study/progression.ts
+++ b/app/src/services/study/progression.ts
@@ -1,0 +1,98 @@
+/**
+ * services/study/progression.ts — Where-am-I helpers over unified
+ * study plans (#1831).
+ *
+ * All state lives in `study_plans` / `study_plan_items` (user.db,
+ * migration v25); these helpers only read via db/userQueries.
+ */
+import {
+  getGuidedStudySession,
+  getStudyPlanItems,
+  getStudyPlans,
+} from '../../db/userQueries';
+import type { GuidedStudyStep, StudyPlan, StudyPlanItem, StudyPlanItemRef } from '../../types';
+import { logger } from '../../utils/logger';
+
+export interface ResumeTarget {
+  bookId: string;
+  chapterNum: number;
+  /** Present when the next item already has an in-flight guided session. */
+  step?: GuidedStudyStep;
+}
+
+function parseItemRef(item: StudyPlanItem): StudyPlanItemRef | null {
+  try {
+    const ref: unknown = JSON.parse(item.ref_json);
+    if (
+      typeof ref === 'object' &&
+      ref !== null &&
+      typeof (ref as StudyPlanItemRef).bookId === 'string' &&
+      typeof (ref as StudyPlanItemRef).chapterNum === 'number'
+    ) {
+      return ref as StudyPlanItemRef;
+    }
+  } catch (err) {
+    logger.warn(
+      'studyPlans',
+      `parseItemRef: bad ref_json on plan ${item.plan_id} item ${item.item_num}`,
+      err,
+    );
+  }
+  return null;
+}
+
+/**
+ * The plan the Study hub should surface: the newest non-archived plan
+ * that still has an incomplete item. Fully-completed plans are never
+ * "active"; returns null when there is nothing to continue.
+ */
+export async function getActivePlan(): Promise<StudyPlan | null> {
+  const plans = await getStudyPlans();
+  for (const plan of plans) {
+    const items = await getStudyPlanItems(plan.id);
+    if (items.some((item) => item.completed_at == null)) return plan;
+  }
+  return null;
+}
+
+/** First incomplete item of the plan (by item_num), or null when done/empty. */
+export async function getNextItem(planId: string): Promise<StudyPlanItem | null> {
+  const items = await getStudyPlanItems(planId);
+  return items.find((item) => item.completed_at == null) ?? null;
+}
+
+/** Whole-number completion percentage (0–100). Empty plans read as 0. */
+export async function percentComplete(planId: string): Promise<number> {
+  const items = await getStudyPlanItems(planId);
+  if (items.length === 0) return 0;
+  const done = items.filter((item) => item.completed_at != null).length;
+  return Math.round((done / items.length) * 100);
+}
+
+/**
+ * Where "Continue" should land: the next item's chapter, plus the
+ * current step when that item already has an active guided session.
+ * Returns null when the plan is complete, empty, or the next item's
+ * ref is unparseable.
+ */
+export async function resumeTarget(planId: string): Promise<ResumeTarget | null> {
+  const next = await getNextItem(planId);
+  if (!next) return null;
+
+  const ref = parseItemRef(next);
+  if (!ref) return null;
+
+  const target: ResumeTarget = { bookId: ref.bookId, chapterNum: ref.chapterNum };
+
+  if (next.session_id != null) {
+    const sessionId = Number(next.session_id);
+    if (Number.isFinite(sessionId)) {
+      const session = await getGuidedStudySession(sessionId);
+      if (session && session.status === 'active') {
+        target.step = session.current_step;
+      }
+    }
+  }
+
+  return target;
+}

--- a/app/src/services/study/rhythm.ts
+++ b/app/src/services/study/rhythm.ts
@@ -1,0 +1,99 @@
+/**
+ * services/study/rhythm.ts — Weekly study rhythm (#1831).
+ *
+ * Derived entirely from `guided_study_sessions` (completed sessions)
+ * and `guided_review_items` (completed reviews) — no new table, no
+ * streak math. "Rhythm" is a per-ISO-week count the hub can render as
+ * a gentle cadence strip, not a gamified streak.
+ */
+import { getUserDb } from '../../db/userDatabase';
+
+export interface WeeklyRhythm {
+  /** ISO week key, e.g. "2026-W27". */
+  week: string;
+  /** Monday of the week, as YYYY-MM-DD (UTC). */
+  weekStart: string;
+  sessions: number;
+  reviews: number;
+}
+
+/**
+ * Parse a SQLite `datetime('now')` timestamp ("YYYY-MM-DD HH:MM:SS",
+ * stored UTC) into a Date. Also tolerates ISO-8601 strings.
+ */
+export function parseSqliteUtc(value: string): Date | null {
+  const normalized = value.includes('T') ? value : `${value.replace(' ', 'T')}Z`;
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Monday 00:00 UTC of the ISO week containing `date`. */
+export function isoWeekStart(date: Date): Date {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = d.getUTCDay() || 7; // Mon=1 … Sun=7
+  d.setUTCDate(d.getUTCDate() - (day - 1));
+  return d;
+}
+
+/** ISO 8601 week key ("2026-W27") — the week belongs to the year of its Thursday. */
+export function isoWeekKey(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day); // shift to Thursday
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+/**
+ * Completed guided sessions and completed review items per ISO week,
+ * for the trailing `weeks` weeks (default 8, oldest first, zero-filled
+ * so the hub always renders a full strip).
+ */
+export async function getWeeklyRhythm(weeks = 8, now: Date = new Date()): Promise<WeeklyRhythm[]> {
+  const db = getUserDb();
+
+  // Zero-filled buckets for the trailing window, oldest → newest.
+  const buckets = new Map<string, WeeklyRhythm>();
+  const currentWeekStart = isoWeekStart(now);
+  for (let i = weeks - 1; i >= 0; i--) {
+    const start = new Date(currentWeekStart);
+    start.setUTCDate(start.getUTCDate() - i * 7);
+    buckets.set(isoWeekKey(start), {
+      week: isoWeekKey(start),
+      weekStart: start.toISOString().slice(0, 10),
+      sessions: 0,
+      reviews: 0,
+    });
+  }
+
+  // +7 days of slack so week boundaries never clip the oldest bucket.
+  const sinceModifier = `-${weeks * 7 + 7} days`;
+
+  const sessionRows = await db.getAllAsync<{ completed_at: string }>(
+    `SELECT completed_at FROM guided_study_sessions
+     WHERE status = 'completed' AND completed_at IS NOT NULL
+       AND completed_at >= datetime('now', ?)`,
+    [sinceModifier],
+  );
+  const reviewRows = await db.getAllAsync<{ updated_at: string }>(
+    `SELECT updated_at FROM guided_review_items
+     WHERE status = 'completed' AND updated_at >= datetime('now', ?)`,
+    [sinceModifier],
+  );
+
+  for (const row of sessionRows) {
+    const date = parseSqliteUtc(row.completed_at);
+    if (!date) continue;
+    const bucket = buckets.get(isoWeekKey(date));
+    if (bucket) bucket.sessions++;
+  }
+  for (const row of reviewRows) {
+    const date = parseSqliteUtc(row.updated_at);
+    if (!date) continue;
+    const bucket = buckets.get(isoWeekKey(date));
+    if (bucket) bucket.reviews++;
+  }
+
+  return Array.from(buckets.values());
+}

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -67,6 +67,56 @@ export interface GuidedStudySession {
   mode_artifact_json?: string | null;
   /** Phase 2.2 (#1731). NULL for pre-migration rows. */
   synthesis_strategy?: string | null;
+  /** Unified study plans (#1831, migration v25). NULL for sessions started outside a plan. */
+  plan_id?: string | null;
+}
+
+// ── Unified study plans (#1831, migration v25) ────────────────────
+
+export const STUDY_PLAN_TYPES = ['book', 'journey', 'topical', 'custom'] as const;
+
+export type StudyPlanType = (typeof STUDY_PLAN_TYPES)[number];
+
+export const STUDY_PLAN_ITEM_KINDS = ['session', 'reading'] as const;
+
+export type StudyPlanItemKind = (typeof STUDY_PLAN_ITEM_KINDS)[number];
+
+export interface StudyPlan {
+  id: string;
+  plan_type: StudyPlanType;
+  /** book_id | journey_id | topic_id | legacy reading_plan id (for plan_type 'custom'). */
+  source_id: string;
+  title: string;
+  /** GuidedStudyMode key ('quick' | 'deep' | 'teaching' | 'devotional'). */
+  default_mode: string;
+  created_at: string;
+  archived_at: string | null;
+}
+
+/** Parsed shape of `study_plan_items.ref_json`. */
+export interface StudyPlanItemRef {
+  bookId: string;
+  chapterNum: number;
+  verseStart?: number;
+  stopId?: number;
+}
+
+export interface StudyPlanItem {
+  plan_id: string;
+  item_num: number;
+  kind: StudyPlanItemKind;
+  ref_json: string;
+  session_id: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Unsaved plan item as produced by the `services/study/planTemplates`
+ * builders — `item_num` is assigned by `createStudyPlan` on insert.
+ */
+export interface StudyPlanItemDraft {
+  kind: StudyPlanItemKind;
+  ref: StudyPlanItemRef;
 }
 
 export interface GuidedStudyResponse {


### PR DESCRIPTION
First PR in the Epic #1830 stack — no dependencies, branched from master. Closes #1831.

## Rationale
The Unified Study System needs one progression data model before any UI can land. This PR adds the data spine only — **no UI, no route changes, no behavior change for users** (the only runtime effect is the append-only migration plus a one-time, guarded seed at startup).

- **Migration v25** (append-only, `app/src/db/userDatabase.ts`): `study_plans`, `study_plan_items`, and a nullable `plan_id` column on `guided_study_sessions`. Legacy `reading_plans` / `plan_progress` are untouched and stay readable.
- **Legacy seed** (`services/study/migrateLegacyPlans.ts`): runs once at startup after migrations, guarded by `app_meta.legacy_plans_migrated = '1'`. Each `reading_plans` row becomes a `custom` study plan (`default_mode='quick'`); `chapters_json` days expand to `kind='reading'` items; `plan_progress.completed_at` is copied onto matching items. Idempotent three ways: app_meta guard, deterministic ids (`legacy_<id>`), and `INSERT OR IGNORE` — verified by unit tests on fixture rows.
- **Service layer** (`app/src/services/study/`): `planTemplates` (book/journey/topic item builders, derived from content queries only — zero hardcoded chapter lists), `progression` (`getActivePlan`, `getNextItem`, `percentComplete`, `resumeTarget`), `rhythm` (`getWeeklyRhythm` per ISO week, derived from `guided_study_sessions` + `guided_review_items`, no new table, no streak math).
- **CRUD** in `userQueries.ts` / `userMutations.ts`: `createStudyPlan`, `getStudyPlans`, `getStudyPlanItems`, `completeStudyPlanItem`, `archiveStudyPlan`, `linkSessionToPlanItem`.

Note for reviewers: `buildTopicPlanItems` sources chapters from `topics.relevant_chapters_json` (`db/content/reference.ts`) — that's the table keyed by `topic_id` with chapter-level references. If #1833's picker intends Life Topics instead, the builder is a one-file swap.

## Rollback plan
Revert the merge commit. The v25 tables/column are additive and simply go unused after a revert — SQLite tolerates the extra column and tables on older code, and the migration runner never re-runs applied versions. The legacy seed only writes to the new tables plus one `app_meta` key, so no legacy data is at risk. No route, flag, or UI surface is touched.

## Verification
- `npx tsc --noEmit` clean
- `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **521 suites / 3973 tests passing**, coverage thresholds met (34 new tests: migration v25 fresh-install + v24→v25 paths, seed idempotency on fixture rows incl. lost-guard retry, planTemplates book/journey/topic, progression, rhythm ISO-week bucketing)
- Pre-existing `migrationV24.test.ts` hardcoded "23 applied → exactly 1 transaction", which breaks whenever a migration is appended; made it (and the new v25 test) robust via `MIGRATION_COUNT - N`.

## Process notes
- Kanban: this environment can't reach the Projects v2 GraphQL API (proxy blocks `gh api graphql`), so the board wasn't moved to In Progress/In Review — please drag #1831 when triaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_