### PR TITLE
feat(study): Study hub behind study_hub flag + Explore→Study rename + LibrarySections — #1832

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -29,12 +29,14 @@ import { pruneEvents } from './src/services/analytics';
 import { checkAndScheduleReengagement } from './src/services/reengagement';
 import { rescheduleIfStale } from './src/services/notifications';
 import { initializePurchases, syncPremiumStatus } from './src/services/purchases';
+import { migrateLegacyPlans } from './src/services/study';
 import { flushQueue } from './src/services/syncQueue';
 import { RootNavigator } from './src/navigation';
 import type { TabParamList } from './src/navigation/types';
 import { useNotificationRouter } from './src/hooks/useNotificationRouter';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { closeAllTranslationDbs } from './src/db/translationManager';
+import { logger } from './src/utils/logger';
 import { ContentUpdateProvider } from './src/providers/ContentUpdateProvider';
 import { AmicusConsentProvider } from './src/services/amicus/consent';
 import type { PromotePeekResult } from './src/services/amicus';
@@ -208,6 +210,14 @@ function AppShell() {
  */
 async function hydrateAppState(): Promise<void> {
   await initUserDatabase(); // User DB (user.db) — never replaced, migrated
+  // One-time seed of legacy reading plans into the unified study-plan
+  // tables (#1831). Best-effort: on failure the app_meta guard stays
+  // unset and the seed retries on the next launch.
+  try {
+    await migrateLegacyPlans();
+  } catch (err) {
+    logger.error('studyPlans', 'migrateLegacyPlans failed — will retry next launch', err);
+  }
   // Bind an anonymous identifier to Sentry so crashes from a single
   // install roll up under one user. Best-effort — if it fails we
   // just don't get per-user grouping this session.

--- a/app/__tests__/components/study/ContinueHero.test.tsx
+++ b/app/__tests__/components/study/ContinueHero.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * #1832 — Continue hero (components/study/ContinueHero).
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { StudyPlan, StudyPlanItem } from '@/types';
+
+const mockUseReducedMotion = jest.fn().mockReturnValue(false);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+import { ContinueHero } from '@/components/study/ContinueHero';
+
+const PLAN: StudyPlan = {
+  id: 'plan-1',
+  plan_type: 'book',
+  source_id: 'jonah',
+  title: 'Jonah',
+  default_mode: 'quick',
+  created_at: '2026-06-01 00:00:00',
+  archived_at: null,
+};
+
+function item(num: number, completed: boolean): StudyPlanItem {
+  return {
+    plan_id: 'plan-1',
+    item_num: num,
+    kind: 'session',
+    ref_json: JSON.stringify({ bookId: 'jonah', chapterNum: num }),
+    session_id: null,
+    completed_at: completed ? '2026-06-02 08:00:00' : null,
+  };
+}
+
+const ITEMS = [item(1, true), item(2, false), item(3, false)];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseReducedMotion.mockReturnValue(false);
+});
+
+describe('ContinueHero (#1832)', () => {
+  it('renders the plan title, chapter ref, paused step, and minutes', () => {
+    const { getByText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2, step: 'explore' }}
+        estimateMin={12}
+        onResume={jest.fn()}
+      />,
+    );
+    expect(getByText('Jonah')).toBeTruthy();
+    expect(getByText('Jonah 2 · Paused at Explore · ~12 min')).toBeTruthy();
+  });
+
+  it('omits step and minutes gracefully when absent', () => {
+    const { getByText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2 }}
+        estimateMin={null}
+        onResume={jest.fn()}
+      />,
+    );
+    expect(getByText('Jonah 2')).toBeTruthy();
+  });
+
+  it('fires onResume from an accessible 44pt button', () => {
+    const onResume = jest.fn();
+    const { getByLabelText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2, step: 'explore' }}
+        estimateMin={12}
+        onResume={onResume}
+      />,
+    );
+    const button = getByLabelText('Resume Jonah at Jonah 2');
+    fireEvent.press(button);
+    expect(onResume).toHaveBeenCalledTimes(1);
+    const flat = Array.isArray(button.props.style) ? Object.assign({}, ...button.props.style.flat()) : button.props.style;
+    expect(flat.minHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  it('renders statically under reduced motion (still one tick per item)', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const { getByText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2 }}
+        estimateMin={null}
+        onResume={jest.fn()}
+      />,
+    );
+    // Smoke: renders without starting the glow loop.
+    expect(getByText('Jonah')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/study/LibrarySections.test.tsx
+++ b/app/__tests__/components/study/LibrarySections.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * #1832 — LibrarySections extraction. The shelves must render the same
+ * section data ExploreMenuScreen used to own, route presses through
+ * onNavigate, and honor the jump-pill filter.
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/db/content', () => ({
+  getAllProphecyChains: jest.fn().mockResolvedValue([]),
+  getDebateTopics: jest.fn().mockResolvedValue([]),
+  getAllWordStudies: jest.fn().mockResolvedValue([]),
+  getLifeTopicCategories: jest.fn().mockResolvedValue([]),
+  getPeopleWithJourneys: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/hooks/useJourneyBrowse', () => ({
+  useJourneyBrowse: jest.fn().mockReturnValue({
+    allJourneys: [],
+    personJourneys: [],
+    conceptJourneys: [],
+    thematicJourneys: [],
+    lensIds: [],
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/hooks/useProphecyChains', () => ({
+  useProphecyChains: jest.fn().mockReturnValue({ chains: [], isLoading: false }),
+}));
+
+import {
+  LibrarySections,
+  LIBRARY_SECTIONS,
+  PREMIUM_SCREENS,
+} from '@/components/study/LibrarySections';
+
+function renderSections(overrides: Partial<React.ComponentProps<typeof LibrarySections>> = {}) {
+  const onNavigate = jest.fn();
+  const utils = render(
+    <LibrarySections
+      imageRegistry={{}}
+      isPremium
+      onNavigate={onNavigate}
+      onDeepLink={jest.fn()}
+      {...overrides}
+    />,
+  );
+  return { onNavigate, ...utils };
+}
+
+describe('LibrarySections (#1832)', () => {
+  it('exports the seven library sections with stable ids', () => {
+    expect(LIBRARY_SECTIONS.map((s) => s.id)).toEqual([
+      'biblical-world', 'themes', 'journeys', 'language', 'scholarly', 'life', 'deep-dive',
+    ]);
+    expect(PREMIUM_SCREENS.Concordance).toBe('Concordance Search');
+  });
+
+  it('renders every section label and its cards', async () => {
+    const { getByText } = renderSections();
+    await waitFor(() => {
+      expect(getByText('The Biblical World')).toBeTruthy();
+      expect(getByText('Themes & Connections')).toBeTruthy();
+      expect(getByText('Language & Reference')).toBeTruthy();
+      expect(getByText('Scholarly Analysis')).toBeTruthy();
+      expect(getByText('Life & Faith')).toBeTruthy();
+      expect(getByText('Deep Dive')).toBeTruthy();
+      expect(getByText('People')).toBeTruthy();
+      expect(getByText('Timeline')).toBeTruthy();
+      expect(getByText('Scholars')).toBeTruthy();
+      expect(getByText('Grammar')).toBeTruthy();
+    });
+  });
+
+  it('routes card presses through onNavigate', async () => {
+    const { getByText, onNavigate } = renderSections();
+    await waitFor(() => expect(getByText('Map')).toBeTruthy());
+    fireEvent.press(getByText('Map'));
+    expect(onNavigate).toHaveBeenCalledWith('Map');
+  });
+
+  it('renders only the filtered section when filterSectionId is set', async () => {
+    const { getByText, queryByText } = renderSections({ filterSectionId: 'deep-dive' });
+    await waitFor(() => expect(getByText('Deep Dive')).toBeTruthy());
+    expect(queryByText('The Biblical World')).toBeNull();
+    expect(queryByText('Scholarly Analysis')).toBeNull();
+  });
+});

--- a/app/__tests__/components/study/RhythmLine.test.tsx
+++ b/app/__tests__/components/study/RhythmLine.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * #1832 — rhythm sentence (components/study/RhythmLine).
+ * No streaks, no emojis — one italic sentence derived from weekly data.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { buildRhythmSentence, RhythmLine } from '@/components/study/RhythmLine';
+import type { WeeklyRhythm } from '@/services/study';
+
+function week(weekKey: string, sessions: number, reviews: number): WeeklyRhythm {
+  return { week: weekKey, weekStart: '2026-06-29', sessions, reviews };
+}
+
+describe('buildRhythmSentence', () => {
+  it('summarizes sessions and reviews with number words', () => {
+    expect(buildRhythmSentence([week('2026-W27', 2, 1)])).toBe(
+      'Two sessions and one review this week — a steady rhythm of study.',
+    );
+    expect(buildRhythmSentence([week('2026-W27', 1, 0)])).toBe(
+      'One session this week — a steady rhythm of study.',
+    );
+    expect(buildRhythmSentence([week('2026-W27', 0, 3)])).toBe(
+      'Three reviews this week — a steady rhythm of study.',
+    );
+  });
+
+  it('offers a gentle line for a quiet week (no counters, no emojis)', () => {
+    const active = buildRhythmSentence([week('2026-W26', 2, 0), week('2026-W27', 0, 0)]);
+    expect(active).toBe('A quiet week so far — the text will keep until you return.');
+
+    const idle = buildRhythmSentence([week('2026-W26', 0, 0), week('2026-W27', 0, 0)]);
+    expect(idle).toBe('A quiet stretch — one unhurried session would begin a rhythm.');
+
+    expect(buildRhythmSentence([])).toBe(
+      'A quiet stretch — one unhurried session would begin a rhythm.',
+    );
+  });
+
+  it('never emits digits for small counts or emoji', () => {
+    const sentence = buildRhythmSentence([week('2026-W27', 4, 2)]);
+    expect(sentence).not.toMatch(/\d/);
+    expect(sentence).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
+  });
+});
+
+describe('RhythmLine', () => {
+  it('renders the sentence', () => {
+    const { getByText } = render(<RhythmLine rhythm={[week('2026-W27', 1, 1)]} />);
+    expect(getByText('One session and one review this week — a steady rhythm of study.')).toBeTruthy();
+  });
+});

--- a/app/__tests__/db/migrationV24.test.ts
+++ b/app/__tests__/db/migrationV24.test.ts
@@ -54,15 +54,16 @@ describe('migration v24 — captured_inputs columns on guided_study_sessions', (
     expect(mockWithTransactionAsync).not.toHaveBeenCalled();
   });
 
-  it('applies exactly one transaction when only versions 1..23 have run (v24 is the only pending one)', async () => {
+  it('runs v24 (and any later migrations) when only versions 1..23 have run', async () => {
     jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
     jest.resetModules();
-    const { initUserDatabase } = require('@/db/userDatabase');
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
     mockGetAllAsync.mockResolvedValueOnce(
       Array.from({ length: 23 }, (_, i) => ({ version: i + 1 })),
     );
     await initUserDatabase();
-    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(1);
+    // v24 plus whatever has been appended since — one transaction each.
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT - 23);
   });
 
   it("v24's SQL adds the three captured-inputs columns to guided_study_sessions", async () => {

--- a/app/__tests__/db/migrationV25.test.ts
+++ b/app/__tests__/db/migrationV25.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #1831 — focused test for migration v25 (unified study plans:
+ * study_plans, study_plan_items, plan_id on guided_study_sessions).
+ *
+ * Mirrors __tests__/db/migrationV24.test.ts so the migration-runner
+ * mocks are reused. NOT mocking @/db/userDatabase — the point is to
+ * exercise the real migration loop on a fresh install and on a v24 DB.
+ */
+const mockExecAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllAsync = jest.fn().mockResolvedValue([]);
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 0 });
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+const mockOpenDatabaseAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: unknown[]) => mockOpenDatabaseAsync(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  mockOpenDatabaseAsync.mockResolvedValue({
+    execAsync: mockExecAsync,
+    getAllAsync: mockGetAllAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  });
+});
+
+describe('migration v25 — unified study plans', () => {
+  it('the migration count includes v25', () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT } = require('@/db/userDatabase');
+    expect(MIGRATION_COUNT).toBeGreaterThanOrEqual(25);
+  });
+
+  it('applies cleanly on a fresh install (no versions applied → every migration runs)', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce([]);
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT);
+  });
+
+  it('runs v25 (and any later migrations) on a v24 DB', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 24 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    // v25 plus whatever gets appended later — one transaction each.
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT - 24);
+  });
+
+  it('skips every migration when v25 (and all earlier versions) are already applied', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: MIGRATION_COUNT }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).not.toHaveBeenCalled();
+  });
+
+  it("v25's SQL creates both plan tables and adds plan_id to guided_study_sessions", async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 24 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    const allSql = mockExecAsync.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('\n');
+    expect(allSql).toContain('CREATE TABLE IF NOT EXISTS study_plans');
+    expect(allSql).toContain('CREATE TABLE IF NOT EXISTS study_plan_items');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN plan_id TEXT');
+    // Append-only contract: v25 must not drop or rewrite legacy tables.
+    expect(allSql).not.toMatch(/DROP TABLE/i);
+    expect(allSql).not.toMatch(/ALTER TABLE reading_plans/i);
+    expect(allSql).not.toMatch(/ALTER TABLE plan_progress/i);
+  });
+});

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * #1832 — StudyHubScreen: hero (with plan / hidden without), review
+ * cycling, rhythm line, and library shelves on the flag-on root.
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { GuidedReviewItem, StudyPlan, StudyPlanItem } from '@/types';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn(), push: jest.fn() }),
+    useRoute: () => ({ params: {} }),
+    useScrollToTop: jest.fn(),
+    useFocusEffect: (cb: () => void) => cb(), // same behavior as the global jest.setup mock
+  };
+});
+
+// ── Library shelf data mocks (same set as ExploreMenuScreen.test) ──
+jest.mock('@/db/content', () => ({
+  getAllProphecyChains: jest.fn().mockResolvedValue([]),
+  getDebateTopics: jest.fn().mockResolvedValue([]),
+  getAllWordStudies: jest.fn().mockResolvedValue([]),
+  getLifeTopicCategories: jest.fn().mockResolvedValue([]),
+  getPeopleWithJourneys: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('@/hooks/useJourneyBrowse', () => ({
+  useJourneyBrowse: jest.fn().mockReturnValue({
+    allJourneys: [], personJourneys: [], conceptJourneys: [], thematicJourneys: [],
+    lensIds: [], isLoading: false,
+  }),
+}));
+jest.mock('@/hooks/useProphecyChains', () => ({
+  useProphecyChains: jest.fn().mockReturnValue({ chains: [], isLoading: false }),
+}));
+jest.mock('@/hooks/useExploreImages', () => ({
+  useExploreImages: jest.fn().mockReturnValue({}),
+}));
+jest.mock('@/hooks/usePremium', () => ({
+  usePremium: jest.fn().mockReturnValue({
+    isPremium: true, upgradeRequest: null, showUpgrade: jest.fn(), dismissUpgrade: jest.fn(),
+  }),
+}));
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: jest.fn().mockReturnValue(true),
+}));
+
+// ── Hub data mocks ──
+const mockUseContinuePlan = jest.fn();
+jest.mock('@/hooks/useContinuePlan', () => ({
+  useContinuePlan: () => mockUseContinuePlan(),
+}));
+
+const mockCompleteItem = jest.fn().mockResolvedValue(undefined);
+const mockUseReviewQueue = jest.fn();
+jest.mock('@/hooks/useReviewQueue', () => ({
+  useReviewQueue: () => mockUseReviewQueue(),
+}));
+
+const RHYTHM = [{ week: '2026-W27', weekStart: '2026-06-29', sessions: 2, reviews: 1 }];
+jest.mock('@/services/study', () => ({
+  getWeeklyRhythm: jest.fn().mockResolvedValue(RHYTHM),
+}));
+
+import StudyHubScreen from '@/screens/StudyHubScreen';
+
+const PLAN: StudyPlan = {
+  id: 'plan-1',
+  plan_type: 'book',
+  source_id: 'jonah',
+  title: 'Jonah',
+  default_mode: 'quick',
+  created_at: '2026-06-01 00:00:00',
+  archived_at: null,
+};
+
+const ITEMS: StudyPlanItem[] = [1, 2, 3].map((n) => ({
+  plan_id: 'plan-1',
+  item_num: n,
+  kind: 'session',
+  ref_json: JSON.stringify({ bookId: 'jonah', chapterNum: n }),
+  session_id: null,
+  completed_at: n === 1 ? '2026-06-02 08:00:00' : null,
+}));
+
+function reviewItem(id: number, prompt: string): GuidedReviewItem {
+  return {
+    id,
+    source_session_id: 10 + id,
+    chapter_id: 'jonah_1',
+    title: 'Jonah 1',
+    prompt,
+    answer: 'answer',
+    due_date: '2026-07-01',
+    interval_days: 3,
+    review_count: 0,
+    status: 'due',
+    created_at: '2026-06-28 08:00:00',
+    updated_at: '2026-06-28 08:00:00',
+  } as GuidedReviewItem;
+}
+
+function stubReviewQueue(dueItems: GuidedReviewItem[]) {
+  mockUseReviewQueue.mockReturnValue({
+    dueItems,
+    completeItem: mockCompleteItem,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseContinuePlan.mockReturnValue({
+    plan: PLAN,
+    items: ITEMS,
+    target: { bookId: 'jonah', chapterNum: 2, step: 'explore' },
+    estimateMin: 12,
+    isLoading: false,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+  stubReviewQueue([reviewItem(1, 'What did the storm reveal?')]);
+});
+
+describe('StudyHubScreen (#1832)', () => {
+  it('renders heading, hero, review, rhythm, and library shelves', async () => {
+    const { getByText } = render(<StudyHubScreen />);
+    expect(getByText('Study')).toBeTruthy();
+    expect(getByText('Jonah')).toBeTruthy();
+    expect(getByText('Jonah 2 · Paused at Explore · ~12 min')).toBeTruthy();
+    expect(getByText('What did the storm reveal?')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Two sessions and one review this week — a steady rhythm of study.')).toBeTruthy();
+      expect(getByText('The Biblical World')).toBeTruthy();
+      expect(getByText('Deep Dive')).toBeTruthy();
+    });
+  });
+
+  it('resumes the plan into StudySession with the paused step', async () => {
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Resume Jonah at Jonah 2'));
+    expect(mockNavigate).toHaveBeenCalledWith('StudySession', {
+      bookId: 'jonah',
+      chapterNum: 2,
+      initialStep: 'explore',
+    });
+  });
+
+  it('renders no hero region when there is no active plan', async () => {
+    mockUseContinuePlan.mockReturnValue({
+      plan: null, items: [], target: null, estimateMin: null,
+      isLoading: false, reload: jest.fn().mockResolvedValue(undefined),
+    });
+    const { queryByText, getByText } = render(<StudyHubScreen />);
+    expect(queryByText('CONTINUE')).toBeNull();
+    expect(queryByText('Resume')).toBeNull();
+    // The rest of the hub still renders.
+    await waitFor(() => expect(getByText('The Biblical World')).toBeTruthy());
+  });
+
+  it('completes the current review on "Recall it"', async () => {
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Recall it — mark this review complete'));
+    await waitFor(() => expect(mockCompleteItem).toHaveBeenCalledWith(1));
+  });
+
+  it('cycles to the next due item on "Later"', async () => {
+    stubReviewQueue([
+      reviewItem(1, 'What did the storm reveal?'),
+      reviewItem(2, 'Why did Jonah flee?'),
+    ]);
+    const { getByLabelText, getByText, queryByText } = render(<StudyHubScreen />);
+    expect(getByText('What did the storm reveal?')).toBeTruthy();
+    expect(getByText('Jonah 1  ·  1 of 2 due')).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Later — show the next due review'));
+    expect(getByText('Why did Jonah flee?')).toBeTruthy();
+    expect(queryByText('What did the storm reveal?')).toBeNull();
+
+    // Wraps back around.
+    fireEvent.press(getByLabelText('Later — show the next due review'));
+    expect(getByText('What did the storm reveal?')).toBeTruthy();
+  });
+
+  it('shows no review card when nothing is due', () => {
+    stubReviewQueue([]);
+    const { queryByText } = render(<StudyHubScreen />);
+    expect(queryByText('Recall it')).toBeNull();
+  });
+});

--- a/app/__tests__/services/study/migrateLegacyPlans.test.ts
+++ b/app/__tests__/services/study/migrateLegacyPlans.test.ts
@@ -1,0 +1,200 @@
+/**
+ * #1831 — legacy reading-plan seed (services/study/migrateLegacyPlans).
+ *
+ * Uses a targeted in-memory fake of the user.db surface the seed
+ * touches (app_meta guard, reading_plans/plan_progress reads,
+ * INSERT OR IGNORE writes) so idempotency is exercised for real:
+ * both the app_meta short-circuit and the deterministic-id/OR-IGNORE
+ * layer that protects a retry after a mid-flight failure.
+ */
+import type { PlanProgress, ReadingPlan } from '@/db/userQueries';
+
+interface FakeDb {
+  appMeta: Map<string, string>;
+  studyPlans: Map<string, unknown[]>;
+  planItems: Map<string, unknown[]>;
+  getFirstAsync: jest.Mock;
+  getAllAsync: jest.Mock;
+  runAsync: jest.Mock;
+  withTransactionAsync: jest.Mock;
+}
+
+const LEGACY_PLANS: ReadingPlan[] = [
+  {
+    id: 'psalms_of_lament',
+    name: 'Psalms of Lament',
+    description: 'Seven lament psalms.',
+    total_days: 2,
+    chapters_json: JSON.stringify([
+      { day: 1, chapters: ['psalms_13'] },
+      { day: 2, chapters: ['psalms_22', 'psalms_42'] },
+    ]),
+  },
+  {
+    id: 'life_of_david',
+    name: 'The Life of David',
+    description: 'David from shepherd to king.',
+    total_days: 1,
+    chapters_json: JSON.stringify([{ day: 1, chapters: ['1_samuel_16', '1_samuel_17'] }]),
+  },
+];
+
+const LEGACY_PROGRESS: PlanProgress[] = [
+  { plan_id: 'psalms_of_lament', day_num: 1, completed_at: '2026-06-01 09:00:00' },
+  { plan_id: 'psalms_of_lament', day_num: 2, completed_at: null },
+  { plan_id: 'life_of_david', day_num: 1, completed_at: '2026-06-15 20:30:00' },
+];
+
+function makeFakeDb(plans: ReadingPlan[], progress: PlanProgress[]): FakeDb {
+  const appMeta = new Map<string, string>();
+  const studyPlans = new Map<string, unknown[]>();
+  const planItems = new Map<string, unknown[]>();
+
+  const db: FakeDb = {
+    appMeta,
+    studyPlans,
+    planItems,
+    getFirstAsync: jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('FROM app_meta')) {
+        const value = appMeta.get(params[0] as string);
+        return value != null ? { value } : null;
+      }
+      return null;
+    }),
+    getAllAsync: jest.fn(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM reading_plans')) return plans;
+      if (sql.includes('FROM plan_progress')) {
+        return progress.filter((p) => p.plan_id === (params?.[0] as string));
+      }
+      return [];
+    }),
+    runAsync: jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('INTO study_plans')) {
+        // INSERT OR IGNORE on PRIMARY KEY (id)
+        const id = params[0] as string;
+        if (!studyPlans.has(id)) studyPlans.set(id, params);
+      } else if (sql.includes('INTO study_plan_items')) {
+        // INSERT OR IGNORE on PRIMARY KEY (plan_id, item_num)
+        const key = `${params[0]}:${params[1]}`;
+        if (!planItems.has(key)) planItems.set(key, params);
+      } else if (sql.includes('INTO app_meta')) {
+        appMeta.set(params[0] as string, '1');
+      }
+      return { changes: 1 };
+    }),
+    withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  };
+  return db;
+}
+
+let mockDb: FakeDb;
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => mockDb,
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { migrateLegacyPlans } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb = makeFakeDb(LEGACY_PLANS, LEGACY_PROGRESS);
+});
+
+describe('migrateLegacyPlans (#1831)', () => {
+  it('seeds one custom study plan per legacy reading plan', async () => {
+    await migrateLegacyPlans();
+
+    expect(mockDb.studyPlans.size).toBe(2);
+    const psalms = mockDb.studyPlans.get('legacy_psalms_of_lament');
+    // params: [id, source_id, title] — plan_type/default_mode are inline SQL
+    expect(psalms).toEqual(['legacy_psalms_of_lament', 'psalms_of_lament', 'Psalms of Lament']);
+    const insertPlanSql = mockDb.runAsync.mock.calls.find((c) =>
+      (c[0] as string).includes('INTO study_plans'),
+    )?.[0] as string;
+    expect(insertPlanSql).toContain("'custom'");
+    expect(insertPlanSql).toContain("'quick'");
+  });
+
+  it('expands chapters_json into reading items and copies day completion onto them', async () => {
+    await migrateLegacyPlans();
+
+    // psalms_of_lament: day 1 = 1 chapter, day 2 = 2 chapters → items 1..3
+    expect(mockDb.planItems.get('legacy_psalms_of_lament:1')).toEqual([
+      'legacy_psalms_of_lament',
+      1,
+      JSON.stringify({ bookId: 'psalms', chapterNum: 13 }),
+      '2026-06-01 09:00:00', // day 1 completed
+    ]);
+    expect(mockDb.planItems.get('legacy_psalms_of_lament:2')).toEqual([
+      'legacy_psalms_of_lament',
+      2,
+      JSON.stringify({ bookId: 'psalms', chapterNum: 22 }),
+      null, // day 2 not completed
+    ]);
+    expect(mockDb.planItems.get('legacy_psalms_of_lament:3')?.[3]).toBeNull();
+
+    // Multi-underscore book ids parse correctly and inherit day completion.
+    expect(mockDb.planItems.get('legacy_life_of_david:1')).toEqual([
+      'legacy_life_of_david',
+      1,
+      JSON.stringify({ bookId: '1_samuel', chapterNum: 16 }),
+      '2026-06-15 20:30:00',
+    ]);
+    expect(mockDb.planItems.get('legacy_life_of_david:2')?.[3]).toBe('2026-06-15 20:30:00');
+    expect(mockDb.planItems.size).toBe(5);
+  });
+
+  it('sets the app_meta guard so the second run is a no-op', async () => {
+    await migrateLegacyPlans();
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
+
+    const writesAfterFirstRun = mockDb.runAsync.mock.calls.length;
+    await migrateLegacyPlans();
+
+    expect(mockDb.runAsync.mock.calls.length).toBe(writesAfterFirstRun);
+    expect(mockDb.withTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(mockDb.studyPlans.size).toBe(2);
+    expect(mockDb.planItems.size).toBe(5);
+  });
+
+  it('is idempotent on retry even when the guard was never written (OR IGNORE layer)', async () => {
+    await migrateLegacyPlans();
+    // Simulate a run where everything inserted but the guard write was lost.
+    mockDb.appMeta.delete('legacy_plans_migrated');
+
+    await migrateLegacyPlans();
+
+    expect(mockDb.studyPlans.size).toBe(2);
+    expect(mockDb.planItems.size).toBe(5);
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
+  });
+
+  it('skips unparseable chapter ids without aborting the seed', async () => {
+    mockDb = makeFakeDb(
+      [
+        {
+          id: 'broken',
+          name: 'Broken',
+          description: '',
+          total_days: 1,
+          chapters_json: JSON.stringify([{ day: 1, chapters: ['???', 'genesis_1'] }]),
+        },
+      ],
+      [],
+    );
+
+    await migrateLegacyPlans();
+
+    expect(mockDb.studyPlans.size).toBe(1);
+    // item_num 1 was consumed by the skipped id; genesis_1 lands at 2.
+    expect(mockDb.planItems.size).toBe(1);
+    expect(mockDb.planItems.get('legacy_broken:2')?.[2]).toBe(
+      JSON.stringify({ bookId: 'genesis', chapterNum: 1 }),
+    );
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
+  });
+});

--- a/app/__tests__/services/study/planTemplates.test.ts
+++ b/app/__tests__/services/study/planTemplates.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #1831 — plan template builders (services/study/planTemplates).
+ * Items must be derived from content queries only, so every builder is
+ * exercised against mocked content-DB rows.
+ */
+import type { JourneyStop } from '@/types';
+
+const mockGetBook = jest.fn();
+const mockGetJourneyStops = jest.fn();
+const mockGetTopic = jest.fn();
+
+jest.mock('@/db/content', () => ({
+  getBook: (...args: unknown[]) => mockGetBook(...args),
+}));
+
+jest.mock('@/db/content/features', () => ({
+  getJourneyStops: (...args: unknown[]) => mockGetJourneyStops(...args),
+}));
+
+jest.mock('@/db/content/reference', () => ({
+  getTopic: (...args: unknown[]) => mockGetTopic(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import {
+  buildBookPlanItems,
+  buildJourneyPlanItems,
+  buildTopicPlanItems,
+  parseChapterId,
+} from '@/services/study';
+
+function makeStop(overrides: Partial<JourneyStop>): JourneyStop {
+  return {
+    id: 1,
+    journey_id: 'j1',
+    stop_order: 1,
+    stop_type: 'passage' as JourneyStop['stop_type'],
+    label: null,
+    ref: null,
+    book_id: null,
+    chapter_num: null,
+    verse_start: null,
+    verse_end: null,
+    development: null,
+    what_changes: null,
+    linked_journey_id: null,
+    linked_journey_intro: null,
+    bridge_to_next: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('parseChapterId', () => {
+  it('parses simple and multi-underscore chapter ids', () => {
+    expect(parseChapterId('genesis_1')).toEqual({ bookId: 'genesis', chapterNum: 1 });
+    expect(parseChapterId('1_samuel_16')).toEqual({ bookId: '1_samuel', chapterNum: 16 });
+    expect(parseChapterId('song_of_solomon_4')).toEqual({
+      bookId: 'song_of_solomon',
+      chapterNum: 4,
+    });
+  });
+
+  it('returns null on unrecognized input', () => {
+    expect(parseChapterId('genesis')).toBeNull();
+    expect(parseChapterId('')).toBeNull();
+  });
+});
+
+describe('buildBookPlanItems', () => {
+  it('emits one session item per chapter in order', async () => {
+    mockGetBook.mockResolvedValue({ id: 'jonah', total_chapters: 4 });
+
+    const items = await buildBookPlanItems('jonah');
+
+    expect(mockGetBook).toHaveBeenCalledWith('jonah');
+    expect(items).toHaveLength(4);
+    expect(items[0]).toEqual({ kind: 'session', ref: { bookId: 'jonah', chapterNum: 1 } });
+    expect(items[3]).toEqual({ kind: 'session', ref: { bookId: 'jonah', chapterNum: 4 } });
+  });
+
+  it('returns [] for an unknown book', async () => {
+    mockGetBook.mockResolvedValue(null);
+    expect(await buildBookPlanItems('atlantis')).toEqual([]);
+  });
+});
+
+describe('buildJourneyPlanItems', () => {
+  it('emits session items for scripture-anchored stops, keeping stop order and verse anchors', async () => {
+    mockGetJourneyStops.mockResolvedValue([
+      makeStop({ id: 11, stop_order: 1, book_id: 'genesis', chapter_num: 9 }),
+      makeStop({ id: 12, stop_order: 2, book_id: null, chapter_num: null }), // interlude
+      makeStop({ id: 13, stop_order: 3, book_id: 'jeremiah', chapter_num: 31, verse_start: 31 }),
+    ]);
+
+    const items = await buildJourneyPlanItems('covenant');
+
+    expect(mockGetJourneyStops).toHaveBeenCalledWith('covenant');
+    expect(items).toEqual([
+      { kind: 'session', ref: { bookId: 'genesis', chapterNum: 9, stopId: 11 } },
+      {
+        kind: 'session',
+        ref: { bookId: 'jeremiah', chapterNum: 31, verseStart: 31, stopId: 13 },
+      },
+    ]);
+  });
+
+  it('returns [] for a journey with no stops', async () => {
+    mockGetJourneyStops.mockResolvedValue([]);
+    expect(await buildJourneyPlanItems('empty')).toEqual([]);
+  });
+});
+
+describe('buildTopicPlanItems', () => {
+  it('emits deduped session items from relevant_chapters_json in curated order', async () => {
+    mockGetTopic.mockResolvedValue({
+      id: 'covenant',
+      relevant_chapters_json: JSON.stringify([
+        'genesis_15',
+        'exodus_19',
+        'genesis_15', // duplicate — dropped
+        'not-a-chapter', // unparseable — dropped
+        '2_samuel_7',
+      ]),
+    });
+
+    const items = await buildTopicPlanItems('covenant');
+
+    expect(items).toEqual([
+      { kind: 'session', ref: { bookId: 'genesis', chapterNum: 15 } },
+      { kind: 'session', ref: { bookId: 'exodus', chapterNum: 19 } },
+      { kind: 'session', ref: { bookId: '2_samuel', chapterNum: 7 } },
+    ]);
+  });
+
+  it('returns [] for an unknown topic, a null chapter list, or bad JSON', async () => {
+    mockGetTopic.mockResolvedValueOnce(null);
+    expect(await buildTopicPlanItems('missing')).toEqual([]);
+
+    mockGetTopic.mockResolvedValueOnce({ id: 't', relevant_chapters_json: null });
+    expect(await buildTopicPlanItems('t')).toEqual([]);
+
+    mockGetTopic.mockResolvedValueOnce({ id: 't', relevant_chapters_json: '{oops' });
+    expect(await buildTopicPlanItems('t')).toEqual([]);
+  });
+});

--- a/app/__tests__/services/study/progression.test.ts
+++ b/app/__tests__/services/study/progression.test.ts
@@ -1,0 +1,156 @@
+/**
+ * #1831 — progression helpers (services/study/progression).
+ */
+import type { StudyPlan, StudyPlanItem } from '@/types';
+
+const mockGetStudyPlans = jest.fn();
+const mockGetStudyPlanItems = jest.fn();
+const mockGetGuidedStudySession = jest.fn();
+
+jest.mock('@/db/userQueries', () => ({
+  getStudyPlans: (...args: unknown[]) => mockGetStudyPlans(...args),
+  getStudyPlanItems: (...args: unknown[]) => mockGetStudyPlanItems(...args),
+  getGuidedStudySession: (...args: unknown[]) => mockGetGuidedStudySession(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { getActivePlan, getNextItem, percentComplete, resumeTarget } from '@/services/study';
+
+function makePlan(id: string): StudyPlan {
+  return {
+    id,
+    plan_type: 'book',
+    source_id: 'genesis',
+    title: 'Genesis',
+    default_mode: 'quick',
+    created_at: '2026-06-01 00:00:00',
+    archived_at: null,
+  };
+}
+
+function makeItem(
+  planId: string,
+  itemNum: number,
+  overrides: Partial<StudyPlanItem> = {},
+): StudyPlanItem {
+  return {
+    plan_id: planId,
+    item_num: itemNum,
+    kind: 'session',
+    ref_json: JSON.stringify({ bookId: 'genesis', chapterNum: itemNum }),
+    session_id: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getActivePlan', () => {
+  it('returns the newest plan that still has an incomplete item', async () => {
+    mockGetStudyPlans.mockResolvedValue([makePlan('newest'), makePlan('older')]);
+    mockGetStudyPlanItems.mockImplementation(async (planId: string) =>
+      planId === 'newest'
+        ? [makeItem('newest', 1, { completed_at: '2026-06-02 08:00:00' })] // fully done
+        : [makeItem('older', 1)],
+    );
+
+    const active = await getActivePlan();
+    expect(active?.id).toBe('older');
+  });
+
+  it('returns null when every plan is complete or there are no plans', async () => {
+    mockGetStudyPlans.mockResolvedValue([makePlan('done')]);
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('done', 1, { completed_at: '2026-06-02 08:00:00' }),
+    ]);
+    expect(await getActivePlan()).toBeNull();
+
+    mockGetStudyPlans.mockResolvedValue([]);
+    expect(await getActivePlan()).toBeNull();
+  });
+});
+
+describe('getNextItem', () => {
+  it('returns the first incomplete item', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('p', 1, { completed_at: '2026-06-02 08:00:00' }),
+      makeItem('p', 2),
+      makeItem('p', 3),
+    ]);
+    const next = await getNextItem('p');
+    expect(next?.item_num).toBe(2);
+  });
+
+  it('returns null when the plan is complete or empty', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('p', 1, { completed_at: '2026-06-02 08:00:00' }),
+    ]);
+    expect(await getNextItem('p')).toBeNull();
+
+    mockGetStudyPlanItems.mockResolvedValue([]);
+    expect(await getNextItem('p')).toBeNull();
+  });
+});
+
+describe('percentComplete', () => {
+  it('rounds to a whole percentage', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([
+      makeItem('p', 1, { completed_at: 'x' }),
+      makeItem('p', 2),
+      makeItem('p', 3),
+    ]);
+    expect(await percentComplete('p')).toBe(33);
+  });
+
+  it('reads empty plans as 0 and finished plans as 100', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([]);
+    expect(await percentComplete('p')).toBe(0);
+
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 1, { completed_at: 'x' })]);
+    expect(await percentComplete('p')).toBe(100);
+  });
+});
+
+describe('resumeTarget', () => {
+  it('returns the next item’s chapter without a step when no session is attached', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 5)]);
+    expect(await resumeTarget('p')).toEqual({ bookId: 'genesis', chapterNum: 5 });
+    expect(mockGetGuidedStudySession).not.toHaveBeenCalled();
+  });
+
+  it('includes the current step when the linked session is still active', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 2, { session_id: '42' })]);
+    mockGetGuidedStudySession.mockResolvedValue({ id: 42, status: 'active', current_step: 'explore' });
+
+    expect(await resumeTarget('p')).toEqual({
+      bookId: 'genesis',
+      chapterNum: 2,
+      step: 'explore',
+    });
+    expect(mockGetGuidedStudySession).toHaveBeenCalledWith(42);
+  });
+
+  it('omits the step when the linked session is completed', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 2, { session_id: '42' })]);
+    mockGetGuidedStudySession.mockResolvedValue({
+      id: 42,
+      status: 'completed',
+      current_step: 'review',
+    });
+    expect(await resumeTarget('p')).toEqual({ bookId: 'genesis', chapterNum: 2 });
+  });
+
+  it('returns null for a finished plan or an unparseable ref', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 1, { completed_at: 'x' })]);
+    expect(await resumeTarget('p')).toBeNull();
+
+    mockGetStudyPlanItems.mockResolvedValue([makeItem('p', 1, { ref_json: '{broken' })]);
+    expect(await resumeTarget('p')).toBeNull();
+  });
+});

--- a/app/__tests__/services/study/rhythm.test.ts
+++ b/app/__tests__/services/study/rhythm.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #1831 — weekly rhythm (services/study/rhythm). Derived only:
+ * counts come straight from guided_study_sessions / guided_review_items.
+ */
+const mockGetAllAsync = jest.fn();
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({ getAllAsync: mockGetAllAsync }),
+}));
+
+import { getWeeklyRhythm, isoWeekKey, isoWeekStart, parseSqliteUtc } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isoWeekKey', () => {
+  it('follows ISO-8601 week-year boundaries', () => {
+    // 2026-01-01 is a Thursday → W01 of 2026.
+    expect(isoWeekKey(new Date(Date.UTC(2026, 0, 1)))).toBe('2026-W01');
+    // 2025-12-29 (Mon) belongs to the same ISO week → 2026-W01.
+    expect(isoWeekKey(new Date(Date.UTC(2025, 11, 29)))).toBe('2026-W01');
+    // 2027-01-01 is a Friday whose week's Thursday is 2026-12-31 → 2026-W53.
+    expect(isoWeekKey(new Date(Date.UTC(2027, 0, 1)))).toBe('2026-W53');
+    expect(isoWeekKey(new Date(Date.UTC(2026, 6, 2)))).toBe('2026-W27');
+  });
+});
+
+describe('isoWeekStart', () => {
+  it('returns the Monday of the containing ISO week', () => {
+    // 2026-07-02 is a Thursday; its week starts Monday 2026-06-29.
+    expect(isoWeekStart(new Date(Date.UTC(2026, 6, 2))).toISOString().slice(0, 10)).toBe(
+      '2026-06-29',
+    );
+    // A Monday maps to itself; a Sunday maps back six days.
+    expect(isoWeekStart(new Date(Date.UTC(2026, 5, 29))).toISOString().slice(0, 10)).toBe(
+      '2026-06-29',
+    );
+    expect(isoWeekStart(new Date(Date.UTC(2026, 6, 5))).toISOString().slice(0, 10)).toBe(
+      '2026-06-29',
+    );
+  });
+});
+
+describe('parseSqliteUtc', () => {
+  it('parses SQLite datetime strings as UTC and rejects garbage', () => {
+    const parsed = parseSqliteUtc('2026-07-02 08:30:00');
+    expect(parsed?.toISOString()).toBe('2026-07-02T08:30:00.000Z');
+    expect(parseSqliteUtc('not a date')).toBeNull();
+  });
+});
+
+describe('getWeeklyRhythm', () => {
+  const NOW = new Date(Date.UTC(2026, 6, 2, 12, 0, 0)); // Thu 2026-07-02, week 2026-W27
+
+  it('zero-fills the trailing window and buckets completions per ISO week', async () => {
+    mockGetAllAsync
+      .mockResolvedValueOnce([
+        // sessions
+        { completed_at: '2026-07-01 09:00:00' }, // W27
+        { completed_at: '2026-06-24 21:00:00' }, // W26
+        { completed_at: '2026-06-23 07:15:00' }, // W26
+      ])
+      .mockResolvedValueOnce([
+        // reviews
+        { updated_at: '2026-06-29 06:00:00' }, // W27
+        { updated_at: '2026-05-20 06:00:00' }, // W21 — inside a 8-week window
+      ]);
+
+    const rhythm = await getWeeklyRhythm(8, NOW);
+
+    expect(rhythm).toHaveLength(8);
+    expect(rhythm[0].week).toBe('2026-W20'); // oldest first
+    expect(rhythm[7]).toEqual({
+      week: '2026-W27',
+      weekStart: '2026-06-29',
+      sessions: 1,
+      reviews: 1,
+    });
+    const w26 = rhythm.find((r) => r.week === '2026-W26');
+    expect(w26).toMatchObject({ sessions: 2, reviews: 0 });
+    const w21 = rhythm.find((r) => r.week === '2026-W21');
+    expect(w21).toMatchObject({ sessions: 0, reviews: 1 });
+    // Untouched weeks stay zero-filled.
+    expect(rhythm.find((r) => r.week === '2026-W24')).toMatchObject({ sessions: 0, reviews: 0 });
+  });
+
+  it('ignores rows outside the window and unparseable timestamps', async () => {
+    mockGetAllAsync
+      .mockResolvedValueOnce([
+        { completed_at: '2020-01-01 00:00:00' }, // ancient — no bucket
+        { completed_at: 'garbage' },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const rhythm = await getWeeklyRhythm(4, NOW);
+
+    expect(rhythm).toHaveLength(4);
+    expect(rhythm.every((r) => r.sessions === 0 && r.reviews === 0)).toBe(true);
+  });
+
+  it('queries only completed sessions and completed reviews', async () => {
+    mockGetAllAsync.mockResolvedValue([]);
+    await getWeeklyRhythm(8, NOW);
+
+    const [sessionSql] = mockGetAllAsync.mock.calls[0];
+    const [reviewSql] = mockGetAllAsync.mock.calls[1];
+    expect(sessionSql).toContain('FROM guided_study_sessions');
+    expect(sessionSql).toContain("status = 'completed'");
+    expect(reviewSql).toContain('FROM guided_review_items');
+    expect(reviewSql).toContain("status = 'completed'");
+  });
+});

--- a/app/src/components/study/ContinueHero.tsx
+++ b/app/src/components/study/ContinueHero.tsx
@@ -1,0 +1,178 @@
+/**
+ * components/study/ContinueHero.tsx — The Study hub's "Continue" hero
+ * (#1832): active plan title in Cinzel, chapter trail ticks (done =
+ * filled gold, current = hollow with a soft glow, upcoming = hollow
+ * dim), paused step + minutes, and a Resume action.
+ *
+ * The current-tick glow is decorative; it renders statically when the
+ * OS reduce-motion setting is on.
+ */
+import React, { useEffect, useState } from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Play } from 'lucide-react-native';
+import { formatChapterRef, getGuidedStudyStepLabel } from '../../services/guidedStudy';
+import type { ResumeTarget } from '../../services/study';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { StudyPlan, StudyPlanItem } from '../../types';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+
+interface Props {
+  plan: StudyPlan;
+  items: StudyPlanItem[];
+  target: ResumeTarget;
+  estimateMin: number | null;
+  onResume: () => void;
+}
+
+function TrailTick({ state, glow }: { state: 'done' | 'current' | 'upcoming'; glow: boolean }) {
+  const { base } = useTheme();
+  const [pulse] = useState(() => new Animated.Value(0.35));
+
+  useEffect(() => {
+    if (state !== 'current' || !glow) return;
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 1, duration: 1100, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 0.35, duration: 1100, useNativeDriver: true }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [state, glow, pulse]);
+
+  if (state === 'done') {
+    return <View style={[styles.tick, { backgroundColor: base.gold }]} />;
+  }
+  if (state === 'current') {
+    return (
+      <View style={styles.currentWrap}>
+        <Animated.View
+          style={[
+            styles.halo,
+            { borderColor: base.gold, opacity: glow ? pulse : 0.55 },
+          ]}
+        />
+        <View style={[styles.tick, styles.hollow, { borderColor: base.gold }]} />
+      </View>
+    );
+  }
+  return <View style={[styles.tick, styles.hollow, { borderColor: base.border }]} />;
+}
+
+export function ContinueHero({ plan, items, target, estimateMin, onResume }: Props) {
+  const { base } = useTheme();
+  const reducedMotion = useReducedMotion();
+
+  const currentItemNum = items.find((i) => i.completed_at == null)?.item_num ?? null;
+  const chapterRef = formatChapterRef(`${target.bookId}_${target.chapterNum}`);
+
+  const metaParts: string[] = [chapterRef];
+  if (target.step) metaParts.push(`Paused at ${getGuidedStudyStepLabel(target.step)}`);
+  if (estimateMin != null) metaParts.push(`~${estimateMin} min`);
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}
+    >
+      <Text style={[styles.kicker, { color: base.textMuted }]}>CONTINUE</Text>
+      <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
+        {plan.title}
+      </Text>
+
+      <View style={styles.trail} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+        {items.map((item) => (
+          <TrailTick
+            key={item.item_num}
+            state={
+              item.completed_at != null
+                ? 'done'
+                : item.item_num === currentItemNum
+                  ? 'current'
+                  : 'upcoming'
+            }
+            glow={!reducedMotion}
+          />
+        ))}
+      </View>
+
+      <Text style={[styles.meta, { color: base.textMuted }]}>{metaParts.join(' · ')}</Text>
+
+      <TouchableOpacity
+        onPress={onResume}
+        activeOpacity={0.72}
+        style={[styles.resumeButton, { backgroundColor: base.gold }]}
+        accessibilityRole="button"
+        accessibilityLabel={`Resume ${plan.title} at ${chapterRef}`}
+      >
+        <Play size={16} color={base.bg} />
+        <Text style={[styles.resumeLabel, { color: base.bg }]}>Resume</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  kicker: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 1,
+  },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 20,
+    // No numberOfLines on purpose — Dynamic Type must never truncate
+    // the hero title (a11y acceptance criterion, #1832).
+  },
+  trail: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    alignItems: 'center',
+  },
+  tick: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+  hollow: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+  },
+  currentWrap: {
+    width: 15,
+    height: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  halo: {
+    position: 'absolute',
+    width: 15,
+    height: 15,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  meta: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+  },
+  resumeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 44,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    alignSelf: 'stretch',
+  },
+  resumeLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
+  },
+});

--- a/app/src/components/study/LibrarySections.tsx
+++ b/app/src/components/study/LibrarySections.tsx
@@ -1,0 +1,315 @@
+/**
+ * components/study/LibrarySections.tsx — The Explore/Study library
+ * shelves, extracted from ExploreMenuScreen (#1832) so the Study hub
+ * and the legacy Explore menu render the exact same sections.
+ *
+ * Each section is a horizontal shelf (FlatList) of cards: art slot
+ * (content_images via the explore image registry, tonal-wash fallback
+ * inside FeatureCard when no image) + title + subtitle. The per-tool
+ * `color` values in LIBRARY_SECTIONS are intentional data colors, not
+ * theme leaks — everything else styles through useTheme() tokens.
+ *
+ * Consumers own premium gating: pass `onNavigate` that checks
+ * PREMIUM_SCREENS (exported here) and shows the upgrade prompt.
+ */
+import React, { useCallback } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { useTheme, spacing, fontFamily } from '../../theme';
+import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../FeatureCard';
+import { JourneyBrowseSection } from '../JourneyBrowseSection';
+import {
+  ProphecyChainCard,
+  DebatePreviewList,
+  WordStudyPreviewList,
+  LifeTopicGrid,
+  FullWidthImageCard,
+  GlossySectionWrapper,
+  PROPHECY_CHAIN_CARD_WIDTH,
+} from '../explore';
+import { useProphecyChains } from '../../hooks/useProphecyChains';
+import type { ExploreFeatureImages } from '../../types';
+import type { ProphecyChain } from '../../types';
+
+// ── Section data ───────────────────────────────────────────────
+
+export interface FeatureSection {
+  id: string;
+  label: string;
+  subtitle: string;
+  features: FeatureCardData[];
+}
+
+/** Screens that require premium — consumers gate onNavigate with this. */
+export const PREMIUM_SCREENS: Record<string, string> = {
+  Concordance: 'Concordance Search',
+  ContentLibrary: 'Content Library',
+  ThreadBrowse: 'Cross-Reference Threading',
+  HowWeGotTheBibleLanding: 'How We Got The Bible',
+};
+
+export const LIBRARY_SECTIONS: FeatureSection[] = [
+  {
+    id: 'biblical-world', label: 'The Biblical World', subtitle: 'Where, when, and who',
+    features: [
+      { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                color: '#e86040', screen: 'GenealogyTree' }, // data-color: intentional
+      { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        color: '#70b8e8', screen: 'Timeline' }, // data-color: intentional
+      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
+      { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    color: '#8a6e3a', screen: 'Periods', premium: true }, // data-color: intentional
+      { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          color: '#c8a040', screen: 'RedemptiveArc', premium: true }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'themes', label: 'Themes & Connections', subtitle: 'Trace ideas across Scripture',
+    features: [
+      { title: 'Guided Journeys',    subtitle: '60 journeys — people, concepts, themes',             color: '#bfa050', screen: 'JourneyBrowse' }, // data-color: intentional
+      { title: 'Topical Index',      subtitle: 'What does the Bible say about...?',                    color: '#c8a040', screen: 'TopicBrowse' }, // data-color: intentional
+      { title: 'Prophecy',           subtitle: '50 chains — OT to NT fulfillment',                color: '#e8a070', screen: 'ProphecyBrowse' }, // data-color: intentional
+      { title: 'Threads',            subtitle: 'One idea across 31 chains',                            color: '#9090e0', screen: 'ThreadBrowse', premium: true }, // data-color: intentional
+      { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                color: '#70d098', screen: 'HarmonyBrowse' }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'journeys', label: 'Journeys', subtitle: 'Follow a life or trace an idea across Scripture',
+    features: [], // Custom renderer — uses JourneyBrowseSection instead of FeatureCards
+  },
+  {
+    id: 'language', label: 'Language & Reference', subtitle: 'Original words and definitions',
+    features: [
+      { title: 'Word Studies', subtitle: 'Hebrew & Greek deep dives',                                  color: '#e890b8', screen: 'WordStudyBrowse' }, // data-color: intentional
+      { title: 'Concordance',  subtitle: 'Every occurrence of a word',                                 color: '#70b8e8', screen: 'Concordance', premium: true }, // data-color: intentional
+      { title: 'Dictionary',   subtitle: 'Definitions for every biblical term',                         color: '#c090e0', screen: 'DictionaryBrowse' }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'scholarly', label: 'Scholarly Analysis', subtitle: 'Academic perspectives & debate',
+    features: [
+      { title: 'Scholars',             subtitle: 'Browse all 54 by tradition',                            color: '#a0b8d0', screen: 'ScholarBrowse' }, // data-color: intentional
+      { title: 'Debates',              subtitle: '303 topics where scholars disagree',                    color: '#d08080', screen: 'DebateBrowse' }, // data-color: intentional
+      { title: 'Difficult Passages',   subtitle: '53 hard texts with multi-view responses',               color: '#FFB74D', screen: 'DifficultPassagesBrowse' }, // data-color: intentional
+      { title: 'How We Got The Bible', subtitle: 'Canon, manuscripts, translations, and the books Jude quoted', color: '#c89858', screen: 'HowWeGotTheBibleLanding', premium: true }, // data-color: intentional
+      { title: 'Content Library',      subtitle: 'Discourse, manuscripts & more',                          color: '#b8a0d0', screen: 'ContentLibrary', premium: true }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'life', label: 'Life & Faith', subtitle: 'Biblical guidance for everyday life',
+    features: [
+      { title: 'Life Topics', subtitle: 'Practical guidance from Scripture',                             color: '#81C784', screen: 'LifeTopics' }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'deep-dive', label: 'Deep Dive', subtitle: 'Advanced study tools',
+    features: [
+      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
+      { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                color: '#b07d4f', screen: 'ArchaeologyBrowse' }, // data-color: intentional
+      { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   color: '#8a6a3a', screen: 'TimeTravelBrowse' }, // data-color: intentional
+      { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  color: '#7a9ab0', screen: 'GrammarBrowse' }, // data-color: intentional
+    ],
+  },
+];
+
+// ── Component ──────────────────────────────────────────────────
+
+export interface LibrarySectionsProps {
+  /** Explore image registry (useExploreImages) keyed by screen name. */
+  imageRegistry: Record<string, ExploreFeatureImages>;
+  isPremium: boolean;
+  /** Navigate to a tool screen. Consumer applies PREMIUM_SCREENS gating. */
+  onNavigate: (screen: string, params?: Record<string, string>) => void;
+  /** Follow a card image's deep link. */
+  onDeepLink: (deepLink: { screen: string; params?: Record<string, string> }) => void;
+  /** When set, render only the section with this id (jump-pill filter). */
+  filterSectionId?: string | null;
+}
+
+export function LibrarySections({
+  imageRegistry,
+  isPremium,
+  onNavigate,
+  onDeepLink,
+  filterSectionId,
+}: LibrarySectionsProps) {
+  const { base } = useTheme();
+  const { chains: prophecyChains } = useProphecyChains();
+
+  const getScreenImages = useCallback(
+    (screenName: string) => imageRegistry[screenName],
+    [imageRegistry],
+  );
+
+  const renderFeatureCard = useCallback(
+    ({ item, index }: { item: FeatureCardData; index: number }, compact: boolean) => {
+      const imgData = getScreenImages(item.screen);
+      return (
+        <FeatureCard
+          feature={item}
+          onPress={() => onNavigate(item.screen)}
+          isPremium={isPremium}
+          images={imgData?.images}
+          count={imgData?.count}
+          noun={imgData?.noun}
+          onImagePress={onDeepLink}
+          staggerMs={index * 1200}
+          compact={compact || undefined}
+        />
+      );
+    },
+    [getScreenImages, isPremium, onNavigate, onDeepLink],
+  );
+
+  const featureKey = useCallback((item: FeatureCardData) => item.screen, []);
+  const chainKey = useCallback((item: ProphecyChain) => item.id, []);
+
+  // ── Per-section content renderer ────────────────────────────
+  const renderSectionContent = (section: FeatureSection) => {
+    switch (section.id) {
+      case 'journeys':
+        return <JourneyBrowseSection />;
+      case 'themes':
+        return (
+          <View style={styles.sectionGap}>
+            {prophecyChains.length > 0 && (
+              <FlatList
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.carouselContent}
+                decelerationRate="fast"
+                snapToInterval={PROPHECY_CHAIN_CARD_WIDTH + spacing.sm}
+                data={prophecyChains.slice(0, 4)}
+                keyExtractor={chainKey}
+                renderItem={({ item }) => (
+                  <ProphecyChainCard
+                    chain={item}
+                    onPress={() => onNavigate('ProphecyDetail', { chainId: item.id })}
+                  />
+                )}
+              />
+            )}
+            <FlatList
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.carouselContent}
+              decelerationRate="fast"
+              data={section.features}
+              keyExtractor={featureKey}
+              renderItem={(info) => renderFeatureCard(info, true)}
+            />
+          </View>
+        );
+      case 'scholarly': {
+        // Debates renders as the preview strip above; everything else flows
+        // into the horizontal carousel below. Denylist (vs. allowlist) so
+        // future cards added to LIBRARY_SECTIONS surface automatically —
+        // same pattern as the 'language' case for WordStudyBrowse.
+        const carouselFeatures = section.features.filter(
+          (f) => f.screen !== 'DebateBrowse',
+        );
+        const totalDebates = getScreenImages('DebateBrowse')?.count ?? undefined;
+        return (
+          <View style={styles.sectionGap}>
+            <DebatePreviewList
+              onDebatePress={(debateId) => onNavigate('DebateDetail', { topicId: debateId })}
+              onSeeAll={() => onNavigate('DebateBrowse')}
+              totalCount={totalDebates ?? undefined}
+            />
+            <FlatList
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.carouselContent}
+              decelerationRate="fast"
+              data={carouselFeatures}
+              keyExtractor={featureKey}
+              renderItem={(info) => renderFeatureCard(info, true)}
+            />
+          </View>
+        );
+      }
+      case 'language': {
+        const splitFeatures = section.features.filter(
+          (f) => f.screen !== 'WordStudyBrowse',
+        );
+        const totalWords = getScreenImages('WordStudyBrowse')?.count ?? undefined;
+        return (
+          <View style={styles.sectionGap}>
+            <WordStudyPreviewList
+              onWordPress={(id) => onNavigate('WordStudyDetail', { wordId: id })}
+              onSeeAll={() => onNavigate('WordStudyBrowse')}
+              totalCount={totalWords ?? undefined}
+            />
+            <View style={styles.row3}>
+              {splitFeatures.map((f, i) => (
+                <View key={f.screen} style={styles.rowCell}>
+                  {renderFeatureCard({ item: f, index: i }, true)}
+                </View>
+              ))}
+            </View>
+          </View>
+        );
+      }
+      case 'life': {
+        const lifeImage = getScreenImages('LifeTopics');
+        return (
+          <View style={styles.sectionGap}>
+            <FullWidthImageCard
+              title="Life Topics"
+              subtitle="Practical guidance from Scripture"
+              image={lifeImage?.images?.[0] ?? null}
+              count={lifeImage?.count ?? null}
+              noun={lifeImage?.noun}
+              onPress={() => onNavigate('LifeTopics')}
+            />
+            <LifeTopicGrid
+              onCategoryPress={(categoryId) => onNavigate('LifeTopics', { categoryId })}
+            />
+          </View>
+        );
+      }
+      case 'deep-dive':
+      case 'biblical-world':
+      default:
+        return (
+          <FlatList
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.carouselContent}
+            decelerationRate="fast"
+            snapToInterval={CARD_WIDTH + spacing.sm}
+            data={section.features}
+            keyExtractor={featureKey}
+            renderItem={(info) => renderFeatureCard(info, false)}
+          />
+        );
+    }
+  };
+
+  const sections = filterSectionId
+    ? LIBRARY_SECTIONS.filter((s) => s.id === filterSectionId)
+    : LIBRARY_SECTIONS;
+
+  return (
+    <>
+      {sections.map((section, sectionIndex) => (
+        <View key={section.id}>
+          <GlossySectionWrapper sectionIndex={sectionIndex}>
+            <View style={styles.section}>
+              <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
+              <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
+              {renderSectionContent(section)}
+            </View>
+          </GlossySectionWrapper>
+        </View>
+      ))}
+    </>
+  );
+}
+
+// ── Styles ─────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  section: { marginBottom: spacing.md },
+  sectionLabel: { fontFamily: fontFamily.displayMedium, fontSize: 13, letterSpacing: 0.5, marginBottom: 2 },
+  sectionSubtitle: { fontFamily: fontFamily.ui, fontSize: 11, marginBottom: spacing.sm },
+  carouselContent: { gap: spacing.sm },
+  sectionGap: { gap: spacing.md },
+  row3: { flexDirection: 'row', gap: spacing.sm },
+  rowCell: { flex: 1 },
+});

--- a/app/src/components/study/ReviewRecallCard.tsx
+++ b/app/src/components/study/ReviewRecallCard.tsx
@@ -1,0 +1,100 @@
+/**
+ * components/study/ReviewRecallCard.tsx — Single focused review card
+ * on the Study hub (#1832). Shows one due prompt at a time; "Recall it"
+ * completes the item, "Later" cycles to the next due item.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Clock } from 'lucide-react-native';
+import { formatChapterRef } from '../../services/guidedStudy';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { GuidedReviewItem } from '../../types';
+
+interface Props {
+  item: GuidedReviewItem;
+  dueCount: number;
+  onRecall: () => void;
+  onLater: () => void;
+}
+
+export function ReviewRecallCard({ item, dueCount, onRecall, onLater }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.border }]}
+    >
+      <View style={styles.header}>
+        <Clock size={14} color={base.gold} />
+        <Text style={[styles.headerText, { color: base.textMuted }]}>
+          {formatChapterRef(item.chapter_id)}
+          {dueCount > 1 ? `  ·  1 of ${dueCount} due` : ''}
+        </Text>
+      </View>
+
+      <Text style={[styles.prompt, { color: base.text }]}>{item.prompt}</Text>
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          onPress={onRecall}
+          activeOpacity={0.72}
+          style={[styles.action, { borderColor: `${base.gold}55` }]}
+          accessibilityRole="button"
+          accessibilityLabel="Recall it — mark this review complete"
+        >
+          <Text style={[styles.actionLabel, { color: base.gold }]}>Recall it</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={onLater}
+          activeOpacity={0.72}
+          style={[styles.action, { borderColor: base.border }]}
+          accessibilityRole="button"
+          accessibilityLabel="Later — show the next due review"
+        >
+          <Text style={[styles.actionLabel, { color: base.textMuted }]}>Later</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  headerText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    letterSpacing: 0.4,
+  },
+  prompt: {
+    fontFamily: fontFamily.body,
+    fontSize: 17,
+    lineHeight: 24,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  action: {
+    flex: 1,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  actionLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 13,
+  },
+});

--- a/app/src/components/study/RhythmLine.tsx
+++ b/app/src/components/study/RhythmLine.tsx
@@ -1,0 +1,56 @@
+/**
+ * components/study/RhythmLine.tsx — One italic Garamond sentence
+ * describing this week's study rhythm (#1832). Deliberately NOT a
+ * streak: no counters, no flames, no emojis — just a gentle cadence
+ * observation derived from getWeeklyRhythm().
+ */
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import type { WeeklyRhythm } from '../../services/study';
+import { fontFamily, spacing, useTheme } from '../../theme';
+
+const NUMBER_WORDS = [
+  'no', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
+];
+
+function asWord(n: number): string {
+  return n >= 0 && n < NUMBER_WORDS.length ? NUMBER_WORDS[n] : String(n);
+}
+
+/** Pure sentence builder — exported for tests. */
+export function buildRhythmSentence(rhythm: WeeklyRhythm[]): string {
+  const week = rhythm.length > 0 ? rhythm[rhythm.length - 1] : null;
+  const sessions = week?.sessions ?? 0;
+  const reviews = week?.reviews ?? 0;
+
+  if (sessions === 0 && reviews === 0) {
+    const previous = rhythm.length > 1 ? rhythm[rhythm.length - 2] : null;
+    const wasActive = (previous?.sessions ?? 0) + (previous?.reviews ?? 0) > 0;
+    return wasActive
+      ? 'A quiet week so far — the text will keep until you return.'
+      : 'A quiet stretch — one unhurried session would begin a rhythm.';
+  }
+
+  const parts: string[] = [];
+  if (sessions > 0) parts.push(`${asWord(sessions)} ${sessions === 1 ? 'session' : 'sessions'}`);
+  if (reviews > 0) parts.push(`${asWord(reviews)} ${reviews === 1 ? 'review' : 'reviews'}`);
+  const summary = parts.join(' and ');
+  const sentence = `${summary} this week — a steady rhythm of study.`;
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+}
+
+export function RhythmLine({ rhythm }: { rhythm: WeeklyRhythm[] }) {
+  const { base } = useTheme();
+  return (
+    <Text style={[styles.line, { color: base.textMuted }]}>{buildRhythmSentence(rhythm)}</Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  line: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 14,
+    lineHeight: 21,
+    paddingHorizontal: spacing.xs,
+  },
+});

--- a/app/src/config/featureFlags.ts
+++ b/app/src/config/featureFlags.ts
@@ -19,6 +19,17 @@ export const FEATURE_FLAGS = {
    * When false, premium users get the structured-form synthesis path.
    */
   GUIDED_STUDY_AMICUS_SYNTHESIS: false,
+
+  /**
+   * Unified Study System (#1830): makes StudyHubScreen the root of the
+   * Explore/Study tab instead of ExploreMenuScreen. Before flipping true
+   * (#1838, only after on-device verification of the whole spine):
+   *   - Continue hero resumes the active plan into StudySession correctly.
+   *   - Review card cycles due items and completes them.
+   *   - Flag-off behavior is byte-for-byte identical to master.
+   * When false, the Explore tab renders ExploreMenuScreen exactly as today.
+   */
+  study_hub: false,
 } as const;
 
 /** Compile-time feature flag key (distinct from the env-driven EnvFeatureFlag). */

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -772,6 +772,34 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE guided_study_sessions ADD COLUMN synthesis_strategy TEXT;
     `,
   },
+  {
+    version: 25,
+    description:
+      'Unified study plans (#1831) — study_plans + study_plan_items, plan_id on guided_study_sessions. Legacy reading_plans/plan_progress stay untouched (read-only).',
+    sql: `
+      CREATE TABLE IF NOT EXISTS study_plans (
+        id TEXT PRIMARY KEY,
+        plan_type TEXT NOT NULL,          -- 'book' | 'journey' | 'topical' | 'custom'
+        source_id TEXT NOT NULL,          -- book_id | journey_id | topic_id
+        title TEXT NOT NULL,
+        default_mode TEXT NOT NULL,       -- GuidedStudyMode
+        created_at TEXT NOT NULL,
+        archived_at TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS study_plan_items (
+        plan_id TEXT NOT NULL REFERENCES study_plans(id),
+        item_num INTEGER NOT NULL,
+        kind TEXT NOT NULL,               -- 'session' | 'reading'
+        ref_json TEXT NOT NULL,           -- {"bookId","chapterNum","verseStart"?,"stopId"?}
+        session_id TEXT,
+        completed_at TEXT,
+        PRIMARY KEY (plan_id, item_num)
+      );
+
+      ALTER TABLE guided_study_sessions ADD COLUMN plan_id TEXT;
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -5,6 +5,7 @@
  * via getUserDb().
  */
 
+import * as Crypto from 'expo-crypto';
 import { serializeAmicusChapterRef, type AmicusEntryPoint } from '../services/amicus/context';
 import { emitAmicusUsageChanged } from '../services/amicus/usageEvents';
 import {
@@ -14,7 +15,7 @@ import {
 } from '../services/guidedStudy/capturedInputs';
 import { logger } from '../utils/logger';
 import { nextIntervalAfter } from '../services/guidedStudy/review';
-import type { GuidedStudyStep } from '../types';
+import type { GuidedStudyStep, StudyPlanItemDraft, StudyPlanType } from '../types';
 import { getUserDb } from './userDatabase';
 import type { ReadingPlan } from './userQueries';
 
@@ -191,6 +192,78 @@ export async function abandonPlan(planId: string): Promise<void> {
     await getUserDb().runAsync(
       "INSERT OR REPLACE INTO user_preferences (key, value) VALUES ('active_plan', '')",
     );
+  });
+}
+
+// ── Unified Study Plans (write) — #1831, migration v25 ───────────
+
+export interface CreateStudyPlanArgs {
+  /** Optional stable id — generated (UUID v4) when omitted. */
+  id?: string;
+  planType: StudyPlanType;
+  sourceId: string;
+  title: string;
+  defaultMode: string;
+  items: StudyPlanItemDraft[];
+}
+
+/**
+ * Insert a study plan and its items in one transaction.
+ * Items receive sequential `item_num` values starting at 1.
+ * Returns the plan id.
+ */
+export async function createStudyPlan(args: CreateStudyPlanArgs): Promise<string> {
+  const planId = args.id ?? Crypto.randomUUID();
+  await getUserDb().withTransactionAsync(async () => {
+    await getUserDb().runAsync(
+      `INSERT INTO study_plans (id, plan_type, source_id, title, default_mode, created_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      [planId, args.planType, args.sourceId, args.title, args.defaultMode],
+    );
+    for (let i = 0; i < args.items.length; i++) {
+      const item = args.items[i];
+      await getUserDb().runAsync(
+        'INSERT INTO study_plan_items (plan_id, item_num, kind, ref_json) VALUES (?, ?, ?, ?)',
+        [planId, i + 1, item.kind, JSON.stringify(item.ref)],
+      );
+    }
+  });
+  return planId;
+}
+
+export async function completeStudyPlanItem(planId: string, itemNum: number): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE study_plan_items SET completed_at = datetime('now')
+     WHERE plan_id = ? AND item_num = ? AND completed_at IS NULL`,
+    [planId, itemNum],
+  );
+}
+
+export async function archiveStudyPlan(planId: string): Promise<void> {
+  await getUserDb().runAsync(
+    "UPDATE study_plans SET archived_at = datetime('now') WHERE id = ? AND archived_at IS NULL",
+    [planId],
+  );
+}
+
+/**
+ * Attach a guided study session to a plan item (both directions:
+ * `study_plan_items.session_id` and `guided_study_sessions.plan_id`).
+ */
+export async function linkSessionToPlanItem(
+  planId: string,
+  itemNum: number,
+  sessionId: number,
+): Promise<void> {
+  await getUserDb().withTransactionAsync(async () => {
+    await getUserDb().runAsync(
+      'UPDATE study_plan_items SET session_id = ? WHERE plan_id = ? AND item_num = ?',
+      [String(sessionId), planId, itemNum],
+    );
+    await getUserDb().runAsync('UPDATE guided_study_sessions SET plan_id = ? WHERE id = ?', [
+      planId,
+      sessionId,
+    ]);
   });
 }
 

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -27,6 +27,8 @@ import type {
   GuidedStudySession,
   GuidedStudySynthesis,
   GuidedStudyTakeawaySummary,
+  StudyPlan,
+  StudyPlanItem,
 } from '../types';
 import {
   emptyCapturedInputs,
@@ -234,6 +236,30 @@ export async function getPlanProgress(planId: string): Promise<PlanProgress[]> {
 export async function getActivePlanId(): Promise<string | null> {
   const id = await getPreference('active_plan');
   return id && id.length > 0 ? id : null;
+}
+
+// ── Unified Study Plans (read) — #1831, migration v25 ─────────────
+
+/**
+ * All study plans, newest first. Archived plans are excluded unless
+ * `includeArchived` is set.
+ */
+export async function getStudyPlans(includeArchived = false): Promise<StudyPlan[]> {
+  if (includeArchived) {
+    return getUserDb().getAllAsync<StudyPlan>(
+      'SELECT * FROM study_plans ORDER BY created_at DESC, id DESC',
+    );
+  }
+  return getUserDb().getAllAsync<StudyPlan>(
+    'SELECT * FROM study_plans WHERE archived_at IS NULL ORDER BY created_at DESC, id DESC',
+  );
+}
+
+export async function getStudyPlanItems(planId: string): Promise<StudyPlanItem[]> {
+  return getUserDb().getAllAsync<StudyPlanItem>(
+    'SELECT * FROM study_plan_items WHERE plan_id = ? ORDER BY item_num',
+    [planId],
+  );
 }
 
 // ── Reading Stats ─────────────────────────────────────────────────

--- a/app/src/hooks/useContinuePlan.ts
+++ b/app/src/hooks/useContinuePlan.ts
@@ -1,0 +1,83 @@
+/**
+ * hooks/useContinuePlan.ts — Data for the Study hub's Continue hero
+ * (#1832): the active plan, its items (for the chapter trail ticks),
+ * the resume target, and a minutes estimate for the next chapter from
+ * services/guidedStudy/estimate.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { getChapterPanels, getSectionPanels, getSections, getVerses } from '../db/content';
+import { getStudyPlanItems } from '../db/userQueries';
+import { getStudyDepthEstimate } from '../services/guidedStudy';
+import { getActivePlan, resumeTarget, type ResumeTarget } from '../services/study';
+import type { SectionPanel, StudyPlan, StudyPlanItem } from '../types';
+import { logger } from '../utils/logger';
+
+export interface ContinuePlanState {
+  plan: StudyPlan | null;
+  items: StudyPlanItem[];
+  target: ResumeTarget | null;
+  /** Estimated minutes for the next chapter (null while loading/unknown). */
+  estimateMin: number | null;
+  isLoading: boolean;
+  reload: () => Promise<void>;
+}
+
+export function useContinuePlan(): ContinuePlanState {
+  const [plan, setPlan] = useState<StudyPlan | null>(null);
+  const [items, setItems] = useState<StudyPlanItem[]>([]);
+  const [target, setTarget] = useState<ResumeTarget | null>(null);
+  const [estimateMin, setEstimateMin] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const activePlan = await getActivePlan();
+      if (!activePlan) {
+        setPlan(null);
+        setItems([]);
+        setTarget(null);
+        setEstimateMin(null);
+        return;
+      }
+
+      const [planItems, nextTarget] = await Promise.all([
+        getStudyPlanItems(activePlan.id),
+        resumeTarget(activePlan.id),
+      ]);
+      setPlan(activePlan);
+      setItems(planItems);
+      setTarget(nextTarget);
+
+      if (!nextTarget) {
+        setEstimateMin(null);
+        return;
+      }
+
+      // Minutes for the next chapter, from the same estimator the
+      // session screens use. Deep plans read the deep figure; every
+      // other mode maps to the guided figure.
+      const chapterId = `${nextTarget.bookId}_${nextTarget.chapterNum}`;
+      const [verses, sections, chapterPanels] = await Promise.all([
+        getVerses(nextTarget.bookId, nextTarget.chapterNum),
+        getSections(chapterId),
+        getChapterPanels(chapterId),
+      ]);
+      const sectionPanels: SectionPanel[] = (
+        await Promise.all(sections.map((s) => getSectionPanels(s.id)))
+      ).flat();
+      const estimate = getStudyDepthEstimate(verses, sectionPanels, chapterPanels);
+      setEstimateMin(activePlan.default_mode === 'deep' ? estimate.deepMin : estimate.guidedMin);
+    } catch (err) {
+      logger.warn('useContinuePlan', 'Failed to load continue-plan state', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { plan, items, target, estimateMin, isLoading, reload };
+}

--- a/app/src/hooks/useReducedMotion.ts
+++ b/app/src/hooks/useReducedMotion.ts
@@ -1,0 +1,29 @@
+/**
+ * hooks/useReducedMotion.ts — Tracks the OS "reduce motion" setting.
+ * Decorative animations (e.g. the Study hub's current-tick glow, #1832)
+ * must render statically when this returns true.
+ */
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((value) => {
+        if (mounted) setReduced(value);
+      })
+      .catch(() => {
+        /* default to full motion */
+      });
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduced);
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+
+  return reduced;
+}

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
+import { isFlagEnabled } from '../config/featureFlags';
 import ExploreMenuScreen from '../screens/ExploreMenuScreen';
+import StudyHubScreen from '../screens/StudyHubScreen';
 import { useTheme } from '../theme';
 import type { ExploreStackParamList } from './types';
 import { lazySuspense } from './lazySuspense';
@@ -63,12 +65,16 @@ export function ExploreStack() {
 
   return (
     <Stack.Navigator
+      // study_hub (#1832) is a compile-time flag, so the initial route is
+      // fixed for the lifetime of the process — no remount concerns.
+      initialRouteName={isFlagEnabled('study_hub') ? 'StudyHub' : 'ExploreMenu'}
       screenOptions={{
         headerShown: false,
         cardStyle: { backgroundColor: base.bg },
         gestureEnabled: true,
       }}
     >
+      <Stack.Screen name="StudyHub" component={StudyHubScreen} />
       <Stack.Screen name="ExploreMenu" component={ExploreMenuScreen} />
       <Stack.Screen
         name="GenealogyTree"

--- a/app/src/navigation/TabNavigator.tsx
+++ b/app/src/navigation/TabNavigator.tsx
@@ -1,5 +1,6 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Home, Library, Compass, Search, MessageSquare, MoreHorizontal } from 'lucide-react-native';
+import { Home, Library, GraduationCap, Search, MessageSquare, MoreHorizontal } from 'lucide-react-native';
+import { isFlagEnabled } from '../config/featureFlags';
 import { useSettingsStore } from '../stores';
 import { useTheme } from '../theme';
 import { AmicusStack } from './AmicusStack';
@@ -65,12 +66,17 @@ export function TabNavigator() {
         name="ExploreTab"
         component={ExploreStack}
         options={{
-          tabBarLabel: 'Explore',
-          tabBarIcon: ({ color, size }) => <Compass color={color} size={size} />,
+          tabBarLabel: 'Study',
+          tabBarIcon: ({ color, size }) => <GraduationCap color={color} size={size} />,
         }}
         listeners={({ navigation }) => ({
           tabPress: () => {
-            navigation.navigate('ExploreTab', { screen: 'ExploreMenu' });
+            // Route names are stable (#1832): the tab renames to Study but the
+            // stack/routes stay ExploreTab/ExploreMenu. The hub only becomes
+            // the tab-press target behind the study_hub flag.
+            navigation.navigate('ExploreTab', {
+              screen: isFlagEnabled('study_hub') ? 'StudyHub' : 'ExploreMenu',
+            });
           },
         })}
       />

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -77,6 +77,9 @@ export type HomeStackParamList = {
 
 export type ExploreStackParamList = {
   ExploreMenu: undefined;
+  // Unified Study System hub (#1832) — root of the tab when the
+  // `study_hub` feature flag is on; ExploreMenu stays the fallback root.
+  StudyHub: undefined;
   GenealogyTree: { personId?: string } | undefined;
   PersonDetail: { personId: string };
   Map: { storyId?: string; placeId?: string; personId?: string };

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -3,10 +3,11 @@
  *   1. Jump-to category pills (horizontal scroll)
  *   2. Start Here banner (new users, chaptersRead < 5)
  *   3. Recommended for You with editorial RecommendedCards
- *   4. Horizontal feature carousels with image cards + count CTAs
+ *   4. Library shelves (components/study/LibrarySections — extracted in
+ *      #1832 so the Study hub renders the same sections)
  *   5. Gold separators between sections
  *
- * Part of Epic #1071 (#1077).
+ * Part of Epic #1071 (#1077); flag-off root of the Study tab (#1830).
  */
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
@@ -19,99 +20,16 @@ import { useTheme, spacing, fontFamily } from '../theme';
 import { usePremium } from '../hooks/usePremium';
 import { useExploreRecommendations } from '../hooks/useExploreRecommendations';
 import { useExploreImages } from '../hooks/useExploreImages';
-import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../components/FeatureCard';
 import { RecommendedCard } from '../components/RecommendedCard';
 import { StartHereBanner } from '../components/StartHereBanner';
 import { UpgradePrompt } from '../components/UpgradePrompt';
-import { JourneyBrowseSection } from '../components/JourneyBrowseSection';
 import {
-  ProphecyChainCard,
-  DebatePreviewList,
-  WordStudyPreviewList,
-  LifeTopicGrid,
-  FullWidthImageCard,
-  GlossySectionWrapper,
-  PROPHECY_CHAIN_CARD_WIDTH,
-} from '../components/explore';
-import { useProphecyChains } from '../hooks/useProphecyChains';
+  LibrarySections,
+  LIBRARY_SECTIONS,
+  PREMIUM_SCREENS,
+} from '../components/study/LibrarySections';
 import { getReadingStats, getPreference, setPreference } from '../db/user';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
-
-// ── Section data ───────────────────────────────────────────────
-
-interface FeatureSection {
-  id: string;
-  label: string;
-  subtitle: string;
-  features: FeatureCardData[];
-}
-
-const PREMIUM_SCREENS: Record<string, string> = {
-  Concordance: 'Concordance Search',
-  ContentLibrary: 'Content Library',
-  ThreadBrowse: 'Cross-Reference Threading',
-  HowWeGotTheBibleLanding: 'How We Got The Bible',
-};
-
-const SECTIONS: FeatureSection[] = [
-  {
-    id: 'biblical-world', label: 'The Biblical World', subtitle: 'Where, when, and who',
-    features: [
-      { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                color: '#e86040', screen: 'GenealogyTree' }, // data-color: intentional
-      { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        color: '#70b8e8', screen: 'Timeline' }, // data-color: intentional
-      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
-      { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    color: '#8a6e3a', screen: 'Periods', premium: true }, // data-color: intentional
-      { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          color: '#c8a040', screen: 'RedemptiveArc', premium: true }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'themes', label: 'Themes & Connections', subtitle: 'Trace ideas across Scripture',
-    features: [
-      { title: 'Guided Journeys',    subtitle: '60 journeys \u2014 people, concepts, themes',             color: '#bfa050', screen: 'JourneyBrowse' }, // data-color: intentional
-      { title: 'Topical Index',      subtitle: 'What does the Bible say about...?',                    color: '#c8a040', screen: 'TopicBrowse' }, // data-color: intentional
-      { title: 'Prophecy',           subtitle: '50 chains \u2014 OT to NT fulfillment',                color: '#e8a070', screen: 'ProphecyBrowse' }, // data-color: intentional
-      { title: 'Threads',            subtitle: 'One idea across 31 chains',                            color: '#9090e0', screen: 'ThreadBrowse', premium: true }, // data-color: intentional
-      { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                color: '#70d098', screen: 'HarmonyBrowse' }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'journeys', label: 'Journeys', subtitle: 'Follow a life or trace an idea across Scripture',
-    features: [], // Custom renderer — uses JourneyBrowseSection instead of FeatureCards
-  },
-  {
-    id: 'language', label: 'Language & Reference', subtitle: 'Original words and definitions',
-    features: [
-      { title: 'Word Studies', subtitle: 'Hebrew & Greek deep dives',                                  color: '#e890b8', screen: 'WordStudyBrowse' }, // data-color: intentional
-      { title: 'Concordance',  subtitle: 'Every occurrence of a word',                                 color: '#70b8e8', screen: 'Concordance', premium: true }, // data-color: intentional
-      { title: 'Dictionary',   subtitle: 'Definitions for every biblical term',                         color: '#c090e0', screen: 'DictionaryBrowse' }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'scholarly', label: 'Scholarly Analysis', subtitle: 'Academic perspectives & debate',
-    features: [
-      { title: 'Scholars',             subtitle: 'Browse all 54 by tradition',                            color: '#a0b8d0', screen: 'ScholarBrowse' }, // data-color: intentional
-      { title: 'Debates',              subtitle: '303 topics where scholars disagree',                    color: '#d08080', screen: 'DebateBrowse' }, // data-color: intentional
-      { title: 'Difficult Passages',   subtitle: '53 hard texts with multi-view responses',               color: '#FFB74D', screen: 'DifficultPassagesBrowse' }, // data-color: intentional
-      { title: 'How We Got The Bible', subtitle: 'Canon, manuscripts, translations, and the books Jude quoted', color: '#c89858', screen: 'HowWeGotTheBibleLanding', premium: true }, // data-color: intentional
-      { title: 'Content Library',      subtitle: 'Discourse, manuscripts & more',                          color: '#b8a0d0', screen: 'ContentLibrary', premium: true }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'life', label: 'Life & Faith', subtitle: 'Biblical guidance for everyday life',
-    features: [
-      { title: 'Life Topics', subtitle: 'Practical guidance from Scripture',                             color: '#81C784', screen: 'LifeTopics' }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'deep-dive', label: 'Deep Dive', subtitle: 'Advanced study tools',
-    features: [
-      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
-      { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                color: '#b07d4f', screen: 'ArchaeologyBrowse' }, // data-color: intentional
-      { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   color: '#8a6a3a', screen: 'TimeTravelBrowse' }, // data-color: intentional
-      { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  color: '#7a9ab0', screen: 'GrammarBrowse' }, // data-color: intentional
-    ],
-  },
-];
 
 // ── Component ──────────────────────────────────────────────────
 
@@ -123,7 +41,6 @@ function ExploreMenuScreen() {
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const { recommendations, bookName } = useExploreRecommendations();
   const imageRegistry = useExploreImages();
-  const { chains: prophecyChains } = useProphecyChains();
 
   const [activeJump, setActiveJump] = useState<string | null>(null);
   const [chaptersRead, setChaptersRead] = useState<number | null>(null);
@@ -137,7 +54,7 @@ function ExploreMenuScreen() {
   // ── Preload initial card images on mount ───────────────────
   useEffect(() => {
     const urls: string[] = [];
-    for (const section of SECTIONS.slice(0, 2)) {
+    for (const section of LIBRARY_SECTIONS.slice(0, 2)) {
       for (const f of section.features.slice(0, 3)) {
         const fi = imageRegistry[f.screen];
         if (fi?.images?.[0]) urls.push(fi.images[0].url);
@@ -171,237 +88,12 @@ function ExploreMenuScreen() {
     setActiveJump((prev) => prev === sectionId ? null : sectionId);
   }, []);
 
-  // ── Image lookup (flat registry keyed by screen name) ──────
   const getScreenImages = useCallback((screenName: string) => {
     return imageRegistry[screenName];
   }, [imageRegistry]);
 
-  const handleProphecyPress = useCallback((chainId: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('ProphecyDetail' as any, { chainId } as any);
-  }, [navigation]);
-
-  const handleDebatePress = useCallback((debateId: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('DebateDetail' as any, { topicId: debateId } as any);
-  }, [navigation]);
-
-  const handleWordStudyPress = useCallback((id: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('WordStudyDetail' as any, { wordId: id } as any);
-  }, [navigation]);
-
-  const handleLifeCategoryPress = useCallback((categoryId: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('LifeTopics' as any, { categoryId } as any);
-  }, [navigation]);
-
   const showStartHere = chaptersRead !== null && chaptersRead < 5 && !startHereDismissed;
   const showRecommendations = !showStartHere && recommendations.length > 0;
-  const filteredSections = activeJump ? SECTIONS.filter((s) => s.id === activeJump) : SECTIONS;
-
-  // ── Per-section content renderer ────────────────────────────
-  const renderSectionContent = (section: FeatureSection) => {
-    switch (section.id) {
-      case 'journeys':
-        return <JourneyBrowseSection />;
-      case 'themes':
-        return (
-          <View style={styles.sectionGap}>
-            {prophecyChains.length > 0 && (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.carouselContent}
-                decelerationRate="fast"
-                snapToInterval={PROPHECY_CHAIN_CARD_WIDTH + spacing.sm}
-              >
-                {prophecyChains.slice(0, 4).map((chain) => (
-                  <ProphecyChainCard
-                    key={chain.id}
-                    chain={chain}
-                    onPress={() => handleProphecyPress(chain.id)}
-                  />
-                ))}
-              </ScrollView>
-            )}
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.carouselContent}
-              decelerationRate="fast"
-            >
-              {section.features.map((f, cardIndex) => {
-                const imgData = getScreenImages(f.screen);
-                return (
-                  <FeatureCard
-                    key={f.screen}
-                    feature={f}
-                    onPress={() => handleNavigate(f.screen)}
-                    isPremium={isPremium}
-                    images={imgData?.images}
-                    count={imgData?.count}
-                    noun={imgData?.noun}
-                    onImagePress={handleDeepLink}
-                    staggerMs={cardIndex * 1200}
-                    compact
-                  />
-                );
-              })}
-            </ScrollView>
-          </View>
-        );
-      case 'scholarly': {
-        // Debates renders as the preview strip above; everything else flows
-        // into the horizontal carousel below. Denylist (vs. allowlist) so
-        // future cards added to SECTIONS surface automatically — same
-        // pattern as the 'language' case for WordStudyBrowse.
-        const carouselFeatures = section.features.filter(
-          (f) => f.screen !== 'DebateBrowse',
-        );
-        const totalDebates = getScreenImages('DebateBrowse')?.count ?? undefined;
-        return (
-          <View style={styles.sectionGap}>
-            <DebatePreviewList
-              onDebatePress={handleDebatePress}
-              onSeeAll={() => handleNavigate('DebateBrowse')}
-              totalCount={totalDebates ?? undefined}
-            />
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.carouselContent}
-              decelerationRate="fast"
-            >
-              {carouselFeatures.map((f, cardIndex) => {
-                const imgData = getScreenImages(f.screen);
-                return (
-                  <FeatureCard
-                    key={f.screen}
-                    feature={f}
-                    onPress={() => handleNavigate(f.screen)}
-                    isPremium={isPremium}
-                    images={imgData?.images}
-                    count={imgData?.count}
-                    noun={imgData?.noun}
-                    onImagePress={handleDeepLink}
-                    staggerMs={cardIndex * 1200}
-                    compact
-                  />
-                );
-              })}
-            </ScrollView>
-          </View>
-        );
-      }
-      case 'language': {
-        const splitFeatures = section.features.filter(
-          (f) => f.screen !== 'WordStudyBrowse',
-        );
-        const totalWords = getScreenImages('WordStudyBrowse')?.count ?? undefined;
-        return (
-          <View style={styles.sectionGap}>
-            <WordStudyPreviewList
-              onWordPress={handleWordStudyPress}
-              onSeeAll={() => handleNavigate('WordStudyBrowse')}
-              totalCount={totalWords ?? undefined}
-            />
-            <View style={styles.row3}>
-              {splitFeatures.map((f, i) => {
-                const imgData = getScreenImages(f.screen);
-                return (
-                  <View key={f.screen} style={styles.rowCell}>
-                    <FeatureCard
-                      feature={f}
-                      onPress={() => handleNavigate(f.screen)}
-                      isPremium={isPremium}
-                      images={imgData?.images}
-                      count={imgData?.count}
-                      noun={imgData?.noun}
-                      onImagePress={handleDeepLink}
-                      staggerMs={i * 1200}
-                      compact
-                    />
-                  </View>
-                );
-              })}
-            </View>
-          </View>
-        );
-      }
-      case 'life': {
-        const lifeImage = getScreenImages('LifeTopics');
-        return (
-          <View style={styles.sectionGap}>
-            <FullWidthImageCard
-              title="Life Topics"
-              subtitle="Practical guidance from Scripture"
-              image={lifeImage?.images?.[0] ?? null}
-              count={lifeImage?.count ?? null}
-              noun={lifeImage?.noun}
-              onPress={() => handleNavigate('LifeTopics')}
-            />
-            <LifeTopicGrid onCategoryPress={handleLifeCategoryPress} />
-          </View>
-        );
-      }
-      case 'deep-dive':
-        return (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.carouselContent}
-            decelerationRate="fast"
-            snapToInterval={CARD_WIDTH + spacing.sm}
-          >
-            {section.features.map((f, cardIndex) => {
-              const imgData = getScreenImages(f.screen);
-              return (
-                <FeatureCard
-                  key={f.screen}
-                  feature={f}
-                  onPress={() => handleNavigate(f.screen)}
-                  isPremium={isPremium}
-                  images={imgData?.images}
-                  count={imgData?.count}
-                  noun={imgData?.noun}
-                  onImagePress={handleDeepLink}
-                  staggerMs={cardIndex * 1200}
-                />
-              );
-            })}
-          </ScrollView>
-        );
-      case 'biblical-world':
-      default:
-        return (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.carouselContent}
-            decelerationRate="fast"
-            snapToInterval={CARD_WIDTH + spacing.sm}
-          >
-            {section.features.map((f, cardIndex) => {
-              const imgData = getScreenImages(f.screen);
-              return (
-                <FeatureCard
-                  key={f.screen}
-                  feature={f}
-                  onPress={() => handleNavigate(f.screen)}
-                  isPremium={isPremium}
-                  images={imgData?.images}
-                  count={imgData?.count}
-                  noun={imgData?.noun}
-                  onImagePress={handleDeepLink}
-                  staggerMs={cardIndex * 1200}
-                />
-              );
-            })}
-          </ScrollView>
-        );
-    }
-  };
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
@@ -415,7 +107,7 @@ function ExploreMenuScreen() {
           contentContainerStyle={styles.pillScroll}
           style={styles.pillContainer}
         >
-          {SECTIONS.map((s) => (
+          {LIBRARY_SECTIONS.map((s) => (
             <TouchableOpacity
               key={s.id}
               onPress={() => handleJumpTo(s.id)}
@@ -471,18 +163,14 @@ function ExploreMenuScreen() {
           </View>
         )}
 
-        {/* ── Sections with varied layouts ─── */}
-        {filteredSections.map((section, sectionIndex) => (
-          <View key={section.id}>
-            <GlossySectionWrapper sectionIndex={sectionIndex}>
-              <View style={styles.section}>
-                <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
-                <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
-                {renderSectionContent(section)}
-              </View>
-            </GlossySectionWrapper>
-          </View>
-        ))}
+        {/* ── Library shelves (shared with the Study hub) ─── */}
+        <LibrarySections
+          imageRegistry={imageRegistry}
+          isPremium={isPremium}
+          onNavigate={handleNavigate}
+          onDeepLink={handleDeepLink}
+          filterSectionId={activeJump}
+        />
 
         {/* Show all link when filtered */}
         {activeJump && (
@@ -529,18 +217,8 @@ const styles = StyleSheet.create({
   recsLabel: { fontFamily: fontFamily.uiMedium, fontSize: 10, letterSpacing: 1, marginBottom: 2 },
   recsSubtitle: { fontFamily: fontFamily.ui, fontSize: 10, marginBottom: spacing.sm },
 
-  // Sections
-  section: { marginBottom: spacing.md },
-  sectionLabel: { fontFamily: fontFamily.displayMedium, fontSize: 13, letterSpacing: 0.5, marginBottom: 2 },
-  sectionSubtitle: { fontFamily: fontFamily.ui, fontSize: 11, marginBottom: spacing.sm },
-
   // Carousels
   carouselContent: { gap: spacing.sm },
-
-  // Split/grid rows
-  sectionGap: { gap: spacing.md },
-  row3: { flexDirection: 'row', gap: spacing.sm },
-  rowCell: { flex: 1 },
 
   // Show all
   showAllBtn: {

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -1,0 +1,177 @@
+/**
+ * StudyHubScreen — Root of the Study tab behind the `study_hub` flag
+ * (#1832, Epic #1830). One screen that answers "where was I?":
+ *   1. Continue hero — active plan, chapter trail, resume beat
+ *   2. Review card — one due prompt at a time (Recall it / Later)
+ *   3. Rhythm line — one italic sentence, deliberately not a streak
+ *   4. Library — the same shelves ExploreMenuScreen renders
+ *
+ * With no active plan the hero region renders nothing (the first-run
+ * empty state is #1837; the plan picker row is #1833).
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
+import { ContinueHero } from '../components/study/ContinueHero';
+import {
+  LibrarySections,
+  PREMIUM_SCREENS,
+} from '../components/study/LibrarySections';
+import { ReviewRecallCard } from '../components/study/ReviewRecallCard';
+import { RhythmLine } from '../components/study/RhythmLine';
+import { UpgradePrompt } from '../components/UpgradePrompt';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { useContinuePlan } from '../hooks/useContinuePlan';
+import { useExploreImages } from '../hooks/useExploreImages';
+import { usePremium } from '../hooks/usePremium';
+import { useReviewQueue } from '../hooks/useReviewQueue';
+import type { ScreenNavProp } from '../navigation/types';
+import { getWeeklyRhythm, type WeeklyRhythm } from '../services/study';
+import { fontFamily, spacing, useTheme } from '../theme';
+import { logger } from '../utils/logger';
+
+function StudyHubScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'StudyHub'>>();
+  const scrollRef = useRef<ScrollView>(null);
+  useScrollToTop(scrollRef);
+
+  const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
+  const imageRegistry = useExploreImages();
+  const { plan, items, target, estimateMin, reload: reloadPlan } = useContinuePlan();
+  const { dueItems, completeItem, reload: reloadReviews } = useReviewQueue();
+
+  const [rhythm, setRhythm] = useState<WeeklyRhythm[]>([]);
+  const [reviewIndex, setReviewIndex] = useState(0);
+
+  const reloadRhythm = useCallback(async () => {
+    try {
+      setRhythm(await getWeeklyRhythm());
+    } catch (err) {
+      logger.warn('StudyHub', 'Failed to load weekly rhythm', err);
+    }
+  }, []);
+
+  // Refresh hub state when the tab gains focus — including first mount
+  // (useFocusEffect fires on initial focus) and returning from a
+  // completed session — so the trail, reviews, and rhythm stay live.
+  useFocusEffect(
+    useCallback(() => {
+      void reloadPlan();
+      void reloadReviews();
+      void reloadRhythm();
+    }, [reloadPlan, reloadReviews, reloadRhythm]),
+  );
+
+  const handleResume = useCallback(() => {
+    if (!target) return;
+    navigation.navigate('StudySession', {
+      bookId: target.bookId,
+      chapterNum: target.chapterNum,
+      ...(target.step ? { initialStep: target.step } : {}),
+    });
+  }, [navigation, target]);
+
+  const currentReview =
+    dueItems.length > 0 ? dueItems[reviewIndex % dueItems.length] : null;
+
+  const handleRecall = useCallback(async () => {
+    if (!currentReview) return;
+    try {
+      await completeItem(currentReview.id);
+    } catch (err) {
+      logger.warn('StudyHub', 'Failed to complete review item', err);
+    }
+  }, [completeItem, currentReview]);
+
+  const handleLater = useCallback(() => {
+    setReviewIndex((i) => i + 1);
+  }, []);
+
+  const handleNavigate = useCallback(
+    (screen: string, params?: Record<string, string>) => {
+      const premiumLabel = PREMIUM_SCREENS[screen];
+      if (premiumLabel && !isPremium) {
+        showUpgrade('feature', premiumLabel);
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      navigation.navigate(screen as any, params as any);
+    },
+    [isPremium, showUpgrade, navigation],
+  );
+
+  const handleDeepLink = useCallback(
+    (deepLink: { screen: string; params?: Record<string, string> }) => {
+      handleNavigate(deepLink.screen, deepLink.params);
+    },
+    [handleNavigate],
+  );
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <ScrollView ref={scrollRef} contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: base.gold }]} accessibilityRole="header">
+          Study
+        </Text>
+
+        {/* ── Continue hero (hidden entirely when no active plan) ─── */}
+        {plan && target && (
+          <View style={styles.block}>
+            <ContinueHero
+              plan={plan}
+              items={items}
+              target={target}
+              estimateMin={estimateMin}
+              onResume={handleResume}
+            />
+          </View>
+        )}
+
+        {/* ── Review card — one due prompt at a time ─── */}
+        {currentReview && (
+          <View style={styles.block}>
+            <ReviewRecallCard
+              item={currentReview}
+              dueCount={dueItems.length}
+              onRecall={handleRecall}
+              onLater={handleLater}
+            />
+          </View>
+        )}
+
+        {/* ── Rhythm line ─── */}
+        <View style={styles.block}>
+          <RhythmLine rhythm={rhythm} />
+        </View>
+
+        {/* ── Library shelves (shared with ExploreMenuScreen) ─── */}
+        <LibrarySections
+          imageRegistry={imageRegistry}
+          isPremium={isPremium}
+          onNavigate={handleNavigate}
+          onDeepLink={handleDeepLink}
+        />
+      </ScrollView>
+
+      {upgradeRequest && (
+        <UpgradePrompt
+          visible
+          variant={upgradeRequest.variant}
+          featureName={upgradeRequest.featureName}
+          onClose={dismissUpgrade}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: spacing.md, paddingBottom: spacing.xxl },
+  title: { fontFamily: fontFamily.displaySemiBold, fontSize: 22, marginBottom: spacing.sm },
+  block: { marginBottom: spacing.md },
+});
+
+export default withErrorBoundary(StudyHubScreen);

--- a/app/src/services/study/index.ts
+++ b/app/src/services/study/index.ts
@@ -1,0 +1,29 @@
+/**
+ * services/study — Unified study-plan service layer (#1831).
+ *
+ * Data model lives in user.db (migration v25: `study_plans`,
+ * `study_plan_items`); CRUD lives in db/userQueries + db/userMutations.
+ * This barrel exposes the derived helpers: template builders,
+ * progression, weekly rhythm, and the one-time legacy seed.
+ */
+export {
+  buildBookPlanItems,
+  buildJourneyPlanItems,
+  buildTopicPlanItems,
+  parseChapterId,
+} from './planTemplates';
+export {
+  getActivePlan,
+  getNextItem,
+  percentComplete,
+  resumeTarget,
+  type ResumeTarget,
+} from './progression';
+export {
+  getWeeklyRhythm,
+  isoWeekKey,
+  isoWeekStart,
+  parseSqliteUtc,
+  type WeeklyRhythm,
+} from './rhythm';
+export { migrateLegacyPlans } from './migrateLegacyPlans';

--- a/app/src/services/study/migrateLegacyPlans.ts
+++ b/app/src/services/study/migrateLegacyPlans.ts
@@ -1,0 +1,114 @@
+/**
+ * services/study/migrateLegacyPlans.ts — One-time seed of legacy
+ * reading plans into the unified study-plan tables (#1831).
+ *
+ * Runs once at startup after migrations, guarded by the `app_meta`
+ * key `legacy_plans_migrated = '1'`. Every `reading_plans` row becomes
+ * a `study_plans` row (plan_type 'custom', source_id = legacy id,
+ * default_mode 'quick'); its `chapters_json` days become
+ * `study_plan_items` rows (kind 'reading', one per chapter); and
+ * `plan_progress.completed_at` is copied onto the matching items.
+ *
+ * The legacy tables are never dropped or altered — they stay readable
+ * until #1838 retires the write paths. Idempotency comes from three
+ * layers: the app_meta guard, deterministic plan ids
+ * (`legacy_<reading_plan id>`), and INSERT OR IGNORE on every row.
+ */
+import { getUserDb } from '../../db/userDatabase';
+import type { PlanProgress, ReadingPlan } from '../../db/userQueries';
+import { logger } from '../../utils/logger';
+import { parseChapterId } from './planTemplates';
+
+const GUARD_KEY = 'legacy_plans_migrated';
+
+interface LegacyPlanDay {
+  day: number;
+  chapters: string[];
+}
+
+function parseChaptersJson(chaptersJson: string, planId: string): LegacyPlanDay[] {
+  try {
+    const parsed: unknown = JSON.parse(chaptersJson);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (d): d is LegacyPlanDay =>
+        typeof d === 'object' &&
+        d !== null &&
+        typeof (d as LegacyPlanDay).day === 'number' &&
+        Array.isArray((d as LegacyPlanDay).chapters),
+    );
+  } catch (err) {
+    logger.warn('studyPlans', `migrateLegacyPlans: bad chapters_json on "${planId}"`, err);
+    return [];
+  }
+}
+
+/**
+ * Seed `study_plans` / `study_plan_items` from the legacy reading-plan
+ * tables. Safe to call on every launch — after the first successful
+ * run the app_meta guard makes it a no-op. Runs in one transaction, so
+ * a mid-flight failure leaves the guard unset and the seed retries on
+ * the next launch (deterministic ids + INSERT OR IGNORE make the retry
+ * safe).
+ */
+export async function migrateLegacyPlans(): Promise<void> {
+  const db = getUserDb();
+
+  const guard = await db.getFirstAsync<{ value: string }>(
+    'SELECT value FROM app_meta WHERE key = ?',
+    [GUARD_KEY],
+  );
+  if (guard?.value === '1') return;
+
+  const legacyPlans = await db.getAllAsync<ReadingPlan>('SELECT * FROM reading_plans');
+
+  await db.withTransactionAsync(async () => {
+    for (const legacy of legacyPlans) {
+      const planId = `legacy_${legacy.id}`;
+      await db.runAsync(
+        `INSERT OR IGNORE INTO study_plans
+           (id, plan_type, source_id, title, default_mode, created_at)
+         VALUES (?, 'custom', ?, ?, 'quick', datetime('now'))`,
+        [planId, legacy.id, legacy.name],
+      );
+
+      const progress = await db.getAllAsync<PlanProgress>(
+        'SELECT * FROM plan_progress WHERE plan_id = ?',
+        [legacy.id],
+      );
+      const completedByDay = new Map<number, string>();
+      for (const p of progress) {
+        if (p.completed_at) completedByDay.set(p.day_num, p.completed_at);
+      }
+
+      let itemNum = 0;
+      for (const day of parseChaptersJson(legacy.chapters_json, legacy.id)) {
+        for (const chapterId of day.chapters) {
+          itemNum++;
+          const ref = parseChapterId(chapterId);
+          if (!ref) {
+            logger.warn(
+              'studyPlans',
+              `migrateLegacyPlans: unparseable chapter "${chapterId}" in "${legacy.id}"`,
+            );
+            continue;
+          }
+          await db.runAsync(
+            `INSERT OR IGNORE INTO study_plan_items
+               (plan_id, item_num, kind, ref_json, completed_at)
+             VALUES (?, ?, 'reading', ?, ?)`,
+            [planId, itemNum, JSON.stringify(ref), completedByDay.get(day.day) ?? null],
+          );
+        }
+      }
+    }
+
+    await db.runAsync(
+      `INSERT OR REPLACE INTO app_meta (key, value, updated_at)
+       VALUES (?, '1', datetime('now'))`,
+      [GUARD_KEY],
+    );
+  });
+
+  logger.info('studyPlans', `migrateLegacyPlans: seeded ${legacyPlans.length} legacy plan(s)`);
+}

--- a/app/src/services/study/planTemplates.ts
+++ b/app/src/services/study/planTemplates.ts
@@ -1,0 +1,102 @@
+/**
+ * services/study/planTemplates.ts — Item builders for unified study
+ * plans (#1831).
+ *
+ * Each builder derives its items from content-DB queries only — there
+ * are no hardcoded book/chapter lists here. Builders return
+ * `StudyPlanItemDraft[]`; `createStudyPlan` (db/userMutations) assigns
+ * `item_num` on insert.
+ */
+import { getBook } from '../../db/content';
+import { getJourneyStops } from '../../db/content/features';
+import { getTopic } from '../../db/content/reference';
+import type { StudyPlanItemDraft } from '../../types';
+import { logger } from '../../utils/logger';
+
+/**
+ * Parse a content chapter id ("genesis_1", "1_samuel_16") into its
+ * book id and chapter number. Returns null on unrecognized input.
+ */
+export function parseChapterId(
+  chapterId: string,
+): { bookId: string; chapterNum: number } | null {
+  const m = chapterId.match(/^(.+)_(\d+)$/);
+  if (!m) return null;
+  return { bookId: m[1], chapterNum: parseInt(m[2], 10) };
+}
+
+/**
+ * One guided session per chapter of the book, in canonical order.
+ * Returns [] when the book id is unknown.
+ */
+export async function buildBookPlanItems(bookId: string): Promise<StudyPlanItemDraft[]> {
+  const book = await getBook(bookId);
+  if (!book) {
+    logger.warn('studyPlans', `buildBookPlanItems: unknown book "${bookId}"`);
+    return [];
+  }
+  const items: StudyPlanItemDraft[] = [];
+  for (let ch = 1; ch <= book.total_chapters; ch++) {
+    items.push({ kind: 'session', ref: { bookId, chapterNum: ch } });
+  }
+  return items;
+}
+
+/**
+ * One guided session per scripture-anchored journey stop, in stop
+ * order. Stops without a book/chapter anchor (narrative interludes)
+ * are skipped — a session needs a chapter to open on.
+ */
+export async function buildJourneyPlanItems(journeyId: string): Promise<StudyPlanItemDraft[]> {
+  const stops = await getJourneyStops(journeyId);
+  const items: StudyPlanItemDraft[] = [];
+  for (const stop of stops) {
+    if (!stop.book_id || stop.chapter_num == null) continue;
+    items.push({
+      kind: 'session',
+      ref: {
+        bookId: stop.book_id,
+        chapterNum: stop.chapter_num,
+        ...(stop.verse_start != null ? { verseStart: stop.verse_start } : {}),
+        stopId: stop.id,
+      },
+    });
+  }
+  return items;
+}
+
+/**
+ * One guided session per chapter in the topic's
+ * `relevant_chapters_json`, preserving the curated order and skipping
+ * duplicates/unparseable ids. Returns [] when the topic is unknown or
+ * has no relevant chapters.
+ */
+export async function buildTopicPlanItems(topicId: string): Promise<StudyPlanItemDraft[]> {
+  const topic = await getTopic(topicId);
+  if (!topic) {
+    logger.warn('studyPlans', `buildTopicPlanItems: unknown topic "${topicId}"`);
+    return [];
+  }
+
+  let chapterIds: string[] = [];
+  try {
+    const parsed: unknown = JSON.parse(topic.relevant_chapters_json ?? '[]');
+    if (Array.isArray(parsed)) {
+      chapterIds = parsed.filter((c): c is string => typeof c === 'string');
+    }
+  } catch (err) {
+    logger.warn('studyPlans', `buildTopicPlanItems: bad relevant_chapters_json on "${topicId}"`, err);
+    return [];
+  }
+
+  const items: StudyPlanItemDraft[] = [];
+  const seen = new Set<string>();
+  for (const chapterId of chapterIds) {
+    if (seen.has(chapterId)) continue;
+    seen.add(chapterId);
+    const ref = parseChapterId(chapterId);
+    if (!ref) continue;
+    items.push({ kind: 'session', ref });
+  }
+  return items;
+}

--- a/app/src/services/study/progression.ts
+++ b/app/src/services/study/progression.ts
@@ -1,0 +1,98 @@
+/**
+ * services/study/progression.ts — Where-am-I helpers over unified
+ * study plans (#1831).
+ *
+ * All state lives in `study_plans` / `study_plan_items` (user.db,
+ * migration v25); these helpers only read via db/userQueries.
+ */
+import {
+  getGuidedStudySession,
+  getStudyPlanItems,
+  getStudyPlans,
+} from '../../db/userQueries';
+import type { GuidedStudyStep, StudyPlan, StudyPlanItem, StudyPlanItemRef } from '../../types';
+import { logger } from '../../utils/logger';
+
+export interface ResumeTarget {
+  bookId: string;
+  chapterNum: number;
+  /** Present when the next item already has an in-flight guided session. */
+  step?: GuidedStudyStep;
+}
+
+function parseItemRef(item: StudyPlanItem): StudyPlanItemRef | null {
+  try {
+    const ref: unknown = JSON.parse(item.ref_json);
+    if (
+      typeof ref === 'object' &&
+      ref !== null &&
+      typeof (ref as StudyPlanItemRef).bookId === 'string' &&
+      typeof (ref as StudyPlanItemRef).chapterNum === 'number'
+    ) {
+      return ref as StudyPlanItemRef;
+    }
+  } catch (err) {
+    logger.warn(
+      'studyPlans',
+      `parseItemRef: bad ref_json on plan ${item.plan_id} item ${item.item_num}`,
+      err,
+    );
+  }
+  return null;
+}
+
+/**
+ * The plan the Study hub should surface: the newest non-archived plan
+ * that still has an incomplete item. Fully-completed plans are never
+ * "active"; returns null when there is nothing to continue.
+ */
+export async function getActivePlan(): Promise<StudyPlan | null> {
+  const plans = await getStudyPlans();
+  for (const plan of plans) {
+    const items = await getStudyPlanItems(plan.id);
+    if (items.some((item) => item.completed_at == null)) return plan;
+  }
+  return null;
+}
+
+/** First incomplete item of the plan (by item_num), or null when done/empty. */
+export async function getNextItem(planId: string): Promise<StudyPlanItem | null> {
+  const items = await getStudyPlanItems(planId);
+  return items.find((item) => item.completed_at == null) ?? null;
+}
+
+/** Whole-number completion percentage (0–100). Empty plans read as 0. */
+export async function percentComplete(planId: string): Promise<number> {
+  const items = await getStudyPlanItems(planId);
+  if (items.length === 0) return 0;
+  const done = items.filter((item) => item.completed_at != null).length;
+  return Math.round((done / items.length) * 100);
+}
+
+/**
+ * Where "Continue" should land: the next item's chapter, plus the
+ * current step when that item already has an active guided session.
+ * Returns null when the plan is complete, empty, or the next item's
+ * ref is unparseable.
+ */
+export async function resumeTarget(planId: string): Promise<ResumeTarget | null> {
+  const next = await getNextItem(planId);
+  if (!next) return null;
+
+  const ref = parseItemRef(next);
+  if (!ref) return null;
+
+  const target: ResumeTarget = { bookId: ref.bookId, chapterNum: ref.chapterNum };
+
+  if (next.session_id != null) {
+    const sessionId = Number(next.session_id);
+    if (Number.isFinite(sessionId)) {
+      const session = await getGuidedStudySession(sessionId);
+      if (session && session.status === 'active') {
+        target.step = session.current_step;
+      }
+    }
+  }
+
+  return target;
+}

--- a/app/src/services/study/rhythm.ts
+++ b/app/src/services/study/rhythm.ts
@@ -1,0 +1,99 @@
+/**
+ * services/study/rhythm.ts — Weekly study rhythm (#1831).
+ *
+ * Derived entirely from `guided_study_sessions` (completed sessions)
+ * and `guided_review_items` (completed reviews) — no new table, no
+ * streak math. "Rhythm" is a per-ISO-week count the hub can render as
+ * a gentle cadence strip, not a gamified streak.
+ */
+import { getUserDb } from '../../db/userDatabase';
+
+export interface WeeklyRhythm {
+  /** ISO week key, e.g. "2026-W27". */
+  week: string;
+  /** Monday of the week, as YYYY-MM-DD (UTC). */
+  weekStart: string;
+  sessions: number;
+  reviews: number;
+}
+
+/**
+ * Parse a SQLite `datetime('now')` timestamp ("YYYY-MM-DD HH:MM:SS",
+ * stored UTC) into a Date. Also tolerates ISO-8601 strings.
+ */
+export function parseSqliteUtc(value: string): Date | null {
+  const normalized = value.includes('T') ? value : `${value.replace(' ', 'T')}Z`;
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Monday 00:00 UTC of the ISO week containing `date`. */
+export function isoWeekStart(date: Date): Date {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = d.getUTCDay() || 7; // Mon=1 … Sun=7
+  d.setUTCDate(d.getUTCDate() - (day - 1));
+  return d;
+}
+
+/** ISO 8601 week key ("2026-W27") — the week belongs to the year of its Thursday. */
+export function isoWeekKey(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day); // shift to Thursday
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+/**
+ * Completed guided sessions and completed review items per ISO week,
+ * for the trailing `weeks` weeks (default 8, oldest first, zero-filled
+ * so the hub always renders a full strip).
+ */
+export async function getWeeklyRhythm(weeks = 8, now: Date = new Date()): Promise<WeeklyRhythm[]> {
+  const db = getUserDb();
+
+  // Zero-filled buckets for the trailing window, oldest → newest.
+  const buckets = new Map<string, WeeklyRhythm>();
+  const currentWeekStart = isoWeekStart(now);
+  for (let i = weeks - 1; i >= 0; i--) {
+    const start = new Date(currentWeekStart);
+    start.setUTCDate(start.getUTCDate() - i * 7);
+    buckets.set(isoWeekKey(start), {
+      week: isoWeekKey(start),
+      weekStart: start.toISOString().slice(0, 10),
+      sessions: 0,
+      reviews: 0,
+    });
+  }
+
+  // +7 days of slack so week boundaries never clip the oldest bucket.
+  const sinceModifier = `-${weeks * 7 + 7} days`;
+
+  const sessionRows = await db.getAllAsync<{ completed_at: string }>(
+    `SELECT completed_at FROM guided_study_sessions
+     WHERE status = 'completed' AND completed_at IS NOT NULL
+       AND completed_at >= datetime('now', ?)`,
+    [sinceModifier],
+  );
+  const reviewRows = await db.getAllAsync<{ updated_at: string }>(
+    `SELECT updated_at FROM guided_review_items
+     WHERE status = 'completed' AND updated_at >= datetime('now', ?)`,
+    [sinceModifier],
+  );
+
+  for (const row of sessionRows) {
+    const date = parseSqliteUtc(row.completed_at);
+    if (!date) continue;
+    const bucket = buckets.get(isoWeekKey(date));
+    if (bucket) bucket.sessions++;
+  }
+  for (const row of reviewRows) {
+    const date = parseSqliteUtc(row.updated_at);
+    if (!date) continue;
+    const bucket = buckets.get(isoWeekKey(date));
+    if (bucket) bucket.reviews++;
+  }
+
+  return Array.from(buckets.values());
+}

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -67,6 +67,56 @@ export interface GuidedStudySession {
   mode_artifact_json?: string | null;
   /** Phase 2.2 (#1731). NULL for pre-migration rows. */
   synthesis_strategy?: string | null;
+  /** Unified study plans (#1831, migration v25). NULL for sessions started outside a plan. */
+  plan_id?: string | null;
+}
+
+// ── Unified study plans (#1831, migration v25) ────────────────────
+
+export const STUDY_PLAN_TYPES = ['book', 'journey', 'topical', 'custom'] as const;
+
+export type StudyPlanType = (typeof STUDY_PLAN_TYPES)[number];
+
+export const STUDY_PLAN_ITEM_KINDS = ['session', 'reading'] as const;
+
+export type StudyPlanItemKind = (typeof STUDY_PLAN_ITEM_KINDS)[number];
+
+export interface StudyPlan {
+  id: string;
+  plan_type: StudyPlanType;
+  /** book_id | journey_id | topic_id | legacy reading_plan id (for plan_type 'custom'). */
+  source_id: string;
+  title: string;
+  /** GuidedStudyMode key ('quick' | 'deep' | 'teaching' | 'devotional'). */
+  default_mode: string;
+  created_at: string;
+  archived_at: string | null;
+}
+
+/** Parsed shape of `study_plan_items.ref_json`. */
+export interface StudyPlanItemRef {
+  bookId: string;
+  chapterNum: number;
+  verseStart?: number;
+  stopId?: number;
+}
+
+export interface StudyPlanItem {
+  plan_id: string;
+  item_num: number;
+  kind: StudyPlanItemKind;
+  ref_json: string;
+  session_id: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Unsaved plan item as produced by the `services/study/planTemplates`
+ * builders — `item_num` is assigned by `createStudyPlan` on insert.
+ */
+export interface StudyPlanItemDraft {
+  kind: StudyPlanItemKind;
+  ref: StudyPlanItemRef;
 }
 
 export interface GuidedStudyResponse {


### PR DESCRIPTION
Depends on #1844 — merge in order.

Second PR in the Epic #1830 stack (branched from `feature/1831-study-service`). Closes #1832.

## Rationale
The Explore tab becomes **Study**, with the new hub screen entirely behind the `study_hub` compile-time flag (shipped **off**; #1838 flips it only after on-device verification). Route and stack names are unchanged — only the tab label/icon change ships visibly.

- **Flag** `study_hub: false` in `config/featureFlags.ts`, with a verify-before-flipping comment.
- **Tab**: label `Explore`→`Study`, icon `Compass`→`GraduationCap` (lucide). Tab-press targets `StudyHub` vs `ExploreMenu` by flag; `ExploreTab`/`ExploreMenu` route names stay stable so every existing deep link resolves.
- **LibrarySections extraction**: the seven section shelves (data + rendering) move from `ExploreMenuScreen` into `components/study/LibrarySections.tsx` — horizontal `FlatList` shelves, cards via the existing `FeatureCard` (art from the explore image registry, tonal-wash fallback), per-tool data colors kept as data, everything else on `useTheme()` tokens. `ExploreMenuScreen` consumes the component; its pre-existing test file passes **unchanged**, which is the flag-off parity evidence in CI.
- **StudyHubScreen** (root of ExploreStack only when the flag is on):
  - *Continue hero* — active plan from `progression.getActivePlan()`, Cinzel title (no `numberOfLines`, so Dynamic Type never truncates), chapter-trail ticks (done = filled gold, current = hollow with a soft glow, upcoming = hollow dim), paused step + `~min` from `services/guidedStudy/estimate.ts` (deep plans read `deepMin`, others `guidedMin`), Resume → `StudySession` with `initialStep`. Renders nothing when there's no plan (empty state is #1837).
  - *Review card* — one due item at a time from `useReviewQueue`; prompt in EB Garamond 17; `Recall it` completes (same semantics as MyStudy's check action), `Later` cycles with wrap-around.
  - *Rhythm line* — one italic Garamond sentence from `getWeeklyRhythm()`; number words, no digits, no streak counters, no emojis.
  - *Library* — the same `<LibrarySections />` shelves (per the epic's "library shelves"; flagged the garbled spec bullet on the issue).
- **A11y**: Resume/Recall/Later are ≥44pt with explicit VoiceOver labels; the tick trail is hidden from screen readers as decorative; the glow renders statically under OS reduce-motion (new `useReducedMotion` hook).

## Rollback plan
Revert the merge commit. The flag ships off, so user-visible surface is only the tab label/icon; reverting restores `Explore`/`Compass`. No DB, route, or service changes — the hub screen and components are additive files.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **525 suites / 3991 tests passing**, thresholds met — including the untouched `ExploreMenuScreen.test.tsx` (parity) and 18 new tests (hub hero/resume/review-cycling/empty, LibrarySections labels + onNavigate + filter, ContinueHero a11y + reduced motion, rhythm sentence builder)
- `npx expo export --platform ios` bundles cleanly (runtime import-graph smoke)
- **On-device parity check**: this cloud environment has no dev client/simulator, so I could not run the app interactively. Parity evidence is the unchanged ExploreMenu test suite + the extraction being a move-not-rewrite (same component tree; carousels ScrollView→FlatList is the only render-level change, called for by the card). Please eyeball the flag-off Explore tab on-device before merging — the acceptance criterion is yours to confirm.

## Process notes
- Kanban: Projects v2 GraphQL is blocked by this environment's proxy, so the board wasn't moved — please drag #1832 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_