### PR TITLE
feat(study): one-decision plan picker + StudyPlanDetailScreen + journey adoption — #1833

### DIFF
--- a/app/__tests__/components/study/ContinueHero.test.tsx
+++ b/app/__tests__/components/study/ContinueHero.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * #1832 — Continue hero (components/study/ContinueHero).
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { StudyPlan, StudyPlanItem } from '@/types';
+
+const mockUseReducedMotion = jest.fn().mockReturnValue(false);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+import { ContinueHero } from '@/components/study/ContinueHero';
+
+const PLAN: StudyPlan = {
+  id: 'plan-1',
+  plan_type: 'book',
+  source_id: 'jonah',
+  title: 'Jonah',
+  default_mode: 'quick',
+  created_at: '2026-06-01 00:00:00',
+  archived_at: null,
+};
+
+function item(num: number, completed: boolean): StudyPlanItem {
+  return {
+    plan_id: 'plan-1',
+    item_num: num,
+    kind: 'session',
+    ref_json: JSON.stringify({ bookId: 'jonah', chapterNum: num }),
+    session_id: null,
+    completed_at: completed ? '2026-06-02 08:00:00' : null,
+  };
+}
+
+const ITEMS = [item(1, true), item(2, false), item(3, false)];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseReducedMotion.mockReturnValue(false);
+});
+
+describe('ContinueHero (#1832)', () => {
+  it('renders the plan title, chapter ref, paused step, and minutes', () => {
+    const { getByText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2, step: 'explore' }}
+        estimateMin={12}
+        onResume={jest.fn()}
+      />,
+    );
+    expect(getByText('Jonah')).toBeTruthy();
+    expect(getByText('Jonah 2 · Paused at Explore · ~12 min')).toBeTruthy();
+  });
+
+  it('omits step and minutes gracefully when absent', () => {
+    const { getByText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2 }}
+        estimateMin={null}
+        onResume={jest.fn()}
+      />,
+    );
+    expect(getByText('Jonah 2')).toBeTruthy();
+  });
+
+  it('fires onResume from an accessible 44pt button', () => {
+    const onResume = jest.fn();
+    const { getByLabelText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2, step: 'explore' }}
+        estimateMin={12}
+        onResume={onResume}
+      />,
+    );
+    const button = getByLabelText('Resume Jonah at Jonah 2');
+    fireEvent.press(button);
+    expect(onResume).toHaveBeenCalledTimes(1);
+    const flat = Array.isArray(button.props.style) ? Object.assign({}, ...button.props.style.flat()) : button.props.style;
+    expect(flat.minHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  it('renders statically under reduced motion (still one tick per item)', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const { getByText } = render(
+      <ContinueHero
+        plan={PLAN}
+        items={ITEMS}
+        target={{ bookId: 'jonah', chapterNum: 2 }}
+        estimateMin={null}
+        onResume={jest.fn()}
+      />,
+    );
+    // Smoke: renders without starting the glow loop.
+    expect(getByText('Jonah')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/study/LibrarySections.test.tsx
+++ b/app/__tests__/components/study/LibrarySections.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * #1832 — LibrarySections extraction. The shelves must render the same
+ * section data ExploreMenuScreen used to own, route presses through
+ * onNavigate, and honor the jump-pill filter.
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/db/content', () => ({
+  getAllProphecyChains: jest.fn().mockResolvedValue([]),
+  getDebateTopics: jest.fn().mockResolvedValue([]),
+  getAllWordStudies: jest.fn().mockResolvedValue([]),
+  getLifeTopicCategories: jest.fn().mockResolvedValue([]),
+  getPeopleWithJourneys: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/hooks/useJourneyBrowse', () => ({
+  useJourneyBrowse: jest.fn().mockReturnValue({
+    allJourneys: [],
+    personJourneys: [],
+    conceptJourneys: [],
+    thematicJourneys: [],
+    lensIds: [],
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/hooks/useProphecyChains', () => ({
+  useProphecyChains: jest.fn().mockReturnValue({ chains: [], isLoading: false }),
+}));
+
+import {
+  LibrarySections,
+  LIBRARY_SECTIONS,
+  PREMIUM_SCREENS,
+} from '@/components/study/LibrarySections';
+
+function renderSections(overrides: Partial<React.ComponentProps<typeof LibrarySections>> = {}) {
+  const onNavigate = jest.fn();
+  const utils = render(
+    <LibrarySections
+      imageRegistry={{}}
+      isPremium
+      onNavigate={onNavigate}
+      onDeepLink={jest.fn()}
+      {...overrides}
+    />,
+  );
+  return { onNavigate, ...utils };
+}
+
+describe('LibrarySections (#1832)', () => {
+  it('exports the seven library sections with stable ids', () => {
+    expect(LIBRARY_SECTIONS.map((s) => s.id)).toEqual([
+      'biblical-world', 'themes', 'journeys', 'language', 'scholarly', 'life', 'deep-dive',
+    ]);
+    expect(PREMIUM_SCREENS.Concordance).toBe('Concordance Search');
+  });
+
+  it('renders every section label and its cards', async () => {
+    const { getByText } = renderSections();
+    await waitFor(() => {
+      expect(getByText('The Biblical World')).toBeTruthy();
+      expect(getByText('Themes & Connections')).toBeTruthy();
+      expect(getByText('Language & Reference')).toBeTruthy();
+      expect(getByText('Scholarly Analysis')).toBeTruthy();
+      expect(getByText('Life & Faith')).toBeTruthy();
+      expect(getByText('Deep Dive')).toBeTruthy();
+      expect(getByText('People')).toBeTruthy();
+      expect(getByText('Timeline')).toBeTruthy();
+      expect(getByText('Scholars')).toBeTruthy();
+      expect(getByText('Grammar')).toBeTruthy();
+    });
+  });
+
+  it('routes card presses through onNavigate', async () => {
+    const { getByText, onNavigate } = renderSections();
+    await waitFor(() => expect(getByText('Map')).toBeTruthy());
+    fireEvent.press(getByText('Map'));
+    expect(onNavigate).toHaveBeenCalledWith('Map');
+  });
+
+  it('renders only the filtered section when filterSectionId is set', async () => {
+    const { getByText, queryByText } = renderSections({ filterSectionId: 'deep-dive' });
+    await waitFor(() => expect(getByText('Deep Dive')).toBeTruthy());
+    expect(queryByText('The Biblical World')).toBeNull();
+    expect(queryByText('Scholarly Analysis')).toBeNull();
+  });
+});

--- a/app/__tests__/components/study/RhythmLine.test.tsx
+++ b/app/__tests__/components/study/RhythmLine.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * #1832 — rhythm sentence (components/study/RhythmLine).
+ * No streaks, no emojis — one italic sentence derived from weekly data.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { buildRhythmSentence, RhythmLine } from '@/components/study/RhythmLine';
+import type { WeeklyRhythm } from '@/services/study';
+
+function week(weekKey: string, sessions: number, reviews: number): WeeklyRhythm {
+  return { week: weekKey, weekStart: '2026-06-29', sessions, reviews };
+}
+
+describe('buildRhythmSentence', () => {
+  it('summarizes sessions and reviews with number words', () => {
+    expect(buildRhythmSentence([week('2026-W27', 2, 1)])).toBe(
+      'Two sessions and one review this week — a steady rhythm of study.',
+    );
+    expect(buildRhythmSentence([week('2026-W27', 1, 0)])).toBe(
+      'One session this week — a steady rhythm of study.',
+    );
+    expect(buildRhythmSentence([week('2026-W27', 0, 3)])).toBe(
+      'Three reviews this week — a steady rhythm of study.',
+    );
+  });
+
+  it('offers a gentle line for a quiet week (no counters, no emojis)', () => {
+    const active = buildRhythmSentence([week('2026-W26', 2, 0), week('2026-W27', 0, 0)]);
+    expect(active).toBe('A quiet week so far — the text will keep until you return.');
+
+    const idle = buildRhythmSentence([week('2026-W26', 0, 0), week('2026-W27', 0, 0)]);
+    expect(idle).toBe('A quiet stretch — one unhurried session would begin a rhythm.');
+
+    expect(buildRhythmSentence([])).toBe(
+      'A quiet stretch — one unhurried session would begin a rhythm.',
+    );
+  });
+
+  it('never emits digits for small counts or emoji', () => {
+    const sentence = buildRhythmSentence([week('2026-W27', 4, 2)]);
+    expect(sentence).not.toMatch(/\d/);
+    expect(sentence).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
+  });
+});
+
+describe('RhythmLine', () => {
+  it('renders the sentence', () => {
+    const { getByText } = render(<RhythmLine rhythm={[week('2026-W27', 1, 1)]} />);
+    expect(getByText('One session and one review this week — a steady rhythm of study.')).toBeTruthy();
+  });
+});

--- a/app/__tests__/screens/PlanPickerScreen.test.tsx
+++ b/app/__tests__/screens/PlanPickerScreen.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * #1833 — one-decision plan picker. Book segment ordering, the two-tap
+ * acceptance path (segment card → book → session), zero mode prompt,
+ * and topic filtering.
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockNavigate = jest.fn();
+const mockReplace = jest.fn();
+const mockGoBack = jest.fn();
+let mockRouteParams: object | undefined = undefined;
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: mockNavigate, replace: mockReplace, goBack: mockGoBack }),
+    useRoute: () => ({ params: mockRouteParams }),
+    useScrollToTop: jest.fn(),
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+jest.mock('@/hooks', () => ({
+  useBooks: jest.fn().mockReturnValue({
+    liveBooks: [
+      { id: 'genesis', name: 'Genesis', testament: 'ot', total_chapters: 50, book_order: 1, is_live: true, starter: 1 },
+      { id: 'psalms', name: 'Psalms', testament: 'ot', total_chapters: 150, book_order: 19, is_live: true, starter: 1 },
+      { id: 'romans', name: 'Romans', testament: 'nt', total_chapters: 16, book_order: 45, is_live: true, starter: 1 },
+      { id: 'jude', name: 'Jude', testament: 'nt', total_chapters: 1, book_order: 65, is_live: true },
+    ],
+  }),
+}));
+
+const mockGetRecentChapters = jest.fn();
+jest.mock('@/db/userQueries', () => ({
+  getRecentChapters: (...args: unknown[]) => mockGetRecentChapters(...args),
+}));
+
+jest.mock('@/db/content', () => ({
+  getTopics: jest.fn().mockResolvedValue([
+    {
+      id: 'covenant',
+      title: 'Covenant',
+      category: 'theology',
+      relevant_chapters_json: JSON.stringify(['genesis_15', 'exodus_19']),
+    },
+    {
+      id: 'empty-topic',
+      title: 'Empty Topic',
+      category: 'theology',
+      relevant_chapters_json: '[]',
+    },
+  ]),
+}));
+
+jest.mock('@/db/content/features', () => ({
+  getAllJourneys: jest.fn().mockResolvedValue([
+    { id: 'covenant-journey', title: 'The Covenant', subtitle: 'From Noah to the New Covenant' },
+  ]),
+}));
+
+const mockStartStudyPlan = jest.fn();
+jest.mock('@/services/study', () => ({
+  startStudyPlan: (...args: unknown[]) => mockStartStudyPlan(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import PlanPickerScreen from '@/screens/PlanPickerScreen';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRouteParams = undefined;
+  mockGetRecentChapters.mockResolvedValue([
+    { book_id: 'john', chapter_num: 3, completed_at: 'x', title: null, book_name: 'John' },
+  ]);
+  mockStartStudyPlan.mockResolvedValue({
+    planId: 'plan-1',
+    mode: 'deep',
+    firstRef: { bookId: 'romans', chapterNum: 1 },
+  });
+});
+
+describe('PlanPickerScreen (#1833)', () => {
+  it('renders the book segment: continue row, starter shelf, testament groups — and no mode prompt', async () => {
+    const { getByText, queryByText } = render(<PlanPickerScreen />);
+    await waitFor(() => {
+      expect(getByText("Continue where you're reading")).toBeTruthy();
+      expect(getByText('John 3')).toBeTruthy();
+      expect(getByText('GOOD PLACES TO BEGIN')).toBeTruthy();
+      expect(getByText('OLD TESTAMENT')).toBeTruthy();
+      expect(getByText('NEW TESTAMENT')).toBeTruthy();
+      expect(getByText('Jude')).toBeTruthy();
+    });
+    // Mode is NOT asked — no mode selector labels anywhere.
+    expect(queryByText('Quick pass')).toBeNull();
+    expect(queryByText('Deep study')).toBeNull();
+    expect(queryByText('Teaching prep')).toBeNull();
+    expect(queryByText('Devotional')).toBeNull();
+  });
+
+  it('tapping Romans creates the plan and replaces to StudySession item 1 (one decision)', async () => {
+    // Romans appears on the starter shelf AND in the NT group — press the shelf card.
+    const { getAllByLabelText } = render(<PlanPickerScreen />);
+    await waitFor(() => expect(getAllByLabelText('Study Romans').length).toBeGreaterThan(0));
+
+    fireEvent.press(getAllByLabelText('Study Romans')[0]);
+
+    await waitFor(() => {
+      expect(mockStartStudyPlan).toHaveBeenCalledWith({
+        planType: 'book',
+        sourceId: 'romans',
+        title: 'Romans',
+      });
+      expect(mockReplace).toHaveBeenCalledWith('StudySession', {
+        bookId: 'romans',
+        chapterNum: 1,
+        planId: 'plan-1',
+      });
+    });
+  });
+
+  it('the continue row opens the session at the reading chapter, not item 1', async () => {
+    mockStartStudyPlan.mockResolvedValue({
+      planId: 'plan-john',
+      mode: 'deep',
+      firstRef: { bookId: 'john', chapterNum: 1 },
+    });
+    const { getByLabelText } = render(<PlanPickerScreen />);
+    await waitFor(() =>
+      expect(getByLabelText("Study Continue where you're reading")).toBeTruthy(),
+    );
+
+    fireEvent.press(getByLabelText("Study Continue where you're reading"));
+
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith('StudySession', {
+        bookId: 'john',
+        chapterNum: 3,
+        planId: 'plan-john',
+      }),
+    );
+  });
+
+  it('journey segment lists journeys and starts a journey plan', async () => {
+    mockRouteParams = { segment: 'journey' };
+    const { getByLabelText } = render(<PlanPickerScreen />);
+    await waitFor(() => expect(getByLabelText('Study The Covenant')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Study The Covenant'));
+    await waitFor(() =>
+      expect(mockStartStudyPlan).toHaveBeenCalledWith({
+        planType: 'journey',
+        sourceId: 'covenant-journey',
+        title: 'The Covenant',
+      }),
+    );
+  });
+
+  it('topic segment hides topics with no relevant chapters', async () => {
+    mockRouteParams = { segment: 'topic' };
+    const { getByText, queryByText } = render(<PlanPickerScreen />);
+    await waitFor(() => expect(getByText('Covenant')).toBeTruthy());
+    expect(queryByText('Empty Topic')).toBeNull();
+  });
+
+  it('shows a gentle notice when a source resolves to zero items', async () => {
+    mockStartStudyPlan.mockResolvedValue(null);
+    const { getAllByLabelText, getByText } = render(<PlanPickerScreen />);
+    await waitFor(() => expect(getAllByLabelText('Study Romans').length).toBeGreaterThan(0));
+
+    fireEvent.press(getAllByLabelText('Study Romans')[0]);
+    await waitFor(() =>
+      expect(getByText('Nothing to study there yet — try another pick.')).toBeTruthy(),
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * #1832 — StudyHubScreen: hero (with plan / hidden without), review
+ * cycling, rhythm line, and library shelves on the flag-on root.
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import type { GuidedReviewItem, StudyPlan, StudyPlanItem } from '@/types';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn(), push: jest.fn() }),
+    useRoute: () => ({ params: {} }),
+    useScrollToTop: jest.fn(),
+    useFocusEffect: (cb: () => void) => cb(), // same behavior as the global jest.setup mock
+  };
+});
+
+// ── Library shelf data mocks (same set as ExploreMenuScreen.test) ──
+jest.mock('@/db/content', () => ({
+  getAllProphecyChains: jest.fn().mockResolvedValue([]),
+  getDebateTopics: jest.fn().mockResolvedValue([]),
+  getAllWordStudies: jest.fn().mockResolvedValue([]),
+  getLifeTopicCategories: jest.fn().mockResolvedValue([]),
+  getPeopleWithJourneys: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('@/hooks/useJourneyBrowse', () => ({
+  useJourneyBrowse: jest.fn().mockReturnValue({
+    allJourneys: [], personJourneys: [], conceptJourneys: [], thematicJourneys: [],
+    lensIds: [], isLoading: false,
+  }),
+}));
+jest.mock('@/hooks/useProphecyChains', () => ({
+  useProphecyChains: jest.fn().mockReturnValue({ chains: [], isLoading: false }),
+}));
+jest.mock('@/hooks/useExploreImages', () => ({
+  useExploreImages: jest.fn().mockReturnValue({}),
+}));
+jest.mock('@/hooks/usePremium', () => ({
+  usePremium: jest.fn().mockReturnValue({
+    isPremium: true, upgradeRequest: null, showUpgrade: jest.fn(), dismissUpgrade: jest.fn(),
+  }),
+}));
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: jest.fn().mockReturnValue(true),
+}));
+
+// ── Hub data mocks ──
+const mockUseContinuePlan = jest.fn();
+jest.mock('@/hooks/useContinuePlan', () => ({
+  useContinuePlan: () => mockUseContinuePlan(),
+}));
+
+const mockCompleteItem = jest.fn().mockResolvedValue(undefined);
+const mockUseReviewQueue = jest.fn();
+jest.mock('@/hooks/useReviewQueue', () => ({
+  useReviewQueue: () => mockUseReviewQueue(),
+}));
+
+const RHYTHM = [{ week: '2026-W27', weekStart: '2026-06-29', sessions: 2, reviews: 1 }];
+jest.mock('@/services/study', () => ({
+  getWeeklyRhythm: jest.fn().mockResolvedValue(RHYTHM),
+}));
+
+import StudyHubScreen from '@/screens/StudyHubScreen';
+
+const PLAN: StudyPlan = {
+  id: 'plan-1',
+  plan_type: 'book',
+  source_id: 'jonah',
+  title: 'Jonah',
+  default_mode: 'quick',
+  created_at: '2026-06-01 00:00:00',
+  archived_at: null,
+};
+
+const ITEMS: StudyPlanItem[] = [1, 2, 3].map((n) => ({
+  plan_id: 'plan-1',
+  item_num: n,
+  kind: 'session',
+  ref_json: JSON.stringify({ bookId: 'jonah', chapterNum: n }),
+  session_id: null,
+  completed_at: n === 1 ? '2026-06-02 08:00:00' : null,
+}));
+
+function reviewItem(id: number, prompt: string): GuidedReviewItem {
+  return {
+    id,
+    source_session_id: 10 + id,
+    chapter_id: 'jonah_1',
+    title: 'Jonah 1',
+    prompt,
+    answer: 'answer',
+    due_date: '2026-07-01',
+    interval_days: 3,
+    review_count: 0,
+    status: 'due',
+    created_at: '2026-06-28 08:00:00',
+    updated_at: '2026-06-28 08:00:00',
+  } as GuidedReviewItem;
+}
+
+function stubReviewQueue(dueItems: GuidedReviewItem[]) {
+  mockUseReviewQueue.mockReturnValue({
+    dueItems,
+    completeItem: mockCompleteItem,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseContinuePlan.mockReturnValue({
+    plan: PLAN,
+    items: ITEMS,
+    target: { bookId: 'jonah', chapterNum: 2, step: 'explore' },
+    estimateMin: 12,
+    isLoading: false,
+    reload: jest.fn().mockResolvedValue(undefined),
+  });
+  stubReviewQueue([reviewItem(1, 'What did the storm reveal?')]);
+});
+
+describe('StudyHubScreen (#1832)', () => {
+  it('renders heading, hero, review, rhythm, and library shelves', async () => {
+    const { getByText } = render(<StudyHubScreen />);
+    expect(getByText('Study')).toBeTruthy();
+    expect(getByText('Jonah')).toBeTruthy();
+    expect(getByText('Jonah 2 · Paused at Explore · ~12 min')).toBeTruthy();
+    expect(getByText('What did the storm reveal?')).toBeTruthy();
+    await waitFor(() => {
+      expect(getByText('Two sessions and one review this week — a steady rhythm of study.')).toBeTruthy();
+      expect(getByText('The Biblical World')).toBeTruthy();
+      expect(getByText('Deep Dive')).toBeTruthy();
+    });
+  });
+
+  it('resumes the plan into StudySession with the paused step', async () => {
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Resume Jonah at Jonah 2'));
+    expect(mockNavigate).toHaveBeenCalledWith('StudySession', {
+      bookId: 'jonah',
+      chapterNum: 2,
+      initialStep: 'explore',
+    });
+  });
+
+  it('renders no hero region when there is no active plan', async () => {
+    mockUseContinuePlan.mockReturnValue({
+      plan: null, items: [], target: null, estimateMin: null,
+      isLoading: false, reload: jest.fn().mockResolvedValue(undefined),
+    });
+    const { queryByText, getByText } = render(<StudyHubScreen />);
+    expect(queryByText('CONTINUE')).toBeNull();
+    expect(queryByText('Resume')).toBeNull();
+    // The rest of the hub still renders.
+    await waitFor(() => expect(getByText('The Biblical World')).toBeTruthy());
+  });
+
+  it('completes the current review on "Recall it"', async () => {
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Recall it — mark this review complete'));
+    await waitFor(() => expect(mockCompleteItem).toHaveBeenCalledWith(1));
+  });
+
+  it('cycles to the next due item on "Later"', async () => {
+    stubReviewQueue([
+      reviewItem(1, 'What did the storm reveal?'),
+      reviewItem(2, 'Why did Jonah flee?'),
+    ]);
+    const { getByLabelText, getByText, queryByText } = render(<StudyHubScreen />);
+    expect(getByText('What did the storm reveal?')).toBeTruthy();
+    expect(getByText('Jonah 1  ·  1 of 2 due')).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Later — show the next due review'));
+    expect(getByText('Why did Jonah flee?')).toBeTruthy();
+    expect(queryByText('What did the storm reveal?')).toBeNull();
+
+    // Wraps back around.
+    fireEvent.press(getByLabelText('Later — show the next due review'));
+    expect(getByText('What did the storm reveal?')).toBeTruthy();
+  });
+
+  it('shows no review card when nothing is due', () => {
+    stubReviewQueue([]);
+    const { queryByText } = render(<StudyHubScreen />);
+    expect(queryByText('Recall it')).toBeNull();
+  });
+});

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -137,14 +137,30 @@ describe('StudyHubScreen (#1832)', () => {
     });
   });
 
-  it('resumes the plan into StudySession with the paused step', async () => {
+  it('resumes the plan into StudySession with the paused step and planId', async () => {
     const { getByLabelText } = render(<StudyHubScreen />);
     fireEvent.press(getByLabelText('Resume Jonah at Jonah 2'));
     expect(mockNavigate).toHaveBeenCalledWith('StudySession', {
       bookId: 'jonah',
       chapterNum: 2,
+      planId: 'plan-1',
       initialStep: 'explore',
     });
+  });
+
+  it('opens StudyPlanDetail from the hero chevron (#1833)', async () => {
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Open Jonah plan details'));
+    expect(mockNavigate).toHaveBeenCalledWith('StudyPlanDetail', { planId: 'plan-1' });
+  });
+
+  it('renders the Begin-something-new row and opens the picker preselected (#1833)', async () => {
+    const { getByText, getByLabelText } = render(<StudyHubScreen />);
+    expect(getByText('BEGIN SOMETHING NEW')).toBeTruthy();
+    fireEvent.press(getByLabelText('Begin studying a journey'));
+    expect(mockNavigate).toHaveBeenCalledWith('PlanPicker', { segment: 'journey' });
+    fireEvent.press(getByLabelText('Begin studying a book'));
+    expect(mockNavigate).toHaveBeenCalledWith('PlanPicker', { segment: 'book' });
   });
 
   it('renders no hero region when there is no active plan', async () => {

--- a/app/__tests__/screens/StudyPlanDetailScreen.test.tsx
+++ b/app/__tests__/screens/StudyPlanDetailScreen.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * #1833 — StudyPlanDetailScreen: item list with completion state,
+ * per-item resume, archive action. (Not the legacy PlanDetailScreen.)
+ */
+import React from 'react';
+import { Alert } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+    useRoute: () => ({ params: { planId: 'plan-1' } }),
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+const mockGetStudyPlan = jest.fn();
+const mockGetStudyPlanItems = jest.fn();
+jest.mock('@/db/userQueries', () => ({
+  getStudyPlan: (...args: unknown[]) => mockGetStudyPlan(...args),
+  getStudyPlanItems: (...args: unknown[]) => mockGetStudyPlanItems(...args),
+}));
+
+const mockArchiveStudyPlan = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/db/userMutations', () => ({
+  archiveStudyPlan: (...args: unknown[]) => mockArchiveStudyPlan(...args),
+}));
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: jest.fn().mockReturnValue(true),
+}));
+
+import StudyPlanDetailScreen from '@/screens/StudyPlanDetailScreen';
+
+const PLAN = {
+  id: 'plan-1',
+  plan_type: 'book',
+  source_id: 'jonah',
+  title: 'Jonah',
+  default_mode: 'quick',
+  created_at: '2026-06-01 00:00:00',
+  archived_at: null,
+};
+
+const ITEMS = [1, 2, 3, 4].map((n) => ({
+  plan_id: 'plan-1',
+  item_num: n,
+  kind: 'session',
+  ref_json: JSON.stringify({ bookId: 'jonah', chapterNum: n }),
+  session_id: n === 1 ? '9' : null,
+  completed_at: n === 1 ? '2026-06-02 08:00:00' : null,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetStudyPlan.mockResolvedValue(PLAN);
+  mockGetStudyPlanItems.mockResolvedValue(ITEMS);
+});
+
+describe('StudyPlanDetailScreen (#1833)', () => {
+  it('renders the plan title, progress line, and every item with completion state', async () => {
+    const { getByText, getByLabelText } = render(<StudyPlanDetailScreen />);
+    await waitFor(() => {
+      expect(getByText('Jonah')).toBeTruthy();
+      expect(getByText('1 of 4 complete')).toBeTruthy();
+      expect(getByLabelText('Jonah 1, complete. Revisit session')).toBeTruthy();
+      expect(getByLabelText('Jonah 2. Resume here')).toBeTruthy();
+      expect(getByText('Jonah 4')).toBeTruthy();
+    });
+  });
+
+  it('resumes an item into StudySession with the planId', async () => {
+    const { getByLabelText } = render(<StudyPlanDetailScreen />);
+    await waitFor(() => expect(getByLabelText('Jonah 2. Resume here')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Jonah 2. Resume here'));
+    expect(mockNavigate).toHaveBeenCalledWith('StudySession', {
+      bookId: 'jonah',
+      chapterNum: 2,
+      planId: 'plan-1',
+    });
+  });
+
+  it('archives after confirmation and goes back', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const archive = buttons?.find((b) => b.text === 'Archive');
+      archive?.onPress?.();
+    });
+
+    const { getByLabelText } = render(<StudyPlanDetailScreen />);
+    await waitFor(() => expect(getByLabelText('Archive the Jonah plan')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Archive the Jonah plan'));
+    await waitFor(() => {
+      expect(mockArchiveStudyPlan).toHaveBeenCalledWith('plan-1');
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+    alertSpy.mockRestore();
+  });
+
+  it('shows a not-found state for an unknown plan', async () => {
+    mockGetStudyPlan.mockResolvedValue(null);
+    mockGetStudyPlanItems.mockResolvedValue([]);
+    const { getByText } = render(<StudyPlanDetailScreen />);
+    await waitFor(() => expect(getByText('Plan not found')).toBeTruthy());
+  });
+});

--- a/app/__tests__/services/study/adoption.test.ts
+++ b/app/__tests__/services/study/adoption.test.ts
@@ -1,0 +1,162 @@
+/**
+ * #1833 — one-decision plan adoption (services/study/adoption).
+ * Covers the card's required unit test (picker default-mode
+ * resolution) plus startStudyPlan and the session-completion wiring.
+ */
+const mockGetPreference = jest.fn();
+const mockCreateStudyPlan = jest.fn();
+const mockLinkSessionToPlanItem = jest.fn().mockResolvedValue(undefined);
+const mockCompleteStudyPlanItem = jest.fn().mockResolvedValue(undefined);
+const mockGetStudyPlanItems = jest.fn();
+
+jest.mock('@/db/userQueries', () => ({
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  getStudyPlanItems: (...args: unknown[]) => mockGetStudyPlanItems(...args),
+  getGuidedStudySession: jest.fn(),
+  getStudyPlans: jest.fn(),
+}));
+
+jest.mock('@/db/userMutations', () => ({
+  createStudyPlan: (...args: unknown[]) => mockCreateStudyPlan(...args),
+  linkSessionToPlanItem: (...args: unknown[]) => mockLinkSessionToPlanItem(...args),
+  completeStudyPlanItem: (...args: unknown[]) => mockCompleteStudyPlanItem(...args),
+}));
+
+const mockGetBook = jest.fn();
+jest.mock('@/db/content', () => ({
+  getBook: (...args: unknown[]) => mockGetBook(...args),
+}));
+jest.mock('@/db/content/features', () => ({
+  getJourneyStops: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('@/db/content/reference', () => ({
+  getTopic: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import {
+  completePlanItemForSession,
+  getDefaultStudyMode,
+  resolveDefaultMode,
+  startStudyPlan,
+} from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPreference.mockResolvedValue(null);
+  mockCreateStudyPlan.mockResolvedValue('plan-xyz');
+});
+
+describe('resolveDefaultMode (#1833 acceptance: picker default-mode resolution)', () => {
+  it('accepts every valid guided study mode', () => {
+    expect(resolveDefaultMode('quick')).toBe('quick');
+    expect(resolveDefaultMode('deep')).toBe('deep');
+    expect(resolveDefaultMode('teaching')).toBe('teaching');
+    expect(resolveDefaultMode('devotional')).toBe('devotional');
+  });
+
+  it("falls back to 'deep' for null, empty, and junk values", () => {
+    expect(resolveDefaultMode(null)).toBe('deep');
+    expect(resolveDefaultMode(undefined)).toBe('deep');
+    expect(resolveDefaultMode('')).toBe('deep');
+    expect(resolveDefaultMode('warp-speed')).toBe('deep');
+  });
+});
+
+describe('getDefaultStudyMode', () => {
+  it('reads the guided_study_last_mode preference', async () => {
+    mockGetPreference.mockResolvedValue('quick');
+    await expect(getDefaultStudyMode()).resolves.toBe('quick');
+    expect(mockGetPreference).toHaveBeenCalledWith('guided_study_last_mode');
+  });
+
+  it("falls back to 'deep' when unset or the read throws", async () => {
+    mockGetPreference.mockResolvedValue(null);
+    await expect(getDefaultStudyMode()).resolves.toBe('deep');
+    mockGetPreference.mockRejectedValue(new Error('db closed'));
+    await expect(getDefaultStudyMode()).resolves.toBe('deep');
+  });
+});
+
+describe('startStudyPlan', () => {
+  it('creates a book plan with template items and the remembered mode', async () => {
+    mockGetPreference.mockResolvedValue('devotional');
+    mockGetBook.mockResolvedValue({ id: 'romans', total_chapters: 16 });
+
+    const started = await startStudyPlan({
+      planType: 'book',
+      sourceId: 'romans',
+      title: 'Romans',
+    });
+
+    expect(mockCreateStudyPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planType: 'book',
+        sourceId: 'romans',
+        title: 'Romans',
+        defaultMode: 'devotional',
+      }),
+    );
+    expect(mockCreateStudyPlan.mock.calls[0][0].items).toHaveLength(16);
+    expect(started).toEqual({
+      planId: 'plan-xyz',
+      mode: 'devotional',
+      firstRef: { bookId: 'romans', chapterNum: 1 },
+    });
+  });
+
+  it('returns null (and creates nothing) when the source has no items', async () => {
+    mockGetBook.mockResolvedValue(null);
+    const started = await startStudyPlan({
+      planType: 'book',
+      sourceId: 'atlantis',
+      title: 'Atlantis',
+    });
+    expect(started).toBeNull();
+    expect(mockCreateStudyPlan).not.toHaveBeenCalled();
+  });
+});
+
+describe('completePlanItemForSession', () => {
+  const items = (completedFirst: boolean) => [
+    {
+      plan_id: 'p',
+      item_num: 1,
+      kind: 'session',
+      ref_json: JSON.stringify({ bookId: 'romans', chapterNum: 1 }),
+      session_id: null,
+      completed_at: completedFirst ? 'x' : null,
+    },
+    {
+      plan_id: 'p',
+      item_num: 2,
+      kind: 'session',
+      ref_json: JSON.stringify({ bookId: 'romans', chapterNum: 2 }),
+      session_id: null,
+      completed_at: null,
+    },
+  ];
+
+  it('links and completes the next item when the chapter matches', async () => {
+    mockGetStudyPlanItems.mockResolvedValue(items(true)); // next = item 2
+    await completePlanItemForSession('p', 'romans', 2, 42);
+    expect(mockLinkSessionToPlanItem).toHaveBeenCalledWith('p', 2, 42);
+    expect(mockCompleteStudyPlanItem).toHaveBeenCalledWith('p', 2);
+  });
+
+  it('does nothing when the session chapter is not the next item', async () => {
+    mockGetStudyPlanItems.mockResolvedValue(items(false)); // next = item 1 (romans 1)
+    await completePlanItemForSession('p', 'romans', 9, 42);
+    expect(mockLinkSessionToPlanItem).not.toHaveBeenCalled();
+    expect(mockCompleteStudyPlanItem).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the plan is already complete', async () => {
+    mockGetStudyPlanItems.mockResolvedValue([]);
+    await completePlanItemForSession('p', 'romans', 1, 42);
+    expect(mockLinkSessionToPlanItem).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/study/BeginSomethingNew.tsx
+++ b/app/src/components/study/BeginSomethingNew.tsx
@@ -1,0 +1,73 @@
+/**
+ * components/study/BeginSomethingNew.tsx — Study hub row (#1833):
+ * three cards (A Book / A Journey / A Topic) that open the one-decision
+ * plan picker with the matching segment preselected.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { BookOpen, Footprints, Lightbulb } from 'lucide-react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+
+export type PlanPickerSegment = 'book' | 'journey' | 'topic';
+
+interface Props {
+  onPick: (segment: PlanPickerSegment) => void;
+}
+
+const CARDS: Array<{ segment: PlanPickerSegment; label: string; Icon: typeof BookOpen }> = [
+  { segment: 'book', label: 'A Book', Icon: BookOpen },
+  { segment: 'journey', label: 'A Journey', Icon: Footprints },
+  { segment: 'topic', label: 'A Topic', Icon: Lightbulb },
+];
+
+export function BeginSomethingNew({ onPick }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View>
+      <Text style={[styles.label, { color: base.textMuted }]}>BEGIN SOMETHING NEW</Text>
+      <View style={styles.row}>
+        {CARDS.map(({ segment, label, Icon }) => (
+          <TouchableOpacity
+            key={segment}
+            onPress={() => onPick(segment)}
+            activeOpacity={0.72}
+            accessibilityRole="button"
+            accessibilityLabel={`Begin studying ${label.toLowerCase()}`}
+            style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.border }]}
+          >
+            <Icon size={18} color={base.gold} />
+            <Text style={[styles.cardLabel, { color: base.text }]}>{label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 1,
+    marginBottom: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  card: {
+    flex: 1,
+    minHeight: 64,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    paddingVertical: spacing.sm,
+  },
+  cardLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+});

--- a/app/src/components/study/ChapterTrail.tsx
+++ b/app/src/components/study/ChapterTrail.tsx
@@ -1,0 +1,101 @@
+/**
+ * components/study/ChapterTrail.tsx — Chapter trail ticks for study
+ * plans (#1832/#1833): done = filled gold, current = hollow with a
+ * soft glow (static under OS reduce-motion), upcoming = hollow dim.
+ * Decorative — hidden from screen readers by the consumers.
+ */
+import React, { useEffect, useState } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { useTheme } from '../../theme';
+import type { StudyPlanItem } from '../../types';
+
+function TrailTick({ state, glow }: { state: 'done' | 'current' | 'upcoming'; glow: boolean }) {
+  const { base } = useTheme();
+  const [pulse] = useState(() => new Animated.Value(0.35));
+
+  useEffect(() => {
+    if (state !== 'current' || !glow) return;
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 1, duration: 1100, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 0.35, duration: 1100, useNativeDriver: true }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [state, glow, pulse]);
+
+  if (state === 'done') {
+    return <View style={[styles.tick, { backgroundColor: base.gold }]} />;
+  }
+  if (state === 'current') {
+    return (
+      <View style={styles.currentWrap}>
+        <Animated.View
+          style={[styles.halo, { borderColor: base.gold, opacity: glow ? pulse : 0.55 }]}
+        />
+        <View style={[styles.tick, styles.hollow, { borderColor: base.gold }]} />
+      </View>
+    );
+  }
+  return <View style={[styles.tick, styles.hollow, { borderColor: base.border }]} />;
+}
+
+export function ChapterTrail({ items }: { items: StudyPlanItem[] }) {
+  const reducedMotion = useReducedMotion();
+  const currentItemNum = items.find((i) => i.completed_at == null)?.item_num ?? null;
+
+  return (
+    <View
+      style={styles.trail}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      {items.map((item) => (
+        <TrailTick
+          key={item.item_num}
+          state={
+            item.completed_at != null
+              ? 'done'
+              : item.item_num === currentItemNum
+                ? 'current'
+                : 'upcoming'
+          }
+          glow={!reducedMotion}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  trail: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    alignItems: 'center',
+  },
+  tick: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+  hollow: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+  },
+  currentWrap: {
+    width: 15,
+    height: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  halo: {
+    position: 'absolute',
+    width: 15,
+    height: 15,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+});

--- a/app/src/components/study/ContinueHero.tsx
+++ b/app/src/components/study/ContinueHero.tsx
@@ -1,20 +1,17 @@
 /**
  * components/study/ContinueHero.tsx — The Study hub's "Continue" hero
- * (#1832): active plan title in Cinzel, chapter trail ticks (done =
- * filled gold, current = hollow with a soft glow, upcoming = hollow
- * dim), paused step + minutes, and a Resume action.
- *
- * The current-tick glow is decorative; it renders statically when the
- * OS reduce-motion setting is on.
+ * (#1832): active plan title in Cinzel, chapter trail ticks, paused
+ * step + minutes, and a Resume action. Long-press (or the chevron)
+ * opens StudyPlanDetail (#1833) — never a mandatory hop.
  */
-import React, { useEffect, useState } from 'react';
-import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Play } from 'lucide-react-native';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ChevronRight, Play } from 'lucide-react-native';
 import { formatChapterRef, getGuidedStudyStepLabel } from '../../services/guidedStudy';
 import type { ResumeTarget } from '../../services/study';
 import { fontFamily, radii, spacing, useTheme } from '../../theme';
 import type { StudyPlan, StudyPlanItem } from '../../types';
-import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { ChapterTrail } from './ChapterTrail';
 
 interface Props {
   plan: StudyPlan;
@@ -22,48 +19,13 @@ interface Props {
   target: ResumeTarget;
   estimateMin: number | null;
   onResume: () => void;
+  /** Opens StudyPlanDetail (#1833). Optional so #1832 callers keep working. */
+  onOpenDetail?: () => void;
 }
 
-function TrailTick({ state, glow }: { state: 'done' | 'current' | 'upcoming'; glow: boolean }) {
+export function ContinueHero({ plan, items, target, estimateMin, onResume, onOpenDetail }: Props) {
   const { base } = useTheme();
-  const [pulse] = useState(() => new Animated.Value(0.35));
 
-  useEffect(() => {
-    if (state !== 'current' || !glow) return;
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(pulse, { toValue: 1, duration: 1100, useNativeDriver: true }),
-        Animated.timing(pulse, { toValue: 0.35, duration: 1100, useNativeDriver: true }),
-      ]),
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [state, glow, pulse]);
-
-  if (state === 'done') {
-    return <View style={[styles.tick, { backgroundColor: base.gold }]} />;
-  }
-  if (state === 'current') {
-    return (
-      <View style={styles.currentWrap}>
-        <Animated.View
-          style={[
-            styles.halo,
-            { borderColor: base.gold, opacity: glow ? pulse : 0.55 },
-          ]}
-        />
-        <View style={[styles.tick, styles.hollow, { borderColor: base.gold }]} />
-      </View>
-    );
-  }
-  return <View style={[styles.tick, styles.hollow, { borderColor: base.border }]} />;
-}
-
-export function ContinueHero({ plan, items, target, estimateMin, onResume }: Props) {
-  const { base } = useTheme();
-  const reducedMotion = useReducedMotion();
-
-  const currentItemNum = items.find((i) => i.completed_at == null)?.item_num ?? null;
   const chapterRef = formatChapterRef(`${target.bookId}_${target.chapterNum}`);
 
   const metaParts: string[] = [chapterRef];
@@ -71,29 +33,32 @@ export function ContinueHero({ plan, items, target, estimateMin, onResume }: Pro
   if (estimateMin != null) metaParts.push(`~${estimateMin} min`);
 
   return (
-    <View
+    <TouchableOpacity
+      activeOpacity={0.9}
+      onLongPress={onOpenDetail}
+      disabled={!onOpenDetail}
+      accessibilityLabel={`${plan.title} study plan`}
+      accessibilityHint={onOpenDetail ? 'Long press to open the plan details' : undefined}
       style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}
     >
-      <Text style={[styles.kicker, { color: base.textMuted }]}>CONTINUE</Text>
+      <View style={styles.kickerRow}>
+        <Text style={[styles.kicker, { color: base.textMuted }]}>CONTINUE</Text>
+        {onOpenDetail && (
+          <TouchableOpacity
+            onPress={onOpenDetail}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${plan.title} plan details`}
+            style={styles.detailButton}
+          >
+            <ChevronRight size={18} color={base.textMuted} />
+          </TouchableOpacity>
+        )}
+      </View>
       <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
         {plan.title}
       </Text>
 
-      <View style={styles.trail} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
-        {items.map((item) => (
-          <TrailTick
-            key={item.item_num}
-            state={
-              item.completed_at != null
-                ? 'done'
-                : item.item_num === currentItemNum
-                  ? 'current'
-                  : 'upcoming'
-            }
-            glow={!reducedMotion}
-          />
-        ))}
-      </View>
+      <ChapterTrail items={items} />
 
       <Text style={[styles.meta, { color: base.textMuted }]}>{metaParts.join(' · ')}</Text>
 
@@ -107,7 +72,7 @@ export function ContinueHero({ plan, items, target, estimateMin, onResume }: Pro
         <Play size={16} color={base.bg} />
         <Text style={[styles.resumeLabel, { color: base.bg }]}>Resume</Text>
       </TouchableOpacity>
-    </View>
+    </TouchableOpacity>
   );
 }
 
@@ -118,44 +83,29 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     gap: spacing.sm,
   },
+  kickerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   kicker: {
     fontFamily: fontFamily.uiMedium,
     fontSize: 10,
     letterSpacing: 1,
+  },
+  detailButton: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    marginVertical: -spacing.sm,
+    marginRight: -spacing.xs,
   },
   title: {
     fontFamily: fontFamily.displayMedium,
     fontSize: 20,
     // No numberOfLines on purpose — Dynamic Type must never truncate
     // the hero title (a11y acceptance criterion, #1832).
-  },
-  trail: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
-    alignItems: 'center',
-  },
-  tick: {
-    width: 9,
-    height: 9,
-    borderRadius: 5,
-  },
-  hollow: {
-    backgroundColor: 'transparent',
-    borderWidth: 1.5,
-  },
-  currentWrap: {
-    width: 15,
-    height: 15,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  halo: {
-    position: 'absolute',
-    width: 15,
-    height: 15,
-    borderRadius: 8,
-    borderWidth: 1,
   },
   meta: {
     fontFamily: fontFamily.ui,

--- a/app/src/components/study/ContinueHero.tsx
+++ b/app/src/components/study/ContinueHero.tsx
@@ -1,0 +1,178 @@
+/**
+ * components/study/ContinueHero.tsx — The Study hub's "Continue" hero
+ * (#1832): active plan title in Cinzel, chapter trail ticks (done =
+ * filled gold, current = hollow with a soft glow, upcoming = hollow
+ * dim), paused step + minutes, and a Resume action.
+ *
+ * The current-tick glow is decorative; it renders statically when the
+ * OS reduce-motion setting is on.
+ */
+import React, { useEffect, useState } from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Play } from 'lucide-react-native';
+import { formatChapterRef, getGuidedStudyStepLabel } from '../../services/guidedStudy';
+import type { ResumeTarget } from '../../services/study';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { StudyPlan, StudyPlanItem } from '../../types';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+
+interface Props {
+  plan: StudyPlan;
+  items: StudyPlanItem[];
+  target: ResumeTarget;
+  estimateMin: number | null;
+  onResume: () => void;
+}
+
+function TrailTick({ state, glow }: { state: 'done' | 'current' | 'upcoming'; glow: boolean }) {
+  const { base } = useTheme();
+  const [pulse] = useState(() => new Animated.Value(0.35));
+
+  useEffect(() => {
+    if (state !== 'current' || !glow) return;
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 1, duration: 1100, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 0.35, duration: 1100, useNativeDriver: true }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [state, glow, pulse]);
+
+  if (state === 'done') {
+    return <View style={[styles.tick, { backgroundColor: base.gold }]} />;
+  }
+  if (state === 'current') {
+    return (
+      <View style={styles.currentWrap}>
+        <Animated.View
+          style={[
+            styles.halo,
+            { borderColor: base.gold, opacity: glow ? pulse : 0.55 },
+          ]}
+        />
+        <View style={[styles.tick, styles.hollow, { borderColor: base.gold }]} />
+      </View>
+    );
+  }
+  return <View style={[styles.tick, styles.hollow, { borderColor: base.border }]} />;
+}
+
+export function ContinueHero({ plan, items, target, estimateMin, onResume }: Props) {
+  const { base } = useTheme();
+  const reducedMotion = useReducedMotion();
+
+  const currentItemNum = items.find((i) => i.completed_at == null)?.item_num ?? null;
+  const chapterRef = formatChapterRef(`${target.bookId}_${target.chapterNum}`);
+
+  const metaParts: string[] = [chapterRef];
+  if (target.step) metaParts.push(`Paused at ${getGuidedStudyStepLabel(target.step)}`);
+  if (estimateMin != null) metaParts.push(`~${estimateMin} min`);
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}
+    >
+      <Text style={[styles.kicker, { color: base.textMuted }]}>CONTINUE</Text>
+      <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
+        {plan.title}
+      </Text>
+
+      <View style={styles.trail} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+        {items.map((item) => (
+          <TrailTick
+            key={item.item_num}
+            state={
+              item.completed_at != null
+                ? 'done'
+                : item.item_num === currentItemNum
+                  ? 'current'
+                  : 'upcoming'
+            }
+            glow={!reducedMotion}
+          />
+        ))}
+      </View>
+
+      <Text style={[styles.meta, { color: base.textMuted }]}>{metaParts.join(' · ')}</Text>
+
+      <TouchableOpacity
+        onPress={onResume}
+        activeOpacity={0.72}
+        style={[styles.resumeButton, { backgroundColor: base.gold }]}
+        accessibilityRole="button"
+        accessibilityLabel={`Resume ${plan.title} at ${chapterRef}`}
+      >
+        <Play size={16} color={base.bg} />
+        <Text style={[styles.resumeLabel, { color: base.bg }]}>Resume</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  kicker: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 1,
+  },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 20,
+    // No numberOfLines on purpose — Dynamic Type must never truncate
+    // the hero title (a11y acceptance criterion, #1832).
+  },
+  trail: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    alignItems: 'center',
+  },
+  tick: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+  hollow: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+  },
+  currentWrap: {
+    width: 15,
+    height: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  halo: {
+    position: 'absolute',
+    width: 15,
+    height: 15,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  meta: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+  },
+  resumeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 44,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    alignSelf: 'stretch',
+  },
+  resumeLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
+  },
+});

--- a/app/src/components/study/LibrarySections.tsx
+++ b/app/src/components/study/LibrarySections.tsx
@@ -1,0 +1,315 @@
+/**
+ * components/study/LibrarySections.tsx — The Explore/Study library
+ * shelves, extracted from ExploreMenuScreen (#1832) so the Study hub
+ * and the legacy Explore menu render the exact same sections.
+ *
+ * Each section is a horizontal shelf (FlatList) of cards: art slot
+ * (content_images via the explore image registry, tonal-wash fallback
+ * inside FeatureCard when no image) + title + subtitle. The per-tool
+ * `color` values in LIBRARY_SECTIONS are intentional data colors, not
+ * theme leaks — everything else styles through useTheme() tokens.
+ *
+ * Consumers own premium gating: pass `onNavigate` that checks
+ * PREMIUM_SCREENS (exported here) and shows the upgrade prompt.
+ */
+import React, { useCallback } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { useTheme, spacing, fontFamily } from '../../theme';
+import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../FeatureCard';
+import { JourneyBrowseSection } from '../JourneyBrowseSection';
+import {
+  ProphecyChainCard,
+  DebatePreviewList,
+  WordStudyPreviewList,
+  LifeTopicGrid,
+  FullWidthImageCard,
+  GlossySectionWrapper,
+  PROPHECY_CHAIN_CARD_WIDTH,
+} from '../explore';
+import { useProphecyChains } from '../../hooks/useProphecyChains';
+import type { ExploreFeatureImages } from '../../types';
+import type { ProphecyChain } from '../../types';
+
+// ── Section data ───────────────────────────────────────────────
+
+export interface FeatureSection {
+  id: string;
+  label: string;
+  subtitle: string;
+  features: FeatureCardData[];
+}
+
+/** Screens that require premium — consumers gate onNavigate with this. */
+export const PREMIUM_SCREENS: Record<string, string> = {
+  Concordance: 'Concordance Search',
+  ContentLibrary: 'Content Library',
+  ThreadBrowse: 'Cross-Reference Threading',
+  HowWeGotTheBibleLanding: 'How We Got The Bible',
+};
+
+export const LIBRARY_SECTIONS: FeatureSection[] = [
+  {
+    id: 'biblical-world', label: 'The Biblical World', subtitle: 'Where, when, and who',
+    features: [
+      { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                color: '#e86040', screen: 'GenealogyTree' }, // data-color: intentional
+      { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        color: '#70b8e8', screen: 'Timeline' }, // data-color: intentional
+      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
+      { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    color: '#8a6e3a', screen: 'Periods', premium: true }, // data-color: intentional
+      { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          color: '#c8a040', screen: 'RedemptiveArc', premium: true }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'themes', label: 'Themes & Connections', subtitle: 'Trace ideas across Scripture',
+    features: [
+      { title: 'Guided Journeys',    subtitle: '60 journeys — people, concepts, themes',             color: '#bfa050', screen: 'JourneyBrowse' }, // data-color: intentional
+      { title: 'Topical Index',      subtitle: 'What does the Bible say about...?',                    color: '#c8a040', screen: 'TopicBrowse' }, // data-color: intentional
+      { title: 'Prophecy',           subtitle: '50 chains — OT to NT fulfillment',                color: '#e8a070', screen: 'ProphecyBrowse' }, // data-color: intentional
+      { title: 'Threads',            subtitle: 'One idea across 31 chains',                            color: '#9090e0', screen: 'ThreadBrowse', premium: true }, // data-color: intentional
+      { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                color: '#70d098', screen: 'HarmonyBrowse' }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'journeys', label: 'Journeys', subtitle: 'Follow a life or trace an idea across Scripture',
+    features: [], // Custom renderer — uses JourneyBrowseSection instead of FeatureCards
+  },
+  {
+    id: 'language', label: 'Language & Reference', subtitle: 'Original words and definitions',
+    features: [
+      { title: 'Word Studies', subtitle: 'Hebrew & Greek deep dives',                                  color: '#e890b8', screen: 'WordStudyBrowse' }, // data-color: intentional
+      { title: 'Concordance',  subtitle: 'Every occurrence of a word',                                 color: '#70b8e8', screen: 'Concordance', premium: true }, // data-color: intentional
+      { title: 'Dictionary',   subtitle: 'Definitions for every biblical term',                         color: '#c090e0', screen: 'DictionaryBrowse' }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'scholarly', label: 'Scholarly Analysis', subtitle: 'Academic perspectives & debate',
+    features: [
+      { title: 'Scholars',             subtitle: 'Browse all 54 by tradition',                            color: '#a0b8d0', screen: 'ScholarBrowse' }, // data-color: intentional
+      { title: 'Debates',              subtitle: '303 topics where scholars disagree',                    color: '#d08080', screen: 'DebateBrowse' }, // data-color: intentional
+      { title: 'Difficult Passages',   subtitle: '53 hard texts with multi-view responses',               color: '#FFB74D', screen: 'DifficultPassagesBrowse' }, // data-color: intentional
+      { title: 'How We Got The Bible', subtitle: 'Canon, manuscripts, translations, and the books Jude quoted', color: '#c89858', screen: 'HowWeGotTheBibleLanding', premium: true }, // data-color: intentional
+      { title: 'Content Library',      subtitle: 'Discourse, manuscripts & more',                          color: '#b8a0d0', screen: 'ContentLibrary', premium: true }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'life', label: 'Life & Faith', subtitle: 'Biblical guidance for everyday life',
+    features: [
+      { title: 'Life Topics', subtitle: 'Practical guidance from Scripture',                             color: '#81C784', screen: 'LifeTopics' }, // data-color: intentional
+    ],
+  },
+  {
+    id: 'deep-dive', label: 'Deep Dive', subtitle: 'Advanced study tools',
+    features: [
+      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
+      { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                color: '#b07d4f', screen: 'ArchaeologyBrowse' }, // data-color: intentional
+      { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   color: '#8a6a3a', screen: 'TimeTravelBrowse' }, // data-color: intentional
+      { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  color: '#7a9ab0', screen: 'GrammarBrowse' }, // data-color: intentional
+    ],
+  },
+];
+
+// ── Component ──────────────────────────────────────────────────
+
+export interface LibrarySectionsProps {
+  /** Explore image registry (useExploreImages) keyed by screen name. */
+  imageRegistry: Record<string, ExploreFeatureImages>;
+  isPremium: boolean;
+  /** Navigate to a tool screen. Consumer applies PREMIUM_SCREENS gating. */
+  onNavigate: (screen: string, params?: Record<string, string>) => void;
+  /** Follow a card image's deep link. */
+  onDeepLink: (deepLink: { screen: string; params?: Record<string, string> }) => void;
+  /** When set, render only the section with this id (jump-pill filter). */
+  filterSectionId?: string | null;
+}
+
+export function LibrarySections({
+  imageRegistry,
+  isPremium,
+  onNavigate,
+  onDeepLink,
+  filterSectionId,
+}: LibrarySectionsProps) {
+  const { base } = useTheme();
+  const { chains: prophecyChains } = useProphecyChains();
+
+  const getScreenImages = useCallback(
+    (screenName: string) => imageRegistry[screenName],
+    [imageRegistry],
+  );
+
+  const renderFeatureCard = useCallback(
+    ({ item, index }: { item: FeatureCardData; index: number }, compact: boolean) => {
+      const imgData = getScreenImages(item.screen);
+      return (
+        <FeatureCard
+          feature={item}
+          onPress={() => onNavigate(item.screen)}
+          isPremium={isPremium}
+          images={imgData?.images}
+          count={imgData?.count}
+          noun={imgData?.noun}
+          onImagePress={onDeepLink}
+          staggerMs={index * 1200}
+          compact={compact || undefined}
+        />
+      );
+    },
+    [getScreenImages, isPremium, onNavigate, onDeepLink],
+  );
+
+  const featureKey = useCallback((item: FeatureCardData) => item.screen, []);
+  const chainKey = useCallback((item: ProphecyChain) => item.id, []);
+
+  // ── Per-section content renderer ────────────────────────────
+  const renderSectionContent = (section: FeatureSection) => {
+    switch (section.id) {
+      case 'journeys':
+        return <JourneyBrowseSection />;
+      case 'themes':
+        return (
+          <View style={styles.sectionGap}>
+            {prophecyChains.length > 0 && (
+              <FlatList
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.carouselContent}
+                decelerationRate="fast"
+                snapToInterval={PROPHECY_CHAIN_CARD_WIDTH + spacing.sm}
+                data={prophecyChains.slice(0, 4)}
+                keyExtractor={chainKey}
+                renderItem={({ item }) => (
+                  <ProphecyChainCard
+                    chain={item}
+                    onPress={() => onNavigate('ProphecyDetail', { chainId: item.id })}
+                  />
+                )}
+              />
+            )}
+            <FlatList
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.carouselContent}
+              decelerationRate="fast"
+              data={section.features}
+              keyExtractor={featureKey}
+              renderItem={(info) => renderFeatureCard(info, true)}
+            />
+          </View>
+        );
+      case 'scholarly': {
+        // Debates renders as the preview strip above; everything else flows
+        // into the horizontal carousel below. Denylist (vs. allowlist) so
+        // future cards added to LIBRARY_SECTIONS surface automatically —
+        // same pattern as the 'language' case for WordStudyBrowse.
+        const carouselFeatures = section.features.filter(
+          (f) => f.screen !== 'DebateBrowse',
+        );
+        const totalDebates = getScreenImages('DebateBrowse')?.count ?? undefined;
+        return (
+          <View style={styles.sectionGap}>
+            <DebatePreviewList
+              onDebatePress={(debateId) => onNavigate('DebateDetail', { topicId: debateId })}
+              onSeeAll={() => onNavigate('DebateBrowse')}
+              totalCount={totalDebates ?? undefined}
+            />
+            <FlatList
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.carouselContent}
+              decelerationRate="fast"
+              data={carouselFeatures}
+              keyExtractor={featureKey}
+              renderItem={(info) => renderFeatureCard(info, true)}
+            />
+          </View>
+        );
+      }
+      case 'language': {
+        const splitFeatures = section.features.filter(
+          (f) => f.screen !== 'WordStudyBrowse',
+        );
+        const totalWords = getScreenImages('WordStudyBrowse')?.count ?? undefined;
+        return (
+          <View style={styles.sectionGap}>
+            <WordStudyPreviewList
+              onWordPress={(id) => onNavigate('WordStudyDetail', { wordId: id })}
+              onSeeAll={() => onNavigate('WordStudyBrowse')}
+              totalCount={totalWords ?? undefined}
+            />
+            <View style={styles.row3}>
+              {splitFeatures.map((f, i) => (
+                <View key={f.screen} style={styles.rowCell}>
+                  {renderFeatureCard({ item: f, index: i }, true)}
+                </View>
+              ))}
+            </View>
+          </View>
+        );
+      }
+      case 'life': {
+        const lifeImage = getScreenImages('LifeTopics');
+        return (
+          <View style={styles.sectionGap}>
+            <FullWidthImageCard
+              title="Life Topics"
+              subtitle="Practical guidance from Scripture"
+              image={lifeImage?.images?.[0] ?? null}
+              count={lifeImage?.count ?? null}
+              noun={lifeImage?.noun}
+              onPress={() => onNavigate('LifeTopics')}
+            />
+            <LifeTopicGrid
+              onCategoryPress={(categoryId) => onNavigate('LifeTopics', { categoryId })}
+            />
+          </View>
+        );
+      }
+      case 'deep-dive':
+      case 'biblical-world':
+      default:
+        return (
+          <FlatList
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.carouselContent}
+            decelerationRate="fast"
+            snapToInterval={CARD_WIDTH + spacing.sm}
+            data={section.features}
+            keyExtractor={featureKey}
+            renderItem={(info) => renderFeatureCard(info, false)}
+          />
+        );
+    }
+  };
+
+  const sections = filterSectionId
+    ? LIBRARY_SECTIONS.filter((s) => s.id === filterSectionId)
+    : LIBRARY_SECTIONS;
+
+  return (
+    <>
+      {sections.map((section, sectionIndex) => (
+        <View key={section.id}>
+          <GlossySectionWrapper sectionIndex={sectionIndex}>
+            <View style={styles.section}>
+              <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
+              <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
+              {renderSectionContent(section)}
+            </View>
+          </GlossySectionWrapper>
+        </View>
+      ))}
+    </>
+  );
+}
+
+// ── Styles ─────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  section: { marginBottom: spacing.md },
+  sectionLabel: { fontFamily: fontFamily.displayMedium, fontSize: 13, letterSpacing: 0.5, marginBottom: 2 },
+  sectionSubtitle: { fontFamily: fontFamily.ui, fontSize: 11, marginBottom: spacing.sm },
+  carouselContent: { gap: spacing.sm },
+  sectionGap: { gap: spacing.md },
+  row3: { flexDirection: 'row', gap: spacing.sm },
+  rowCell: { flex: 1 },
+});

--- a/app/src/components/study/ReviewRecallCard.tsx
+++ b/app/src/components/study/ReviewRecallCard.tsx
@@ -1,0 +1,100 @@
+/**
+ * components/study/ReviewRecallCard.tsx — Single focused review card
+ * on the Study hub (#1832). Shows one due prompt at a time; "Recall it"
+ * completes the item, "Later" cycles to the next due item.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Clock } from 'lucide-react-native';
+import { formatChapterRef } from '../../services/guidedStudy';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { GuidedReviewItem } from '../../types';
+
+interface Props {
+  item: GuidedReviewItem;
+  dueCount: number;
+  onRecall: () => void;
+  onLater: () => void;
+}
+
+export function ReviewRecallCard({ item, dueCount, onRecall, onLater }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.border }]}
+    >
+      <View style={styles.header}>
+        <Clock size={14} color={base.gold} />
+        <Text style={[styles.headerText, { color: base.textMuted }]}>
+          {formatChapterRef(item.chapter_id)}
+          {dueCount > 1 ? `  ·  1 of ${dueCount} due` : ''}
+        </Text>
+      </View>
+
+      <Text style={[styles.prompt, { color: base.text }]}>{item.prompt}</Text>
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          onPress={onRecall}
+          activeOpacity={0.72}
+          style={[styles.action, { borderColor: `${base.gold}55` }]}
+          accessibilityRole="button"
+          accessibilityLabel="Recall it — mark this review complete"
+        >
+          <Text style={[styles.actionLabel, { color: base.gold }]}>Recall it</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={onLater}
+          activeOpacity={0.72}
+          style={[styles.action, { borderColor: base.border }]}
+          accessibilityRole="button"
+          accessibilityLabel="Later — show the next due review"
+        >
+          <Text style={[styles.actionLabel, { color: base.textMuted }]}>Later</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  headerText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
+    letterSpacing: 0.4,
+  },
+  prompt: {
+    fontFamily: fontFamily.body,
+    fontSize: 17,
+    lineHeight: 24,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  action: {
+    flex: 1,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  actionLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 13,
+  },
+});

--- a/app/src/components/study/RhythmLine.tsx
+++ b/app/src/components/study/RhythmLine.tsx
@@ -1,0 +1,56 @@
+/**
+ * components/study/RhythmLine.tsx — One italic Garamond sentence
+ * describing this week's study rhythm (#1832). Deliberately NOT a
+ * streak: no counters, no flames, no emojis — just a gentle cadence
+ * observation derived from getWeeklyRhythm().
+ */
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import type { WeeklyRhythm } from '../../services/study';
+import { fontFamily, spacing, useTheme } from '../../theme';
+
+const NUMBER_WORDS = [
+  'no', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten',
+];
+
+function asWord(n: number): string {
+  return n >= 0 && n < NUMBER_WORDS.length ? NUMBER_WORDS[n] : String(n);
+}
+
+/** Pure sentence builder — exported for tests. */
+export function buildRhythmSentence(rhythm: WeeklyRhythm[]): string {
+  const week = rhythm.length > 0 ? rhythm[rhythm.length - 1] : null;
+  const sessions = week?.sessions ?? 0;
+  const reviews = week?.reviews ?? 0;
+
+  if (sessions === 0 && reviews === 0) {
+    const previous = rhythm.length > 1 ? rhythm[rhythm.length - 2] : null;
+    const wasActive = (previous?.sessions ?? 0) + (previous?.reviews ?? 0) > 0;
+    return wasActive
+      ? 'A quiet week so far — the text will keep until you return.'
+      : 'A quiet stretch — one unhurried session would begin a rhythm.';
+  }
+
+  const parts: string[] = [];
+  if (sessions > 0) parts.push(`${asWord(sessions)} ${sessions === 1 ? 'session' : 'sessions'}`);
+  if (reviews > 0) parts.push(`${asWord(reviews)} ${reviews === 1 ? 'review' : 'reviews'}`);
+  const summary = parts.join(' and ');
+  const sentence = `${summary} this week — a steady rhythm of study.`;
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+}
+
+export function RhythmLine({ rhythm }: { rhythm: WeeklyRhythm[] }) {
+  const { base } = useTheme();
+  return (
+    <Text style={[styles.line, { color: base.textMuted }]}>{buildRhythmSentence(rhythm)}</Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  line: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 14,
+    lineHeight: 21,
+    paddingHorizontal: spacing.xs,
+  },
+});

--- a/app/src/config/featureFlags.ts
+++ b/app/src/config/featureFlags.ts
@@ -19,6 +19,17 @@ export const FEATURE_FLAGS = {
    * When false, premium users get the structured-form synthesis path.
    */
   GUIDED_STUDY_AMICUS_SYNTHESIS: false,
+
+  /**
+   * Unified Study System (#1830): makes StudyHubScreen the root of the
+   * Explore/Study tab instead of ExploreMenuScreen. Before flipping true
+   * (#1838, only after on-device verification of the whole spine):
+   *   - Continue hero resumes the active plan into StudySession correctly.
+   *   - Review card cycles due items and completes them.
+   *   - Flag-off behavior is byte-for-byte identical to master.
+   * When false, the Explore tab renders ExploreMenuScreen exactly as today.
+   */
+  study_hub: false,
 } as const;
 
 /** Compile-time feature flag key (distinct from the env-driven EnvFeatureFlag). */

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -255,6 +255,10 @@ export async function getStudyPlans(includeArchived = false): Promise<StudyPlan[
   );
 }
 
+export async function getStudyPlan(planId: string): Promise<StudyPlan | null> {
+  return getUserDb().getFirstAsync<StudyPlan>('SELECT * FROM study_plans WHERE id = ?', [planId]);
+}
+
 export async function getStudyPlanItems(planId: string): Promise<StudyPlanItem[]> {
   return getUserDb().getAllAsync<StudyPlanItem>(
     'SELECT * FROM study_plan_items WHERE plan_id = ? ORDER BY item_num',

--- a/app/src/hooks/useContinuePlan.ts
+++ b/app/src/hooks/useContinuePlan.ts
@@ -1,0 +1,83 @@
+/**
+ * hooks/useContinuePlan.ts — Data for the Study hub's Continue hero
+ * (#1832): the active plan, its items (for the chapter trail ticks),
+ * the resume target, and a minutes estimate for the next chapter from
+ * services/guidedStudy/estimate.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { getChapterPanels, getSectionPanels, getSections, getVerses } from '../db/content';
+import { getStudyPlanItems } from '../db/userQueries';
+import { getStudyDepthEstimate } from '../services/guidedStudy';
+import { getActivePlan, resumeTarget, type ResumeTarget } from '../services/study';
+import type { SectionPanel, StudyPlan, StudyPlanItem } from '../types';
+import { logger } from '../utils/logger';
+
+export interface ContinuePlanState {
+  plan: StudyPlan | null;
+  items: StudyPlanItem[];
+  target: ResumeTarget | null;
+  /** Estimated minutes for the next chapter (null while loading/unknown). */
+  estimateMin: number | null;
+  isLoading: boolean;
+  reload: () => Promise<void>;
+}
+
+export function useContinuePlan(): ContinuePlanState {
+  const [plan, setPlan] = useState<StudyPlan | null>(null);
+  const [items, setItems] = useState<StudyPlanItem[]>([]);
+  const [target, setTarget] = useState<ResumeTarget | null>(null);
+  const [estimateMin, setEstimateMin] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const activePlan = await getActivePlan();
+      if (!activePlan) {
+        setPlan(null);
+        setItems([]);
+        setTarget(null);
+        setEstimateMin(null);
+        return;
+      }
+
+      const [planItems, nextTarget] = await Promise.all([
+        getStudyPlanItems(activePlan.id),
+        resumeTarget(activePlan.id),
+      ]);
+      setPlan(activePlan);
+      setItems(planItems);
+      setTarget(nextTarget);
+
+      if (!nextTarget) {
+        setEstimateMin(null);
+        return;
+      }
+
+      // Minutes for the next chapter, from the same estimator the
+      // session screens use. Deep plans read the deep figure; every
+      // other mode maps to the guided figure.
+      const chapterId = `${nextTarget.bookId}_${nextTarget.chapterNum}`;
+      const [verses, sections, chapterPanels] = await Promise.all([
+        getVerses(nextTarget.bookId, nextTarget.chapterNum),
+        getSections(chapterId),
+        getChapterPanels(chapterId),
+      ]);
+      const sectionPanels: SectionPanel[] = (
+        await Promise.all(sections.map((s) => getSectionPanels(s.id)))
+      ).flat();
+      const estimate = getStudyDepthEstimate(verses, sectionPanels, chapterPanels);
+      setEstimateMin(activePlan.default_mode === 'deep' ? estimate.deepMin : estimate.guidedMin);
+    } catch (err) {
+      logger.warn('useContinuePlan', 'Failed to load continue-plan state', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { plan, items, target, estimateMin, isLoading, reload };
+}

--- a/app/src/hooks/useReducedMotion.ts
+++ b/app/src/hooks/useReducedMotion.ts
@@ -1,0 +1,29 @@
+/**
+ * hooks/useReducedMotion.ts — Tracks the OS "reduce motion" setting.
+ * Decorative animations (e.g. the Study hub's current-tick glow, #1832)
+ * must render statically when this returns true.
+ */
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((value) => {
+        if (mounted) setReduced(value);
+      })
+      .catch(() => {
+        /* default to full motion */
+      });
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduced);
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+
+  return reduced;
+}

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
+import { isFlagEnabled } from '../config/featureFlags';
 import ExploreMenuScreen from '../screens/ExploreMenuScreen';
+import StudyHubScreen from '../screens/StudyHubScreen';
 import { useTheme } from '../theme';
 import type { ExploreStackParamList } from './types';
 import { lazySuspense } from './lazySuspense';
@@ -63,12 +65,16 @@ export function ExploreStack() {
 
   return (
     <Stack.Navigator
+      // study_hub (#1832) is a compile-time flag, so the initial route is
+      // fixed for the lifetime of the process — no remount concerns.
+      initialRouteName={isFlagEnabled('study_hub') ? 'StudyHub' : 'ExploreMenu'}
       screenOptions={{
         headerShown: false,
         cardStyle: { backgroundColor: base.bg },
         gestureEnabled: true,
       }}
     >
+      <Stack.Screen name="StudyHub" component={StudyHubScreen} />
       <Stack.Screen name="ExploreMenu" component={ExploreMenuScreen} />
       <Stack.Screen
         name="GenealogyTree"

--- a/app/src/navigation/ExploreStack.tsx
+++ b/app/src/navigation/ExploreStack.tsx
@@ -57,6 +57,8 @@ const SubmissionDetailScreen = lazySuspense(() => import('../screens/SubmissionD
 const SubmissionFeedScreen = lazySuspense(() => import('../screens/SubmissionFeedScreen'));
 const ChapterScreen = lazySuspense(() => import('../screens/ChapterScreen'));
 const StudySessionScreen = lazySuspense(() => import('../screens/StudySessionScreen'));
+const PlanPickerScreen = lazySuspense(() => import('../screens/PlanPickerScreen'));
+const StudyPlanDetailScreen = lazySuspense(() => import('../screens/StudyPlanDetailScreen'));
 
 const Stack = createStackNavigator<ExploreStackParamList>();
 
@@ -133,6 +135,12 @@ export function ExploreStack() {
       <Stack.Screen name="SubmissionFeed" component={SubmissionFeedScreen} />
       <Stack.Screen name="Chapter" component={ChapterScreen} />
       <Stack.Screen name="StudySession" component={StudySessionScreen} />
+      <Stack.Screen
+        name="PlanPicker"
+        component={PlanPickerScreen}
+        options={{ presentation: 'modal' }}
+      />
+      <Stack.Screen name="StudyPlanDetail" component={StudyPlanDetailScreen} />
     </Stack.Navigator>
   );
 }

--- a/app/src/navigation/TabNavigator.tsx
+++ b/app/src/navigation/TabNavigator.tsx
@@ -1,5 +1,6 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Home, Library, Compass, Search, MessageSquare, MoreHorizontal } from 'lucide-react-native';
+import { Home, Library, GraduationCap, Search, MessageSquare, MoreHorizontal } from 'lucide-react-native';
+import { isFlagEnabled } from '../config/featureFlags';
 import { useSettingsStore } from '../stores';
 import { useTheme } from '../theme';
 import { AmicusStack } from './AmicusStack';
@@ -65,12 +66,17 @@ export function TabNavigator() {
         name="ExploreTab"
         component={ExploreStack}
         options={{
-          tabBarLabel: 'Explore',
-          tabBarIcon: ({ color, size }) => <Compass color={color} size={size} />,
+          tabBarLabel: 'Study',
+          tabBarIcon: ({ color, size }) => <GraduationCap color={color} size={size} />,
         }}
         listeners={({ navigation }) => ({
           tabPress: () => {
-            navigation.navigate('ExploreTab', { screen: 'ExploreMenu' });
+            // Route names are stable (#1832): the tab renames to Study but the
+            // stack/routes stay ExploreTab/ExploreMenu. The hub only becomes
+            // the tab-press target behind the study_hub flag.
+            navigation.navigate('ExploreTab', {
+              screen: isFlagEnabled('study_hub') ? 'StudyHub' : 'ExploreMenu',
+            });
           },
         })}
       />

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -77,6 +77,9 @@ export type HomeStackParamList = {
 
 export type ExploreStackParamList = {
   ExploreMenu: undefined;
+  // Unified Study System hub (#1832) — root of the tab when the
+  // `study_hub` feature flag is on; ExploreMenu stays the fallback root.
+  StudyHub: undefined;
   GenealogyTree: { personId?: string } | undefined;
   PersonDetail: { personId: string };
   Map: { storyId?: string; placeId?: string; personId?: string };

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -25,6 +25,12 @@ export interface StudySessionParam {
   chapterNum: number;
   initialStep?: GuidedStudyStep;
   verseNum?: number;
+  /**
+   * Unified study plan the session belongs to (#1833). When set,
+   * completing the session also completes/links the matching
+   * study_plan_items row.
+   */
+  planId?: string;
 }
 
 export type ReadStackParamList = {
@@ -80,6 +86,11 @@ export type ExploreStackParamList = {
   // Unified Study System hub (#1832) — root of the tab when the
   // `study_hub` feature flag is on; ExploreMenu stays the fallback root.
   StudyHub: undefined;
+  // One-decision plan picker (#1833), presented as a modal sheet.
+  PlanPicker: { segment?: 'book' | 'journey' | 'topic' } | undefined;
+  // Unified plan detail (#1833). Distinct from the legacy PlanDetail
+  // (reading plans) on Home/More stacks — do not conflate.
+  StudyPlanDetail: { planId: string };
   GenealogyTree: { personId?: string } | undefined;
   PersonDetail: { personId: string };
   Map: { storyId?: string; placeId?: string; personId?: string };

--- a/app/src/screens/ExploreMenuScreen.tsx
+++ b/app/src/screens/ExploreMenuScreen.tsx
@@ -3,10 +3,11 @@
  *   1. Jump-to category pills (horizontal scroll)
  *   2. Start Here banner (new users, chaptersRead < 5)
  *   3. Recommended for You with editorial RecommendedCards
- *   4. Horizontal feature carousels with image cards + count CTAs
+ *   4. Library shelves (components/study/LibrarySections — extracted in
+ *      #1832 so the Study hub renders the same sections)
  *   5. Gold separators between sections
  *
- * Part of Epic #1071 (#1077).
+ * Part of Epic #1071 (#1077); flag-off root of the Study tab (#1830).
  */
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
@@ -19,99 +20,16 @@ import { useTheme, spacing, fontFamily } from '../theme';
 import { usePremium } from '../hooks/usePremium';
 import { useExploreRecommendations } from '../hooks/useExploreRecommendations';
 import { useExploreImages } from '../hooks/useExploreImages';
-import { FeatureCard, CARD_WIDTH, type FeatureCardData } from '../components/FeatureCard';
 import { RecommendedCard } from '../components/RecommendedCard';
 import { StartHereBanner } from '../components/StartHereBanner';
 import { UpgradePrompt } from '../components/UpgradePrompt';
-import { JourneyBrowseSection } from '../components/JourneyBrowseSection';
 import {
-  ProphecyChainCard,
-  DebatePreviewList,
-  WordStudyPreviewList,
-  LifeTopicGrid,
-  FullWidthImageCard,
-  GlossySectionWrapper,
-  PROPHECY_CHAIN_CARD_WIDTH,
-} from '../components/explore';
-import { useProphecyChains } from '../hooks/useProphecyChains';
+  LibrarySections,
+  LIBRARY_SECTIONS,
+  PREMIUM_SCREENS,
+} from '../components/study/LibrarySections';
 import { getReadingStats, getPreference, setPreference } from '../db/user';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
-
-// ── Section data ───────────────────────────────────────────────
-
-interface FeatureSection {
-  id: string;
-  label: string;
-  subtitle: string;
-  features: FeatureCardData[];
-}
-
-const PREMIUM_SCREENS: Record<string, string> = {
-  Concordance: 'Concordance Search',
-  ContentLibrary: 'Content Library',
-  ThreadBrowse: 'Cross-Reference Threading',
-  HowWeGotTheBibleLanding: 'How We Got The Bible',
-};
-
-const SECTIONS: FeatureSection[] = [
-  {
-    id: 'biblical-world', label: 'The Biblical World', subtitle: 'Where, when, and who',
-    features: [
-      { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                color: '#e86040', screen: 'GenealogyTree' }, // data-color: intentional
-      { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        color: '#70b8e8', screen: 'Timeline' }, // data-color: intentional
-      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
-      { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    color: '#8a6e3a', screen: 'Periods', premium: true }, // data-color: intentional
-      { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          color: '#c8a040', screen: 'RedemptiveArc', premium: true }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'themes', label: 'Themes & Connections', subtitle: 'Trace ideas across Scripture',
-    features: [
-      { title: 'Guided Journeys',    subtitle: '60 journeys \u2014 people, concepts, themes',             color: '#bfa050', screen: 'JourneyBrowse' }, // data-color: intentional
-      { title: 'Topical Index',      subtitle: 'What does the Bible say about...?',                    color: '#c8a040', screen: 'TopicBrowse' }, // data-color: intentional
-      { title: 'Prophecy',           subtitle: '50 chains \u2014 OT to NT fulfillment',                color: '#e8a070', screen: 'ProphecyBrowse' }, // data-color: intentional
-      { title: 'Threads',            subtitle: 'One idea across 31 chains',                            color: '#9090e0', screen: 'ThreadBrowse', premium: true }, // data-color: intentional
-      { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                color: '#70d098', screen: 'HarmonyBrowse' }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'journeys', label: 'Journeys', subtitle: 'Follow a life or trace an idea across Scripture',
-    features: [], // Custom renderer — uses JourneyBrowseSection instead of FeatureCards
-  },
-  {
-    id: 'language', label: 'Language & Reference', subtitle: 'Original words and definitions',
-    features: [
-      { title: 'Word Studies', subtitle: 'Hebrew & Greek deep dives',                                  color: '#e890b8', screen: 'WordStudyBrowse' }, // data-color: intentional
-      { title: 'Concordance',  subtitle: 'Every occurrence of a word',                                 color: '#70b8e8', screen: 'Concordance', premium: true }, // data-color: intentional
-      { title: 'Dictionary',   subtitle: 'Definitions for every biblical term',                         color: '#c090e0', screen: 'DictionaryBrowse' }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'scholarly', label: 'Scholarly Analysis', subtitle: 'Academic perspectives & debate',
-    features: [
-      { title: 'Scholars',             subtitle: 'Browse all 54 by tradition',                            color: '#a0b8d0', screen: 'ScholarBrowse' }, // data-color: intentional
-      { title: 'Debates',              subtitle: '303 topics where scholars disagree',                    color: '#d08080', screen: 'DebateBrowse' }, // data-color: intentional
-      { title: 'Difficult Passages',   subtitle: '53 hard texts with multi-view responses',               color: '#FFB74D', screen: 'DifficultPassagesBrowse' }, // data-color: intentional
-      { title: 'How We Got The Bible', subtitle: 'Canon, manuscripts, translations, and the books Jude quoted', color: '#c89858', screen: 'HowWeGotTheBibleLanding', premium: true }, // data-color: intentional
-      { title: 'Content Library',      subtitle: 'Discourse, manuscripts & more',                          color: '#b8a0d0', screen: 'ContentLibrary', premium: true }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'life', label: 'Life & Faith', subtitle: 'Biblical guidance for everyday life',
-    features: [
-      { title: 'Life Topics', subtitle: 'Practical guidance from Scripture',                             color: '#81C784', screen: 'LifeTopics' }, // data-color: intentional
-    ],
-  },
-  {
-    id: 'deep-dive', label: 'Deep Dive', subtitle: 'Advanced study tools',
-    features: [
-      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
-      { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                color: '#b07d4f', screen: 'ArchaeologyBrowse' }, // data-color: intentional
-      { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   color: '#8a6a3a', screen: 'TimeTravelBrowse' }, // data-color: intentional
-      { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  color: '#7a9ab0', screen: 'GrammarBrowse' }, // data-color: intentional
-    ],
-  },
-];
 
 // ── Component ──────────────────────────────────────────────────
 
@@ -123,7 +41,6 @@ function ExploreMenuScreen() {
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const { recommendations, bookName } = useExploreRecommendations();
   const imageRegistry = useExploreImages();
-  const { chains: prophecyChains } = useProphecyChains();
 
   const [activeJump, setActiveJump] = useState<string | null>(null);
   const [chaptersRead, setChaptersRead] = useState<number | null>(null);
@@ -137,7 +54,7 @@ function ExploreMenuScreen() {
   // ── Preload initial card images on mount ───────────────────
   useEffect(() => {
     const urls: string[] = [];
-    for (const section of SECTIONS.slice(0, 2)) {
+    for (const section of LIBRARY_SECTIONS.slice(0, 2)) {
       for (const f of section.features.slice(0, 3)) {
         const fi = imageRegistry[f.screen];
         if (fi?.images?.[0]) urls.push(fi.images[0].url);
@@ -171,237 +88,12 @@ function ExploreMenuScreen() {
     setActiveJump((prev) => prev === sectionId ? null : sectionId);
   }, []);
 
-  // ── Image lookup (flat registry keyed by screen name) ──────
   const getScreenImages = useCallback((screenName: string) => {
     return imageRegistry[screenName];
   }, [imageRegistry]);
 
-  const handleProphecyPress = useCallback((chainId: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('ProphecyDetail' as any, { chainId } as any);
-  }, [navigation]);
-
-  const handleDebatePress = useCallback((debateId: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('DebateDetail' as any, { topicId: debateId } as any);
-  }, [navigation]);
-
-  const handleWordStudyPress = useCallback((id: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('WordStudyDetail' as any, { wordId: id } as any);
-  }, [navigation]);
-
-  const handleLifeCategoryPress = useCallback((categoryId: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    navigation.navigate('LifeTopics' as any, { categoryId } as any);
-  }, [navigation]);
-
   const showStartHere = chaptersRead !== null && chaptersRead < 5 && !startHereDismissed;
   const showRecommendations = !showStartHere && recommendations.length > 0;
-  const filteredSections = activeJump ? SECTIONS.filter((s) => s.id === activeJump) : SECTIONS;
-
-  // ── Per-section content renderer ────────────────────────────
-  const renderSectionContent = (section: FeatureSection) => {
-    switch (section.id) {
-      case 'journeys':
-        return <JourneyBrowseSection />;
-      case 'themes':
-        return (
-          <View style={styles.sectionGap}>
-            {prophecyChains.length > 0 && (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.carouselContent}
-                decelerationRate="fast"
-                snapToInterval={PROPHECY_CHAIN_CARD_WIDTH + spacing.sm}
-              >
-                {prophecyChains.slice(0, 4).map((chain) => (
-                  <ProphecyChainCard
-                    key={chain.id}
-                    chain={chain}
-                    onPress={() => handleProphecyPress(chain.id)}
-                  />
-                ))}
-              </ScrollView>
-            )}
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.carouselContent}
-              decelerationRate="fast"
-            >
-              {section.features.map((f, cardIndex) => {
-                const imgData = getScreenImages(f.screen);
-                return (
-                  <FeatureCard
-                    key={f.screen}
-                    feature={f}
-                    onPress={() => handleNavigate(f.screen)}
-                    isPremium={isPremium}
-                    images={imgData?.images}
-                    count={imgData?.count}
-                    noun={imgData?.noun}
-                    onImagePress={handleDeepLink}
-                    staggerMs={cardIndex * 1200}
-                    compact
-                  />
-                );
-              })}
-            </ScrollView>
-          </View>
-        );
-      case 'scholarly': {
-        // Debates renders as the preview strip above; everything else flows
-        // into the horizontal carousel below. Denylist (vs. allowlist) so
-        // future cards added to SECTIONS surface automatically — same
-        // pattern as the 'language' case for WordStudyBrowse.
-        const carouselFeatures = section.features.filter(
-          (f) => f.screen !== 'DebateBrowse',
-        );
-        const totalDebates = getScreenImages('DebateBrowse')?.count ?? undefined;
-        return (
-          <View style={styles.sectionGap}>
-            <DebatePreviewList
-              onDebatePress={handleDebatePress}
-              onSeeAll={() => handleNavigate('DebateBrowse')}
-              totalCount={totalDebates ?? undefined}
-            />
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.carouselContent}
-              decelerationRate="fast"
-            >
-              {carouselFeatures.map((f, cardIndex) => {
-                const imgData = getScreenImages(f.screen);
-                return (
-                  <FeatureCard
-                    key={f.screen}
-                    feature={f}
-                    onPress={() => handleNavigate(f.screen)}
-                    isPremium={isPremium}
-                    images={imgData?.images}
-                    count={imgData?.count}
-                    noun={imgData?.noun}
-                    onImagePress={handleDeepLink}
-                    staggerMs={cardIndex * 1200}
-                    compact
-                  />
-                );
-              })}
-            </ScrollView>
-          </View>
-        );
-      }
-      case 'language': {
-        const splitFeatures = section.features.filter(
-          (f) => f.screen !== 'WordStudyBrowse',
-        );
-        const totalWords = getScreenImages('WordStudyBrowse')?.count ?? undefined;
-        return (
-          <View style={styles.sectionGap}>
-            <WordStudyPreviewList
-              onWordPress={handleWordStudyPress}
-              onSeeAll={() => handleNavigate('WordStudyBrowse')}
-              totalCount={totalWords ?? undefined}
-            />
-            <View style={styles.row3}>
-              {splitFeatures.map((f, i) => {
-                const imgData = getScreenImages(f.screen);
-                return (
-                  <View key={f.screen} style={styles.rowCell}>
-                    <FeatureCard
-                      feature={f}
-                      onPress={() => handleNavigate(f.screen)}
-                      isPremium={isPremium}
-                      images={imgData?.images}
-                      count={imgData?.count}
-                      noun={imgData?.noun}
-                      onImagePress={handleDeepLink}
-                      staggerMs={i * 1200}
-                      compact
-                    />
-                  </View>
-                );
-              })}
-            </View>
-          </View>
-        );
-      }
-      case 'life': {
-        const lifeImage = getScreenImages('LifeTopics');
-        return (
-          <View style={styles.sectionGap}>
-            <FullWidthImageCard
-              title="Life Topics"
-              subtitle="Practical guidance from Scripture"
-              image={lifeImage?.images?.[0] ?? null}
-              count={lifeImage?.count ?? null}
-              noun={lifeImage?.noun}
-              onPress={() => handleNavigate('LifeTopics')}
-            />
-            <LifeTopicGrid onCategoryPress={handleLifeCategoryPress} />
-          </View>
-        );
-      }
-      case 'deep-dive':
-        return (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.carouselContent}
-            decelerationRate="fast"
-            snapToInterval={CARD_WIDTH + spacing.sm}
-          >
-            {section.features.map((f, cardIndex) => {
-              const imgData = getScreenImages(f.screen);
-              return (
-                <FeatureCard
-                  key={f.screen}
-                  feature={f}
-                  onPress={() => handleNavigate(f.screen)}
-                  isPremium={isPremium}
-                  images={imgData?.images}
-                  count={imgData?.count}
-                  noun={imgData?.noun}
-                  onImagePress={handleDeepLink}
-                  staggerMs={cardIndex * 1200}
-                />
-              );
-            })}
-          </ScrollView>
-        );
-      case 'biblical-world':
-      default:
-        return (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.carouselContent}
-            decelerationRate="fast"
-            snapToInterval={CARD_WIDTH + spacing.sm}
-          >
-            {section.features.map((f, cardIndex) => {
-              const imgData = getScreenImages(f.screen);
-              return (
-                <FeatureCard
-                  key={f.screen}
-                  feature={f}
-                  onPress={() => handleNavigate(f.screen)}
-                  isPremium={isPremium}
-                  images={imgData?.images}
-                  count={imgData?.count}
-                  noun={imgData?.noun}
-                  onImagePress={handleDeepLink}
-                  staggerMs={cardIndex * 1200}
-                />
-              );
-            })}
-          </ScrollView>
-        );
-    }
-  };
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
@@ -415,7 +107,7 @@ function ExploreMenuScreen() {
           contentContainerStyle={styles.pillScroll}
           style={styles.pillContainer}
         >
-          {SECTIONS.map((s) => (
+          {LIBRARY_SECTIONS.map((s) => (
             <TouchableOpacity
               key={s.id}
               onPress={() => handleJumpTo(s.id)}
@@ -471,18 +163,14 @@ function ExploreMenuScreen() {
           </View>
         )}
 
-        {/* ── Sections with varied layouts ─── */}
-        {filteredSections.map((section, sectionIndex) => (
-          <View key={section.id}>
-            <GlossySectionWrapper sectionIndex={sectionIndex}>
-              <View style={styles.section}>
-                <Text style={[styles.sectionLabel, { color: base.gold }]}>{section.label}</Text>
-                <Text style={[styles.sectionSubtitle, { color: base.textMuted }]}>{section.subtitle}</Text>
-                {renderSectionContent(section)}
-              </View>
-            </GlossySectionWrapper>
-          </View>
-        ))}
+        {/* ── Library shelves (shared with the Study hub) ─── */}
+        <LibrarySections
+          imageRegistry={imageRegistry}
+          isPremium={isPremium}
+          onNavigate={handleNavigate}
+          onDeepLink={handleDeepLink}
+          filterSectionId={activeJump}
+        />
 
         {/* Show all link when filtered */}
         {activeJump && (
@@ -529,18 +217,8 @@ const styles = StyleSheet.create({
   recsLabel: { fontFamily: fontFamily.uiMedium, fontSize: 10, letterSpacing: 1, marginBottom: 2 },
   recsSubtitle: { fontFamily: fontFamily.ui, fontSize: 10, marginBottom: spacing.sm },
 
-  // Sections
-  section: { marginBottom: spacing.md },
-  sectionLabel: { fontFamily: fontFamily.displayMedium, fontSize: 13, letterSpacing: 0.5, marginBottom: 2 },
-  sectionSubtitle: { fontFamily: fontFamily.ui, fontSize: 11, marginBottom: spacing.sm },
-
   // Carousels
   carouselContent: { gap: spacing.sm },
-
-  // Split/grid rows
-  sectionGap: { gap: spacing.md },
-  row3: { flexDirection: 'row', gap: spacing.sm },
-  rowCell: { flex: 1 },
 
   // Show all
   showAllBtn: {

--- a/app/src/screens/JourneyDetailScreen.tsx
+++ b/app/src/screens/JourneyDetailScreen.tsx
@@ -6,10 +6,13 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
+import { GraduationCap } from 'lucide-react-native';
 import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { startStudyPlan } from '../services/study';
+import { logger } from '../utils/logger';
 import { useJourneyDetail } from '../hooks/useJourneyDetail';
 import { usePremium } from '../hooks/usePremium';
 import { ScreenHeader } from '../components/ScreenHeader';
@@ -18,7 +21,7 @@ import { JourneyStopsTimeline } from '../components/JourneyStopsTimeline';
 import { LinkedJourneySheet } from '../components/LinkedJourneySheet';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { BadgeChip } from '../components/BadgeChip';
-import { useTheme, spacing, fontFamily } from '../theme';
+import { useTheme, spacing, fontFamily, radii } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 const FREE_STOP_COUNT = 3;
@@ -55,6 +58,34 @@ function JourneyDetailScreen() {
     setLinkedSheetJourneyId(null);
     setLinkedSheetIntro(null);
   }, []);
+
+  // "Study this journey" (#1833): adopt the journey as a unified study
+  // plan and open session 1 directly — one decision, no mode prompt.
+  const [startingPlan, setStartingPlan] = useState(false);
+  const handleStudyJourney = useCallback(async () => {
+    if (!journey || startingPlan) return;
+    setStartingPlan(true);
+    try {
+      const started = await startStudyPlan({
+        planType: 'journey',
+        sourceId: journey.id,
+        title: journey.title,
+      });
+      if (!started) {
+        logger.warn('JourneyDetail', `Journey "${journey.id}" has no scripture stops to study`);
+        return;
+      }
+      navigation.navigate('StudySession', {
+        bookId: started.firstRef.bookId,
+        chapterNum: started.firstRef.chapterNum,
+        planId: started.planId,
+      });
+    } catch (err) {
+      logger.warn('JourneyDetail', 'Failed to start journey plan', err);
+    } finally {
+      setStartingPlan(false);
+    }
+  }, [journey, navigation, startingPlan]);
 
   if (isLoading) {
     return (
@@ -108,6 +139,19 @@ function JourneyDetailScreen() {
             {journey.description}
           </Text>
         ) : null}
+
+        {/* Study this journey (#1833) */}
+        <TouchableOpacity
+          onPress={handleStudyJourney}
+          disabled={startingPlan}
+          activeOpacity={0.72}
+          accessibilityRole="button"
+          accessibilityLabel={`Study this journey: ${journey.title}`}
+          style={[styles.studyButton, { backgroundColor: base.gold }]}
+        >
+          <GraduationCap size={16} color={base.bg} />
+          <Text style={[styles.studyButtonLabel, { color: base.bg }]}>Study this journey</Text>
+        </TouchableOpacity>
 
         {/* Stops Timeline */}
         <View style={styles.timelineSection}>
@@ -201,6 +245,20 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     paddingHorizontal: spacing.md,
     marginBottom: spacing.lg,
+  },
+  studyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 44,
+    borderRadius: radii.md,
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  studyButtonLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
   },
   timelineSection: {
     paddingHorizontal: spacing.md,

--- a/app/src/screens/PlanPickerScreen.tsx
+++ b/app/src/screens/PlanPickerScreen.tsx
@@ -1,0 +1,322 @@
+/**
+ * PlanPickerScreen — One-decision plan picker (#1833), presented as a
+ * modal sheet on the Explore/Study stack. Segments: Book / Journey /
+ * Topic. Picking a source creates a unified study plan (mode comes
+ * from the last mode used in a session — the picker NEVER asks) and
+ * replaces itself with the first session.
+ *
+ * Book segment order: pinned "Continue where you're reading" (from
+ * most-recent reading_progress), starter books (books.json meta
+ * `starter: true`, rendered only when the data is present — see #1833
+ * pipeline note), then all live books grouped by testament. No
+ * hardcoded book lists.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { BookMarked, ChevronRight } from 'lucide-react-native';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { ScreenHeader } from '../components/ScreenHeader';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { getTopics } from '../db/content';
+import { getAllJourneys } from '../db/content/features';
+import { getRecentChapters } from '../db/userQueries';
+import { useBooks } from '../hooks';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { startStudyPlan } from '../services/study';
+import { fontFamily, radii, spacing, useTheme } from '../theme';
+import type { Journey, RecentChapter } from '../types';
+import type { Topic } from '../types/topic';
+import { logger } from '../utils/logger';
+
+type Segment = 'book' | 'journey' | 'topic';
+
+const SEGMENTS: Array<{ key: Segment; label: string }> = [
+  { key: 'book', label: 'Book' },
+  { key: 'journey', label: 'Journey' },
+  { key: 'topic', label: 'Topic' },
+];
+
+/** Topics qualify only when they carry relevant chapters to study. */
+function topicHasChapters(topic: Topic): boolean {
+  try {
+    const parsed: unknown = JSON.parse(topic.relevant_chapters_json ?? '[]');
+    return Array.isArray(parsed) && parsed.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function PlanPickerScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'PlanPicker'>>();
+  const route = useRoute<ScreenRouteProp<'Explore', 'PlanPicker'>>();
+  const [segment, setSegment] = useState<Segment>(route.params?.segment ?? 'book');
+
+  const { liveBooks } = useBooks();
+  const [recent, setRecent] = useState<RecentChapter | null>(null);
+  const [journeys, setJourneys] = useState<Journey[]>([]);
+  const [topics, setTopics] = useState<Topic[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [recentRows, journeyRows, topicRows] = await Promise.all([
+          getRecentChapters(1),
+          getAllJourneys(),
+          getTopics(),
+        ]);
+        if (cancelled) return;
+        setRecent(recentRows[0] ?? null);
+        setJourneys(journeyRows);
+        setTopics(topicRows.filter(topicHasChapters));
+      } catch (err) {
+        logger.warn('PlanPicker', 'Failed to load picker sources', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const starterBooks = useMemo(() => liveBooks.filter((b) => !!b.starter), [liveBooks]);
+  const otBooks = useMemo(() => liveBooks.filter((b) => b.testament === 'ot'), [liveBooks]);
+  const ntBooks = useMemo(() => liveBooks.filter((b) => b.testament === 'nt'), [liveBooks]);
+
+  /**
+   * Create the plan and replace the modal with the session — one
+   * decision, zero extra hops. `openAt` overrides the target chapter
+   * for the pinned continue row.
+   */
+  const start = useCallback(
+    async (
+      planType: 'book' | 'journey' | 'topical',
+      sourceId: string,
+      title: string,
+      openAt?: { bookId: string; chapterNum: number },
+    ) => {
+      if (busy) return;
+      setBusy(true);
+      setNotice(null);
+      try {
+        const started = await startStudyPlan({ planType, sourceId, title });
+        if (!started) {
+          setNotice('Nothing to study there yet — try another pick.');
+          return;
+        }
+        navigation.replace('StudySession', {
+          bookId: openAt?.bookId ?? started.firstRef.bookId,
+          chapterNum: openAt?.chapterNum ?? started.firstRef.chapterNum,
+          planId: started.planId,
+        });
+      } catch (err) {
+        logger.warn('PlanPicker', 'Failed to start study plan', err);
+        setNotice('Could not start that study. Please try again.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, navigation],
+  );
+
+  const renderRow = (
+    key: string,
+    title: string,
+    subtitle: string | null,
+    onPress: () => void,
+    pinned = false,
+  ) => (
+    <TouchableOpacity
+      key={key}
+      onPress={onPress}
+      disabled={busy}
+      activeOpacity={0.72}
+      accessibilityRole="button"
+      accessibilityLabel={`Study ${title}`}
+      style={[
+        styles.row,
+        {
+          backgroundColor: base.bgElevated,
+          borderColor: pinned ? `${base.gold}55` : base.border,
+        },
+      ]}
+    >
+      {pinned && <BookMarked size={16} color={base.gold} />}
+      <View style={styles.rowText}>
+        <Text style={[styles.rowTitle, { color: base.text }]}>{title}</Text>
+        {subtitle ? (
+          <Text style={[styles.rowSubtitle, { color: base.textMuted }]}>{subtitle}</Text>
+        ) : null}
+      </View>
+      <ChevronRight size={16} color={base.textMuted} />
+    </TouchableOpacity>
+  );
+
+  const sectionLabel = (label: string) => (
+    <Text key={`label-${label}`} style={[styles.sectionLabel, { color: base.textMuted }]}>
+      {label}
+    </Text>
+  );
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={styles.headerPad}>
+        <ScreenHeader title="Begin a study" onBack={() => navigation.goBack()} />
+      </View>
+
+      {/* ── Segments ─── */}
+      <View style={styles.segmentRow}>
+        {SEGMENTS.map((s) => {
+          const active = segment === s.key;
+          return (
+            <TouchableOpacity
+              key={s.key}
+              onPress={() => setSegment(s.key)}
+              activeOpacity={0.72}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={`${s.label} studies`}
+              style={[
+                styles.segment,
+                {
+                  borderColor: active ? base.gold : base.border,
+                  backgroundColor: active ? `${base.gold}12` : 'transparent',
+                },
+              ]}
+            >
+              <Text style={[styles.segmentLabel, { color: active ? base.gold : base.textMuted }]}>
+                {s.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {notice && <Text style={[styles.notice, { color: base.textMuted }]}>{notice}</Text>}
+
+      {loading ? (
+        <View style={styles.loadingPad}>
+          <LoadingSkeleton lines={8} />
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.content}>
+          {segment === 'book' && (
+            <>
+              {recent &&
+                renderRow(
+                  'continue-reading',
+                  "Continue where you're reading",
+                  `${recent.book_name} ${recent.chapter_num}`,
+                  () =>
+                    start('book', recent.book_id, recent.book_name, {
+                      bookId: recent.book_id,
+                      chapterNum: recent.chapter_num,
+                    }),
+                  true,
+                )}
+              {starterBooks.length > 0 && sectionLabel('GOOD PLACES TO BEGIN')}
+              {starterBooks.map((b) =>
+                renderRow(`starter-${b.id}`, b.name, `${b.total_chapters} chapters`, () =>
+                  start('book', b.id, b.name),
+                ),
+              )}
+              {otBooks.length > 0 && sectionLabel('OLD TESTAMENT')}
+              {otBooks.map((b) =>
+                renderRow(b.id, b.name, `${b.total_chapters} chapters`, () =>
+                  start('book', b.id, b.name),
+                ),
+              )}
+              {ntBooks.length > 0 && sectionLabel('NEW TESTAMENT')}
+              {ntBooks.map((b) =>
+                renderRow(b.id, b.name, `${b.total_chapters} chapters`, () =>
+                  start('book', b.id, b.name),
+                ),
+              )}
+            </>
+          )}
+
+          {segment === 'journey' &&
+            journeys.map((j) =>
+              renderRow(j.id, j.title, j.subtitle, () => start('journey', j.id, j.title)),
+            )}
+
+          {segment === 'topic' &&
+            topics.map((t) =>
+              renderRow(t.id, t.title, t.category, () => start('topical', t.id, t.title)),
+            )}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerPad: { paddingHorizontal: spacing.md, paddingTop: spacing.sm },
+  loadingPad: { padding: spacing.lg },
+  segmentRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  segment: {
+    flex: 1,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: radii.md,
+  },
+  segmentLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  notice: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.xs,
+  },
+  content: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.xxl,
+    gap: spacing.xs,
+  },
+  sectionLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 1,
+    marginTop: spacing.sm,
+    marginBottom: 2,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    minHeight: 52,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  rowText: { flex: 1 },
+  rowTitle: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: 16,
+  },
+  rowSubtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    marginTop: 1,
+  },
+});
+
+export default withErrorBoundary(PlanPickerScreen);

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
+import { BeginSomethingNew, type PlanPickerSegment } from '../components/study/BeginSomethingNew';
 import { ContinueHero } from '../components/study/ContinueHero';
 import {
   LibrarySections,
@@ -65,13 +66,26 @@ function StudyHubScreen() {
   );
 
   const handleResume = useCallback(() => {
-    if (!target) return;
+    if (!target || !plan) return;
     navigation.navigate('StudySession', {
       bookId: target.bookId,
       chapterNum: target.chapterNum,
+      planId: plan.id,
       ...(target.step ? { initialStep: target.step } : {}),
     });
-  }, [navigation, target]);
+  }, [navigation, plan, target]);
+
+  const handleOpenPlanDetail = useCallback(() => {
+    if (!plan) return;
+    navigation.navigate('StudyPlanDetail', { planId: plan.id });
+  }, [navigation, plan]);
+
+  const handlePickSegment = useCallback(
+    (segment: PlanPickerSegment) => {
+      navigation.navigate('PlanPicker', { segment });
+    },
+    [navigation],
+  );
 
   const currentReview =
     dueItems.length > 0 ? dueItems[reviewIndex % dueItems.length] : null;
@@ -125,9 +139,15 @@ function StudyHubScreen() {
               target={target}
               estimateMin={estimateMin}
               onResume={handleResume}
+              onOpenDetail={handleOpenPlanDetail}
             />
           </View>
         )}
+
+        {/* ── Begin something new (#1833) ─── */}
+        <View style={styles.block}>
+          <BeginSomethingNew onPick={handlePickSegment} />
+        </View>
 
         {/* ── Review card — one due prompt at a time ─── */}
         {currentReview && (

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -1,0 +1,177 @@
+/**
+ * StudyHubScreen — Root of the Study tab behind the `study_hub` flag
+ * (#1832, Epic #1830). One screen that answers "where was I?":
+ *   1. Continue hero — active plan, chapter trail, resume beat
+ *   2. Review card — one due prompt at a time (Recall it / Later)
+ *   3. Rhythm line — one italic sentence, deliberately not a streak
+ *   4. Library — the same shelves ExploreMenuScreen renders
+ *
+ * With no active plan the hero region renders nothing (the first-run
+ * empty state is #1837; the plan picker row is #1833).
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
+import { ContinueHero } from '../components/study/ContinueHero';
+import {
+  LibrarySections,
+  PREMIUM_SCREENS,
+} from '../components/study/LibrarySections';
+import { ReviewRecallCard } from '../components/study/ReviewRecallCard';
+import { RhythmLine } from '../components/study/RhythmLine';
+import { UpgradePrompt } from '../components/UpgradePrompt';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { useContinuePlan } from '../hooks/useContinuePlan';
+import { useExploreImages } from '../hooks/useExploreImages';
+import { usePremium } from '../hooks/usePremium';
+import { useReviewQueue } from '../hooks/useReviewQueue';
+import type { ScreenNavProp } from '../navigation/types';
+import { getWeeklyRhythm, type WeeklyRhythm } from '../services/study';
+import { fontFamily, spacing, useTheme } from '../theme';
+import { logger } from '../utils/logger';
+
+function StudyHubScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'StudyHub'>>();
+  const scrollRef = useRef<ScrollView>(null);
+  useScrollToTop(scrollRef);
+
+  const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
+  const imageRegistry = useExploreImages();
+  const { plan, items, target, estimateMin, reload: reloadPlan } = useContinuePlan();
+  const { dueItems, completeItem, reload: reloadReviews } = useReviewQueue();
+
+  const [rhythm, setRhythm] = useState<WeeklyRhythm[]>([]);
+  const [reviewIndex, setReviewIndex] = useState(0);
+
+  const reloadRhythm = useCallback(async () => {
+    try {
+      setRhythm(await getWeeklyRhythm());
+    } catch (err) {
+      logger.warn('StudyHub', 'Failed to load weekly rhythm', err);
+    }
+  }, []);
+
+  // Refresh hub state when the tab gains focus — including first mount
+  // (useFocusEffect fires on initial focus) and returning from a
+  // completed session — so the trail, reviews, and rhythm stay live.
+  useFocusEffect(
+    useCallback(() => {
+      void reloadPlan();
+      void reloadReviews();
+      void reloadRhythm();
+    }, [reloadPlan, reloadReviews, reloadRhythm]),
+  );
+
+  const handleResume = useCallback(() => {
+    if (!target) return;
+    navigation.navigate('StudySession', {
+      bookId: target.bookId,
+      chapterNum: target.chapterNum,
+      ...(target.step ? { initialStep: target.step } : {}),
+    });
+  }, [navigation, target]);
+
+  const currentReview =
+    dueItems.length > 0 ? dueItems[reviewIndex % dueItems.length] : null;
+
+  const handleRecall = useCallback(async () => {
+    if (!currentReview) return;
+    try {
+      await completeItem(currentReview.id);
+    } catch (err) {
+      logger.warn('StudyHub', 'Failed to complete review item', err);
+    }
+  }, [completeItem, currentReview]);
+
+  const handleLater = useCallback(() => {
+    setReviewIndex((i) => i + 1);
+  }, []);
+
+  const handleNavigate = useCallback(
+    (screen: string, params?: Record<string, string>) => {
+      const premiumLabel = PREMIUM_SCREENS[screen];
+      if (premiumLabel && !isPremium) {
+        showUpgrade('feature', premiumLabel);
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      navigation.navigate(screen as any, params as any);
+    },
+    [isPremium, showUpgrade, navigation],
+  );
+
+  const handleDeepLink = useCallback(
+    (deepLink: { screen: string; params?: Record<string, string> }) => {
+      handleNavigate(deepLink.screen, deepLink.params);
+    },
+    [handleNavigate],
+  );
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <ScrollView ref={scrollRef} contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: base.gold }]} accessibilityRole="header">
+          Study
+        </Text>
+
+        {/* ── Continue hero (hidden entirely when no active plan) ─── */}
+        {plan && target && (
+          <View style={styles.block}>
+            <ContinueHero
+              plan={plan}
+              items={items}
+              target={target}
+              estimateMin={estimateMin}
+              onResume={handleResume}
+            />
+          </View>
+        )}
+
+        {/* ── Review card — one due prompt at a time ─── */}
+        {currentReview && (
+          <View style={styles.block}>
+            <ReviewRecallCard
+              item={currentReview}
+              dueCount={dueItems.length}
+              onRecall={handleRecall}
+              onLater={handleLater}
+            />
+          </View>
+        )}
+
+        {/* ── Rhythm line ─── */}
+        <View style={styles.block}>
+          <RhythmLine rhythm={rhythm} />
+        </View>
+
+        {/* ── Library shelves (shared with ExploreMenuScreen) ─── */}
+        <LibrarySections
+          imageRegistry={imageRegistry}
+          isPremium={isPremium}
+          onNavigate={handleNavigate}
+          onDeepLink={handleDeepLink}
+        />
+      </ScrollView>
+
+      {upgradeRequest && (
+        <UpgradePrompt
+          visible
+          variant={upgradeRequest.variant}
+          featureName={upgradeRequest.featureName}
+          onClose={dismissUpgrade}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: spacing.md, paddingBottom: spacing.xxl },
+  title: { fontFamily: fontFamily.displaySemiBold, fontSize: 22, marginBottom: spacing.sm },
+  block: { marginBottom: spacing.md },
+});
+
+export default withErrorBoundary(StudyHubScreen);

--- a/app/src/screens/StudyPlanDetailScreen.tsx
+++ b/app/src/screens/StudyPlanDetailScreen.tsx
@@ -1,0 +1,253 @@
+/**
+ * StudyPlanDetailScreen — Unified study plan detail (#1833). NOT the
+ * legacy PlanDetailScreen (reading plans) — this one reads
+ * study_plans/study_plan_items. Item list with completion state,
+ * chapter trail, per-item resume, and an archive action. Reached from
+ * the hub's Continue hero (chevron / long-press); never a mandatory
+ * hop on the way into a session.
+ */
+import React, { useCallback, useState } from 'react';
+import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
+import { Archive, BookOpen, Check, ChevronRight } from 'lucide-react-native';
+import { ChapterTrail } from '../components/study/ChapterTrail';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { ScreenHeader } from '../components/ScreenHeader';
+import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { archiveStudyPlan } from '../db/userMutations';
+import { getStudyPlan, getStudyPlanItems } from '../db/userQueries';
+import type { ScreenNavProp, ScreenRouteProp } from '../navigation/types';
+import { formatChapterRef } from '../services/guidedStudy';
+import { fontFamily, radii, spacing, useTheme } from '../theme';
+import type { StudyPlan, StudyPlanItem, StudyPlanItemRef } from '../types';
+import { logger } from '../utils/logger';
+
+function parseRef(item: StudyPlanItem): StudyPlanItemRef | null {
+  try {
+    const ref: unknown = JSON.parse(item.ref_json);
+    if (typeof ref === 'object' && ref !== null && 'bookId' in ref && 'chapterNum' in ref) {
+      return ref as StudyPlanItemRef;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+function StudyPlanDetailScreen() {
+  const { base } = useTheme();
+  const navigation = useNavigation<ScreenNavProp<'Explore', 'StudyPlanDetail'>>();
+  const route = useRoute<ScreenRouteProp<'Explore', 'StudyPlanDetail'>>();
+  const { planId } = route.params;
+
+  const [plan, setPlan] = useState<StudyPlan | null>(null);
+  const [items, setItems] = useState<StudyPlanItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    try {
+      const [planRow, itemRows] = await Promise.all([
+        getStudyPlan(planId),
+        getStudyPlanItems(planId),
+      ]);
+      setPlan(planRow);
+      setItems(itemRows);
+    } catch (err) {
+      logger.warn('StudyPlanDetail', 'Failed to load plan', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [planId]);
+
+  // Reload on focus so returning from a session reflects completion.
+  useFocusEffect(
+    useCallback(() => {
+      void reload();
+    }, [reload]),
+  );
+
+  const handleArchive = useCallback(() => {
+    Alert.alert(
+      'Archive this plan?',
+      'The plan moves out of your Study hub. Nothing you wrote is deleted.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Archive',
+          style: 'destructive',
+          onPress: () => {
+            void archiveStudyPlan(planId)
+              .then(() => navigation.goBack())
+              .catch((err) => logger.warn('StudyPlanDetail', 'Failed to archive plan', err));
+          },
+        },
+      ],
+    );
+  }, [navigation, planId]);
+
+  const handleResumeItem = useCallback(
+    (item: StudyPlanItem) => {
+      const ref = parseRef(item);
+      if (!ref) return;
+      navigation.navigate('StudySession', {
+        bookId: ref.bookId,
+        chapterNum: ref.chapterNum,
+        planId,
+      });
+    },
+    [navigation, planId],
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <View style={styles.loadingPad}>
+          <LoadingSkeleton lines={8} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!plan) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+        <View style={styles.headerPad}>
+          <ScreenHeader title="Study Plan" onBack={() => navigation.goBack()} />
+        </View>
+        <Text style={[styles.notFound, { color: base.textMuted }]}>Plan not found</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const done = items.filter((i) => i.completed_at != null).length;
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>
+      <View style={styles.headerPad}>
+        <ScreenHeader title={plan.title} onBack={() => navigation.goBack()} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.progressBlock}>
+          <ChapterTrail items={items} />
+          <Text style={[styles.progressText, { color: base.textMuted }]}>
+            {done} of {items.length} complete
+          </Text>
+        </View>
+
+        <View style={styles.list}>
+          {items.map((item) => {
+            const ref = parseRef(item);
+            const label = ref ? formatChapterRef(`${ref.bookId}_${ref.chapterNum}`) : '—';
+            const completed = item.completed_at != null;
+            return (
+              <TouchableOpacity
+                key={item.item_num}
+                onPress={() => handleResumeItem(item)}
+                disabled={!ref}
+                activeOpacity={0.72}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  completed ? `${label}, complete. Revisit session` : `${label}. Resume here`
+                }
+                style={[
+                  styles.itemRow,
+                  { backgroundColor: base.bgElevated, borderColor: base.border },
+                ]}
+              >
+                {completed ? (
+                  <Check size={16} color={base.gold} />
+                ) : (
+                  <BookOpen size={16} color={base.textMuted} />
+                )}
+                <View style={styles.itemText}>
+                  <Text style={[styles.itemTitle, { color: completed ? base.textMuted : base.text }]}>
+                    {label}
+                  </Text>
+                  <Text style={[styles.itemMeta, { color: base.textMuted }]}>
+                    {item.kind === 'session' ? 'Guided session' : 'Reading'}
+                    {ref?.verseStart != null ? ` · from v${ref.verseStart}` : ''}
+                  </Text>
+                </View>
+                <ChevronRight size={16} color={base.textMuted} />
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <TouchableOpacity
+          onPress={handleArchive}
+          activeOpacity={0.72}
+          accessibilityRole="button"
+          accessibilityLabel={`Archive the ${plan.title} plan`}
+          style={[styles.archiveButton, { borderColor: base.border }]}
+        >
+          <Archive size={15} color={base.textMuted} />
+          <Text style={[styles.archiveLabel, { color: base.textMuted }]}>Archive plan</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerPad: { paddingHorizontal: spacing.md, paddingTop: spacing.sm },
+  loadingPad: { padding: spacing.lg },
+  notFound: {
+    fontFamily: fontFamily.ui,
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: spacing.xl,
+  },
+  content: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.xxl,
+  },
+  progressBlock: {
+    gap: spacing.xs,
+    marginBottom: spacing.md,
+  },
+  progressText: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+  },
+  list: { gap: spacing.xs },
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    minHeight: 52,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  itemText: { flex: 1 },
+  itemTitle: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: 15,
+  },
+  itemMeta: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    marginTop: 1,
+  },
+  archiveButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 44,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    marginTop: spacing.lg,
+  },
+  archiveLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});
+
+export default withErrorBoundary(StudyPlanDetailScreen);

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -39,7 +39,8 @@ import {
   getVerses,
 } from '../db/content';
 import { getCapturedInputs, getGuidedStudyQuestionForSession } from '../db/userQueries';
-import { setCapturedInputs } from '../db/userMutations';
+import { setCapturedInputs, setPreference } from '../db/userMutations';
+import { completePlanItemForSession, LAST_MODE_PREF_KEY } from '../services/study';
 import { useBooks, useGuidedStudySession, usePremium } from '../hooks';
 import { completeGuidedStudySession } from '../db/userMutations';
 import {
@@ -83,13 +84,15 @@ interface RouteParams {
   chapterNum: number;
   initialStep?: GuidedStudyStep;
   verseNum?: number;
+  /** Unified study plan this session belongs to (#1833). */
+  planId?: string;
 }
 
 function StudySessionScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
   const route = useRoute<RouteProp<{ StudySession: RouteParams }, 'StudySession'>>();
-  const { bookId, chapterNum, initialStep } = route.params;
+  const { bookId, chapterNum, initialStep, planId } = route.params;
   const translation = useSettingsStore((s) => s.translation);
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const { liveBooks } = useBooks();
@@ -209,6 +212,15 @@ function StudySessionScreen() {
     (key: SceneInputKey, value: string) => updateCapturedField({ step: 'scene', key }, value),
     [updateCapturedField],
   );
+
+  // Remember the chosen mode so the one-decision plan picker (#1833)
+  // can default to it without ever asking.
+  const handleModeChange = useCallback((mode: GuidedStudyMode) => {
+    setStudyMode(mode);
+    void setPreference(LAST_MODE_PREF_KEY, mode).catch((err) =>
+      logger.warn('StudySessionScreen', 'Failed to persist last study mode', err),
+    );
+  }, []);
 
   // Preserves #1654. The codex branch (codex/amicus-auth-access-hardening)
   // was cut before #1654 merged and reverts this guard. Do NOT remove it
@@ -463,7 +475,7 @@ function StudySessionScreen() {
           onSelect={goStep}
           carryForwardSteps={stepsWithCarryForward(plan.mode, capturedInputs)}
         />
-        <StudyModeSelector value={studyMode} onChange={setStudyMode} />
+        <StudyModeSelector value={studyMode} onChange={handleModeChange} />
 
         {session.currentStep === 'scene' && (
           <View style={styles.section}>
@@ -675,7 +687,17 @@ function StudySessionScreen() {
                 })
               }
               onMarkComplete={() => {
-                if (sessionId != null) void completeGuidedStudySession(sessionId);
+                if (sessionId != null) {
+                  void completeGuidedStudySession(sessionId);
+                  // Plan wiring (#1833): completing a plan-launched
+                  // session also completes/links the matching item.
+                  if (planId) {
+                    void completePlanItemForSession(planId, bookId, chapterNum, sessionId).catch(
+                      (err) =>
+                        logger.warn('StudySessionScreen', 'Failed to complete plan item', err),
+                    );
+                  }
+                }
                 navigation.goBack();
               }}
               onRestart={() =>

--- a/app/src/services/study/adoption.ts
+++ b/app/src/services/study/adoption.ts
@@ -1,0 +1,122 @@
+/**
+ * services/study/adoption.ts — Start a study plan in one decision
+ * (#1833). The picker never asks for a mode: plans adopt the last mode
+ * the user chose in a session (`user_preferences` key
+ * `guided_study_last_mode`), falling back to 'deep'.
+ */
+import { getPreference } from '../../db/userQueries';
+import {
+  completeStudyPlanItem,
+  createStudyPlan,
+  linkSessionToPlanItem,
+} from '../../db/userMutations';
+import { GUIDED_STUDY_MODES, type GuidedStudyMode } from '../guidedStudy/types';
+import type { StudyPlanItemRef, StudyPlanType } from '../../types';
+import { logger } from '../../utils/logger';
+import { getNextItem } from './progression';
+import {
+  buildBookPlanItems,
+  buildJourneyPlanItems,
+  buildTopicPlanItems,
+} from './planTemplates';
+
+export const LAST_MODE_PREF_KEY = 'guided_study_last_mode';
+
+/** Pure resolution of the picker's default mode — exported for tests. */
+export function resolveDefaultMode(value: string | null | undefined): GuidedStudyMode {
+  return (GUIDED_STUDY_MODES as readonly string[]).includes(value ?? '')
+    ? (value as GuidedStudyMode)
+    : 'deep';
+}
+
+/** The mode new plans adopt: last mode used in a session, else 'deep'. */
+export async function getDefaultStudyMode(): Promise<GuidedStudyMode> {
+  try {
+    return resolveDefaultMode(await getPreference(LAST_MODE_PREF_KEY));
+  } catch (err) {
+    logger.warn('studyPlans', 'Failed to read last study mode preference', err);
+    return 'deep';
+  }
+}
+
+export interface StartStudyPlanArgs {
+  planType: Exclude<StudyPlanType, 'custom'>;
+  sourceId: string;
+  title: string;
+}
+
+export interface StartedStudyPlan {
+  planId: string;
+  mode: GuidedStudyMode;
+  /** Ref of item 1 — where the first session should open. */
+  firstRef: StudyPlanItemRef;
+}
+
+/**
+ * Create a plan from content-derived template items and hand back what
+ * navigation needs. Returns null when the source resolves to zero
+ * items (unknown id, journey with no scripture stops, topic without
+ * relevant chapters) — callers should surface that instead of opening
+ * an empty session.
+ */
+export async function startStudyPlan(args: StartStudyPlanArgs): Promise<StartedStudyPlan | null> {
+  const items =
+    args.planType === 'book'
+      ? await buildBookPlanItems(args.sourceId)
+      : args.planType === 'journey'
+        ? await buildJourneyPlanItems(args.sourceId)
+        : await buildTopicPlanItems(args.sourceId);
+
+  if (items.length === 0) {
+    logger.warn(
+      'studyPlans',
+      `startStudyPlan: "${args.sourceId}" (${args.planType}) resolved to zero items`,
+    );
+    return null;
+  }
+
+  const mode = await getDefaultStudyMode();
+  const planId = await createStudyPlan({
+    planType: args.planType,
+    sourceId: args.sourceId,
+    title: args.title,
+    defaultMode: mode,
+    items,
+  });
+  return { planId, mode, firstRef: items[0].ref };
+}
+
+/**
+ * Session-completion wiring (#1833): when a guided session that
+ * belongs to a plan is marked complete, link the session onto the
+ * plan's first incomplete item for that chapter and complete it.
+ * No-op when the chapter isn't (or is no longer) pending in the plan.
+ */
+export async function completePlanItemForSession(
+  planId: string,
+  bookId: string,
+  chapterNum: number,
+  sessionId: number,
+): Promise<void> {
+  const next = await getNextItem(planId);
+  // Walk from the next item onward isn't needed: sessions launched from
+  // a plan always target the next item's chapter. Guard anyway so an
+  // out-of-order session (user wandered to another chapter) never
+  // completes the wrong item.
+  if (!next) return;
+  try {
+    const ref: StudyPlanItemRef = JSON.parse(next.ref_json);
+    if (ref.bookId !== bookId || ref.chapterNum !== chapterNum) {
+      logger.info(
+        'studyPlans',
+        `completePlanItemForSession: session chapter ${bookId}_${chapterNum} does not match next item — skipping`,
+      );
+      return;
+    }
+  } catch (err) {
+    logger.warn('studyPlans', `completePlanItemForSession: bad ref_json on ${planId}`, err);
+    return;
+  }
+  await linkSessionToPlanItem(planId, next.item_num, sessionId);
+  await completeStudyPlanItem(planId, next.item_num);
+}

--- a/app/src/services/study/index.ts
+++ b/app/src/services/study/index.ts
@@ -27,3 +27,12 @@ export {
   type WeeklyRhythm,
 } from './rhythm';
 export { migrateLegacyPlans } from './migrateLegacyPlans';
+export {
+  completePlanItemForSession,
+  getDefaultStudyMode,
+  LAST_MODE_PREF_KEY,
+  resolveDefaultMode,
+  startStudyPlan,
+  type StartedStudyPlan,
+  type StartStudyPlanArgs,
+} from './adoption';

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -13,6 +13,13 @@ export interface Book {
   genre?: string;
   genre_label?: string;
   genre_guidance?: string;
+  /**
+   * Starter-shelf flag from content/meta/books.json (#1833). Optional:
+   * absent until the content pipeline carries the column into
+   * scripture.db, so consumers must treat it as best-effort (SQLite
+   * stores it as 0/1 when present).
+   */
+  starter?: boolean | number;
 }
 
 export interface Chapter {

--- a/content/meta/books.json
+++ b/content/meta/books.json
@@ -8,7 +8,8 @@
     "is_live": true,
     "genre": "theological_narrative",
     "genre_label": "Theological Narrative",
-    "genre_guidance": "Structured around toledot formulas · ANE counter-narrative · Focus on who and why, not how and when"
+    "genre_guidance": "Structured around toledot formulas · ANE counter-narrative · Focus on who and why, not how and when",
+    "starter": true
   },
   {
     "id": "exodus",
@@ -206,7 +207,8 @@
     "is_live": true,
     "genre": "poetry",
     "genre_label": "Hebrew Poetry",
-    "genre_guidance": "Parallelism, not rhyme, drives structure · Superscriptions provide context · Five-book division mirrors Torah"
+    "genre_guidance": "Parallelism, not rhyme, drives structure · Superscriptions provide context · Five-book division mirrors Torah",
+    "starter": true
   },
   {
     "id": "proverbs",
@@ -217,7 +219,8 @@
     "is_live": true,
     "genre": "wisdom",
     "genre_label": "Wisdom Literature",
-    "genre_guidance": "Proverbial sayings are observations, not promises · Fear of the Lord as organizing principle · Two-way theology (wisdom vs. folly)"
+    "genre_guidance": "Proverbial sayings are observations, not promises · Fear of the Lord as organizing principle · Two-way theology (wisdom vs. folly)",
+    "starter": true
   },
   {
     "id": "ecclesiastes",
@@ -470,7 +473,8 @@
     "is_live": true,
     "genre": "gospel",
     "genre_label": "Gospel",
-    "genre_guidance": "Seven signs structure · \"I AM\" sayings · High christology from prologue · Symbolic and theological throughout"
+    "genre_guidance": "Seven signs structure · \"I AM\" sayings · High christology from prologue · Symbolic and theological throughout",
+    "starter": true
   },
   {
     "id": "acts",
@@ -492,7 +496,8 @@
     "is_live": true,
     "genre": "epistle",
     "genre_label": "Epistle",
-    "genre_guidance": "Theological treatise format · Diatribe style (imagined objector) · Righteousness of God as central theme"
+    "genre_guidance": "Theological treatise format · Diatribe style (imagined objector) · Righteousness of God as central theme",
+    "starter": true
   },
   {
     "id": "1_corinthians",


### PR DESCRIPTION
Depends on #1845 — merge in order.

Third PR in the Epic #1830 stack (branched from `feature/1832-study-hub`). Closes #1833.

## Rationale
Starting a study becomes one decision. All new surfaces live behind the flag-gated hub or additive routes — flag-off behavior is untouched.

- **PlanPickerScreen** (modal on ExploreStack, routes additive): segments **Book / Journey / Topic**. Book = pinned "Continue where you're reading" (most-recent `reading_progress`) → starter shelf → all live books grouped by testament; Journey from `db/content/features` queries; Topic from the topical-index queries, filtered to topics that actually carry relevant chapters. **Mode is never asked** — plans adopt `user_preferences.guided_study_last_mode` (fallback `deep`), written whenever the session screen's existing mode selector changes.
- **Adoption service** (`services/study/adoption.ts`): `resolveDefaultMode` (the card's required unit test), `startStudyPlan` (template items → `createStudyPlan` → first-item ref; returns null for zero-item sources instead of opening an empty session), `completePlanItemForSession`.
- **Session wiring**: `StudySession` gains optional `planId`; marking the session complete also links + completes the plan's next item — guarded so an out-of-order chapter never completes the wrong item. Hub hero shows the updated trail on refocus (acceptance: 1/16 after session 1).
- **StudyPlanDetailScreen** (new — legacy PlanDetail/PlanList untouched): item list with completion state, chapter trail, per-item resume, confirmed archive. Reached from the hub hero's chevron/long-press; never a mandatory hop.
- **JourneyDetailScreen**: "Study this journey" primary button → journey plan → session 1.
- **Hub**: "Begin something new" row (A Book / A Journey / A Topic → picker with segment preselected).
- **books.json**: `"starter": true` on john/psalms/genesis/romans/proverbs, exactly as specified. `_tools/schema_validator.py` passes (150,846 checks).

## Known gap (flagged on the issue before building)
The content pipeline doesn't carry `starter` into scripture.db (`_tools/build_sqlite_schema.py` + `populate_books` need one line each — both inside my `_tools/` no-touch boundary). The picker types `starter` as optional and renders the shelf **only when data is present**, so the Book segment fully works today and the shelf lights up automatically once you authorize the pipeline lines. Details in [the issue comment](https://github.com/CraigBuckmaster/ScriptureDeepDive/issues/1833#issuecomment-4866176369).

One judgment call: the pinned continue row opens the session **at the chapter you were reading** (plan still starts at item 1) rather than dropping you back to chapter 1 — the card doesn't specify; say the word if you want different semantics.

## Rollback plan
Revert the merge commit. New screens/routes are additive; the picker/detail are unreachable flag-off except via JourneyDetail's button, which reverts with the commit. `books.json` starter keys are inert data (validator-checked). No migrations.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **528 suites / 4012 tests passing**, thresholds met (21 new tests: default-mode resolution, start/complete wiring, 2-tap picker path with zero mode prompt, topic filtering, plan detail resume/archive, hub Begin row)
- `python _tools/schema_validator.py`: all content checks pass
- `npx expo export --platform ios` bundles cleanly
- Acceptance walk (via tests, no simulator in this env): hub "A Book" card → picker (tap 1) → Romans (tap 2) → `StudySession` scene step with `planId`, no mode prompt

## Process notes
- Kanban: Projects v2 GraphQL blocked by the environment proxy — please drag #1833 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_