### PR TITLE
feat(study): embedded scripture reader in StudySessionScreen — #1834

### DIFF
--- a/app/__tests__/components/guidedStudy/SessionReader.test.tsx
+++ b/app/__tests__/components/guidedStudy/SessionReader.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * #1834 — embedded scripture reader (components/guidedStudy/SessionReader).
+ * Verse text must render byte-identical to the loaded rows.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { SessionReader } from '@/components/guidedStudy/SessionReader';
+import type { Verse } from '@/types';
+
+function verse(num: number, text: string): Verse {
+  return {
+    id: num,
+    book_id: 'jonah',
+    chapter_num: 1,
+    verse_num: num,
+    translation: 'kjv',
+    text,
+  };
+}
+
+const VERSES: Verse[] = [
+  verse(1, 'Now the word of the LORD came unto Jonah the son of Amittai, saying,'),
+  verse(2, 'Arise, go to Nineveh, that great city, and cry against it; for their wickedness is come up before me.'),
+  verse(3, 'But Jonah rose up to flee unto Tarshish from the presence of the LORD.'),
+  verse(4, 'But the LORD sent out a great wind into the sea.'),
+  verse(5, 'Then the mariners were afraid, and cried every man unto his god.'),
+];
+
+describe('SessionReader (#1834)', () => {
+  it('collapsed: shows exactly the first three verses word-for-word plus the count affordance', () => {
+    const { getByText, queryByText } = render(<SessionReader verses={VERSES} />);
+    expect(getByText(VERSES[0].text, { exact: false })).toBeTruthy();
+    expect(getByText(VERSES[2].text, { exact: false })).toBeTruthy();
+    expect(queryByText(VERSES[3].text, { exact: false })).toBeNull();
+    expect(getByText('Read chapter (5 verses)')).toBeTruthy();
+  });
+
+  it('expands to the full chapter — no trimming, no skipping — and collapses back', () => {
+    const { getByLabelText, getByText, queryByText } = render(<SessionReader verses={VERSES} />);
+
+    fireEvent.press(getByLabelText('Read chapter — 2 more verses'));
+    for (const v of VERSES) {
+      expect(getByText(v.text, { exact: false })).toBeTruthy();
+    }
+
+    fireEvent.press(getByLabelText('Collapse chapter text'));
+    expect(queryByText(VERSES[4].text, { exact: false })).toBeNull();
+  });
+
+  it('honors initiallyExpanded and reports toggles', () => {
+    const onToggle = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <SessionReader verses={VERSES} initiallyExpanded onToggle={onToggle} />,
+    );
+    expect(getByText(VERSES[4].text, { exact: false })).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Collapse chapter text'));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('renders short chapters in full with no expand affordance', () => {
+    const short = VERSES.slice(0, 2);
+    const { getByText, queryByText } = render(<SessionReader verses={short} />);
+    expect(getByText(short[0].text, { exact: false })).toBeTruthy();
+    expect(getByText(short[1].text, { exact: false })).toBeTruthy();
+    expect(queryByText(/Read chapter/)).toBeNull();
+  });
+
+  it('renders nothing for an empty verse list', () => {
+    const { toJSON } = render(<SessionReader verses={[]} />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/src/components/guidedStudy/SessionReader.tsx
+++ b/app/src/components/guidedStudy/SessionReader.tsx
@@ -1,0 +1,125 @@
+/**
+ * components/guidedStudy/SessionReader.tsx — Embedded scripture reader
+ * for guided sessions (#1834). The session shows the chapter it is
+ * asking about: collapsed = the first few verses + count + an expand
+ * affordance; expanded = the full chapter.
+ *
+ * Verses render word-for-word from the loaded rows (already in the
+ * user's translation) — no trimming, no paraphrase, no skipping.
+ * Rendered as mapped <Text> inside the session's ScrollView on
+ * purpose: a nested list would fight the outer scroll.
+ *
+ * Expand preference lives in component state only (no DB). The screen
+ * passes `onToggle` + re-seeds `initiallyExpanded` so the preference
+ * survives step switches (the reader unmounts between scene/observe).
+ */
+import React, { useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ChevronDown, ChevronUp } from 'lucide-react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import type { Verse } from '../../types';
+
+const COLLAPSED_VERSE_COUNT = 3;
+
+interface Props {
+  verses: Verse[];
+  initiallyExpanded?: boolean;
+  /** Fires with the new state so the session can persist it across steps. */
+  onToggle?: (expanded: boolean) => void;
+}
+
+export function SessionReader({ verses, initiallyExpanded = false, onToggle }: Props) {
+  const { base } = useTheme();
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+
+  if (verses.length === 0) return null;
+
+  // Chapters at or under the collapsed count are always fully shown —
+  // an expand affordance would be a no-op.
+  const collapsible = verses.length > COLLAPSED_VERSE_COUNT;
+  const shown = expanded || !collapsible ? verses : verses.slice(0, COLLAPSED_VERSE_COUNT);
+  const hiddenCount = verses.length - shown.length;
+
+  const handleToggle = () => {
+    setExpanded((prev) => {
+      onToggle?.(!prev);
+      return !prev;
+    });
+  };
+
+  return (
+    <View style={[styles.card, { backgroundColor: base.bgElevated, borderColor: base.border }]}>
+      <View style={styles.verseBlock}>
+        {shown.map((verse) => (
+          <Text key={verse.verse_num} style={[styles.verseText, { color: base.text }]}>
+            <Text style={[styles.verseNum, { color: base.gold }]}>{verse.verse_num} </Text>
+            {verse.text}
+          </Text>
+        ))}
+      </View>
+
+      {collapsible ? (
+        <TouchableOpacity
+          onPress={handleToggle}
+          activeOpacity={0.72}
+          accessibilityRole="button"
+          accessibilityState={{ expanded }}
+          accessibilityLabel={
+            expanded
+              ? 'Collapse chapter text'
+              : `Read chapter — ${hiddenCount} more ${hiddenCount === 1 ? 'verse' : 'verses'}`
+          }
+          style={styles.toggle}
+        >
+          <Text style={[styles.toggleLabel, { color: base.gold }]}>
+            {expanded
+              ? 'Collapse'
+              : `Read chapter (${verses.length} ${verses.length === 1 ? 'verse' : 'verses'})`}
+          </Text>
+          {expanded ? (
+            <ChevronUp size={14} color={base.gold} />
+          ) : (
+            <ChevronDown size={14} color={base.gold} />
+          )}
+        </TouchableOpacity>
+      ) : (
+        <View style={styles.bottomPad} />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+  verseBlock: {
+    gap: spacing.xs,
+  },
+  verseText: {
+    fontFamily: fontFamily.body,
+    fontSize: 16,
+    lineHeight: 26,
+  },
+  verseNum: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: 11,
+  },
+  toggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    minHeight: 44,
+  },
+  toggleLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+  bottomPad: {
+    height: spacing.md,
+  },
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -6,6 +6,7 @@ export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { NextChapterNudge } from './NextChapterNudge';
 export { PanelRecommendationRow } from './PanelRecommendationRow';
+export { SessionReader } from './SessionReader';
 export { StudyModeSelector } from './StudyModeSelector';
 export { StudySessionCTA } from './StudySessionCTA';
 export { StudySessionStepper } from './StudySessionStepper';

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -22,6 +22,7 @@ import {
   EvidenceTrailRow,
   NextChapterNudge,
   PanelRecommendationRow,
+  SessionReader,
   StudyModeSelector,
   StudySessionStepper,
   SynthesisFreeRecap,
@@ -114,6 +115,9 @@ function StudySessionScreen() {
   const [synthesisDraft, setSynthesisDraft] = useState(session.synthesis);
   const [reviewSaved, setReviewSaved] = useState(false);
   const [studyMode, setStudyMode] = useState<GuidedStudyMode>('deep');
+  // Reader expand preference (#1834) — per-session component state
+  // only; survives step switches because the screen owns it.
+  const [readerExpanded, setReaderExpanded] = useState(false);
   const [capturedInputs, setCapturedInputsState] = useState<CapturedInputs>({});
   const captureSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -480,6 +484,11 @@ function StudySessionScreen() {
         {session.currentStep === 'scene' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Set the Scene</Text>
+            <SessionReader
+              verses={verses}
+              initiallyExpanded={readerExpanded}
+              onToggle={setReaderExpanded}
+            />
             <StepBanner step="scene" />
             <ModePromptList step="scene" />
             {plan.sceneRows.map((row) => (
@@ -515,6 +524,11 @@ function StudySessionScreen() {
         {session.currentStep === 'observe' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Observe</Text>
+            <SessionReader
+              verses={verses}
+              initiallyExpanded={readerExpanded}
+              onToggle={setReaderExpanded}
+            />
             <StepBanner step="observe" />
             <ModePromptList step="observe" />
             {plan.legacyPrompts.map((prompt) => (


### PR DESCRIPTION
Depends on #1846 — merge in order.

Fourth PR in the Epic #1830 stack (branched from `feature/1833-plan-picker`). Closes #1834.

## Rationale
The session now shows the chapter it's asking about — `StudySessionScreen` already loaded `verses` into state and never rendered them.

- **`SessionReader`** (new, `components/guidedStudy/`): collapsed = first 3 verses + verse count + "Read chapter" affordance; expanded = full chapter. Gold verse numbers, EB Garamond body, rendered as mapped `<Text>` inside the session's existing ScrollView (no nested list, no scroll conflicts). Verse text word-for-word from the `getVerses` rows — translation setting flows through untouched; no trimming, paraphrase, or skipping (test asserts every verse renders verbatim).
- Mounted on **scene** and **observe** steps above the prompts; explore/synthesize/review unchanged.
- Expand preference persists per session in screen state only (`initiallyExpanded`/`onToggle` re-seed across step switches, since the reader unmounts between steps). Short chapters (≤3 verses) render in full with no dead affordance.
- A11y: the toggle is a ≥44pt `button` with a descriptive label and `accessibilityState.expanded`; text uses default font scaling with no `numberOfLines`, so Dynamic Type reflows.

## Rollback plan
Revert the merge commit — one new component + two mount points; no DB, route, or service changes. OTA-safe.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **529 suites / 4017 tests passing**, thresholds met (5 new tests: collapsed subset, expand/collapse word-for-word, initiallyExpanded + onToggle, short-chapter, empty)

## Process notes
- Kanban: Projects v2 GraphQL blocked by the environment proxy — please drag #1834 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_