### PR TITLE
feat(study): evidence panel bottom sheet + visited trail state (migration v26) — #1835

### DIFF
--- a/app/__tests__/components/guidedStudy/EvidencePanelSheet.test.tsx
+++ b/app/__tests__/components/guidedStudy/EvidencePanelSheet.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * #1835 — evidence panel sheet. In-place panel rendering via the real
+ * PanelRenderer, close + open-full-chapter actions, missing-content
+ * fallback.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { EvidencePanelSheet } from '@/components/guidedStudy/EvidencePanelSheet';
+
+const ITEM = {
+  key: 'trail-ctx-1',
+  title: 'Literary context',
+  subtitle: 'Section 1 · Context',
+  panelType: 'ctx',
+  sectionNum: 1,
+};
+
+describe('EvidencePanelSheet (#1835)', () => {
+  it('renders the tapped panel content in place via PanelRenderer', () => {
+    const { getByText } = render(
+      <EvidencePanelSheet
+        visible
+        item={ITEM}
+        contentJson={JSON.stringify('The storm scene mirrors the creation account in reverse.')}
+        onClose={jest.fn()}
+        onOpenFullChapter={jest.fn()}
+      />,
+    );
+    expect(getByText('Literary context')).toBeTruthy();
+    expect(getByText('Section 1 · Context')).toBeTruthy();
+    // 'ctx' panels render their string payload through ContextPanel.
+    expect(
+      getByText('The storm scene mirrors the creation account in reverse.', { exact: false }),
+    ).toBeTruthy();
+  });
+
+  it('close and open-full-chapter controls are accessible buttons', () => {
+    const onClose = jest.fn();
+    const onOpenFullChapter = jest.fn();
+    const { getByLabelText } = render(
+      <EvidencePanelSheet
+        visible
+        item={ITEM}
+        contentJson={JSON.stringify('text')}
+        onClose={onClose}
+        onOpenFullChapter={onOpenFullChapter}
+      />,
+    );
+
+    fireEvent.press(getByLabelText('Close panel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(getByLabelText('Open full chapter'));
+    expect(onOpenFullChapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back gracefully when the panel content cannot be located', () => {
+    const { getByText } = render(
+      <EvidencePanelSheet
+        visible
+        item={ITEM}
+        contentJson={null}
+        onClose={jest.fn()}
+        onOpenFullChapter={jest.fn()}
+      />,
+    );
+    expect(getByText('This panel lives in the full chapter view.')).toBeTruthy();
+    expect(getByText('Open full chapter')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/guidedStudy/EvidenceTrailRowVisited.test.tsx
+++ b/app/__tests__/components/guidedStudy/EvidenceTrailRowVisited.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * #1835 — visited state on EvidenceTrailRow (gold check + a11y label).
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { EvidenceTrailRow } from '@/components/guidedStudy/EvidenceTrailRow';
+import type { GuidedEvidenceTrailItem } from '@/services/guidedStudy';
+
+const ITEM: GuidedEvidenceTrailItem = {
+  key: 'trail-hist-2',
+  title: 'Historical context',
+  subtitle: 'Section 2 · Background',
+  panelType: 'hist',
+  sectionNum: 2,
+  badge: 'Required',
+};
+
+describe('EvidenceTrailRow visited state (#1835)', () => {
+  it('unvisited: no check, plain label', () => {
+    const { getByLabelText, queryByTestId } = render(
+      <EvidenceTrailRow item={ITEM} index={0} onPress={jest.fn()} />,
+    );
+    expect(getByLabelText('Open Historical context')).toBeTruthy();
+    expect(queryByTestId('trail-visited-trail-hist-2')).toBeNull();
+  });
+
+  it('visited: gold check icon and ", visited" in the a11y label', () => {
+    const { getByLabelText, getByTestId } = render(
+      <EvidenceTrailRow item={ITEM} index={0} onPress={jest.fn()} visited />,
+    );
+    expect(getByLabelText('Open Historical context, visited')).toBeTruthy();
+    expect(getByTestId('trail-visited-trail-hist-2')).toBeTruthy();
+  });
+});

--- a/app/__tests__/db/migrationV26.test.ts
+++ b/app/__tests__/db/migrationV26.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #1835 — migration v26 (visited_trail_json + deferred_trail_json on
+ * guided_study_sessions). Mirrors migrationV25.test.ts.
+ */
+const mockExecAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllAsync = jest.fn().mockResolvedValue([]);
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 0 });
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+const mockOpenDatabaseAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: unknown[]) => mockOpenDatabaseAsync(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  mockOpenDatabaseAsync.mockResolvedValue({
+    execAsync: mockExecAsync,
+    getAllAsync: mockGetAllAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  });
+});
+
+describe('migration v26 — evidence trail columns', () => {
+  it('the migration count includes v26', () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT } = require('@/db/userDatabase');
+    expect(MIGRATION_COUNT).toBeGreaterThanOrEqual(26);
+  });
+
+  it('runs v26 (and any later migrations) on a v25 DB', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 25 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT - 25);
+  });
+
+  it('skips everything when v26 is already applied', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: MIGRATION_COUNT }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).not.toHaveBeenCalled();
+  });
+
+  it("v26's SQL adds both trail columns and nothing else is dropped/rewritten", async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 25 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    const allSql = mockExecAsync.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('\n');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN visited_trail_json TEXT');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN deferred_trail_json TEXT');
+    expect(allSql).not.toMatch(/DROP TABLE/i);
+  });
+});

--- a/app/__tests__/db/visitedTrail.test.ts
+++ b/app/__tests__/db/visitedTrail.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #1835 — visited-trail persistence (markGuidedTrailItemVisited).
+ * Exercises the real mutation against an in-memory fake of the
+ * guided_study_sessions row so the acceptance criterion "visited
+ * checks survive app kill + session resume" is backed by the actual
+ * read-append-write path.
+ */
+interface FakeSessionRow {
+  visited_trail_json: string | null;
+}
+
+let mockRow: FakeSessionRow | null;
+const mockGetFirstAsync = jest.fn(async () => mockRow);
+const mockRunAsync = jest.fn(async (_sql: string, params: unknown[]) => {
+  if (mockRow) mockRow.visited_trail_json = params[0] as string;
+  return { changes: 1 };
+});
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({
+    getFirstAsync: mockGetFirstAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { markGuidedTrailItemVisited } from '@/db/userMutations';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRow = { visited_trail_json: null };
+});
+
+describe('markGuidedTrailItemVisited (#1835)', () => {
+  it('appends the first key to an empty column', async () => {
+    await markGuidedTrailItemVisited(7, 'trail-hist-1');
+    expect(mockRow?.visited_trail_json).toBe(JSON.stringify(['trail-hist-1']));
+  });
+
+  it('accumulates keys across separate calls (persisted, not in-memory)', async () => {
+    await markGuidedTrailItemVisited(7, 'a');
+    await markGuidedTrailItemVisited(7, 'b');
+    await markGuidedTrailItemVisited(7, 'c');
+    expect(mockRow?.visited_trail_json).toBe(JSON.stringify(['a', 'b', 'c']));
+  });
+
+  it('is idempotent for an already-visited key', async () => {
+    await markGuidedTrailItemVisited(7, 'a');
+    const writesAfterFirst = mockRunAsync.mock.calls.length;
+    await markGuidedTrailItemVisited(7, 'a');
+    expect(mockRunAsync.mock.calls.length).toBe(writesAfterFirst);
+    expect(mockRow?.visited_trail_json).toBe(JSON.stringify(['a']));
+  });
+
+  it('recovers from corrupted JSON by starting a fresh set', async () => {
+    mockRow = { visited_trail_json: '{not-json' };
+    await markGuidedTrailItemVisited(7, 'a');
+    expect(mockRow.visited_trail_json).toBe(JSON.stringify(['a']));
+  });
+
+  it('does nothing when the session row is missing', async () => {
+    mockRow = null;
+    await markGuidedTrailItemVisited(999, 'a');
+    expect(mockRunAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/guidedStudy/EvidencePanelSheet.tsx
+++ b/app/src/components/guidedStudy/EvidencePanelSheet.tsx
@@ -1,0 +1,144 @@
+/**
+ * components/guidedStudy/EvidencePanelSheet.tsx — In-place evidence
+ * viewer for guided sessions (#1835). Kills the pogo stick: tapping an
+ * evidence-trail row opens the panel's content in a pageSheet modal
+ * instead of ejecting to ChapterScreen. Reuses the same PanelRenderer
+ * ChapterScreen uses, so panel rendering is not forked. A footer link
+ * preserves today's "open the full chapter" behavior.
+ */
+import React from 'react';
+import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ExternalLink, X } from 'lucide-react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import { PanelRenderer } from '../panels';
+
+export interface EvidenceSheetItem {
+  key: string;
+  title: string;
+  subtitle: string;
+  panelType: string;
+  sectionNum?: number;
+}
+
+interface Props {
+  visible: boolean;
+  item: EvidenceSheetItem | null;
+  /** Panel content_json for the item, or null when it can't be located. */
+  contentJson: string | null;
+  onClose: () => void;
+  /** Secondary escape hatch — today's navigate('Chapter', {openPanel}). */
+  onOpenFullChapter: () => void;
+}
+
+export function EvidencePanelSheet({
+  visible,
+  item,
+  contentJson,
+  onClose,
+  onOpenFullChapter,
+}: Props) {
+  const { base } = useTheme();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View
+        style={[styles.container, { backgroundColor: base.bg }]}
+        accessibilityViewIsModal
+      >
+        <View style={[styles.header, { borderBottomColor: base.border }]}>
+          <View style={styles.headerText}>
+            <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
+              {item?.title ?? ''}
+            </Text>
+            {item?.subtitle ? (
+              <Text style={[styles.subtitle, { color: base.textMuted }]}>{item.subtitle}</Text>
+            ) : null}
+          </View>
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close panel"
+            style={styles.closeButton}
+          >
+            <X size={20} color={base.textMuted} />
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.content}>
+          {item && contentJson != null ? (
+            <PanelRenderer panelType={item.panelType} contentJson={contentJson} />
+          ) : (
+            <Text style={[styles.missing, { color: base.textMuted }]}>
+              This panel lives in the full chapter view.
+            </Text>
+          )}
+        </ScrollView>
+
+        <TouchableOpacity
+          onPress={onOpenFullChapter}
+          activeOpacity={0.72}
+          accessibilityRole="button"
+          accessibilityLabel="Open full chapter"
+          style={[styles.footer, { borderTopColor: base.border }]}
+        >
+          <ExternalLink size={14} color={base.gold} />
+          <Text style={[styles.footerLabel, { color: base.gold }]}>Open full chapter</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderBottomWidth: 1,
+  },
+  headerText: { flex: 1 },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 17,
+  },
+  subtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  closeButton: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    marginVertical: -spacing.xs,
+  },
+  content: {
+    padding: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  missing: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 52,
+    borderTopWidth: 1,
+    borderRadius: radii.sm,
+  },
+  footerLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});

--- a/app/src/components/guidedStudy/EvidenceTrailRow.tsx
+++ b/app/src/components/guidedStudy/EvidenceTrailRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { ChevronRight } from 'lucide-react-native';
+import { Check, ChevronRight } from 'lucide-react-native';
 import { fontFamily, MIN_TOUCH_TARGET, radii, spacing, useTheme } from '../../theme';
 import type { GuidedEvidenceTrailItem } from '../../services/guidedStudy';
 import { ConfidenceBadge } from './ConfidenceBadge';
@@ -9,9 +9,11 @@ interface Props {
   item: GuidedEvidenceTrailItem;
   index: number;
   onPress: () => void;
+  /** Gold check when this trail key was already opened (#1835). */
+  visited?: boolean;
 }
 
-export function EvidenceTrailRow({ item, index, onPress }: Props) {
+export function EvidenceTrailRow({ item, index, onPress, visited = false }: Props) {
   const { base } = useTheme();
   const isFirst = index === 0;
 
@@ -27,7 +29,7 @@ export function EvidenceTrailRow({ item, index, onPress }: Props) {
         },
       ]}
       accessibilityRole="button"
-      accessibilityLabel={`Open ${item.title}`}
+      accessibilityLabel={visited ? `Open ${item.title}, visited` : `Open ${item.title}`}
     >
       <View style={[styles.stripe, { backgroundColor: base.gold }]} />
       <View style={[styles.indexPill, { borderColor: `${base.gold}45` }]}>
@@ -43,7 +45,13 @@ export function EvidenceTrailRow({ item, index, onPress }: Props) {
         </View>
         <Text style={[styles.subtitle, { color: base.textMuted }]}>{item.subtitle}</Text>
       </View>
-      <ChevronRight size={15} color={base.textMuted} />
+      {visited ? (
+        <View testID={`trail-visited-${item.key}`}>
+          <Check size={15} color={base.gold} />
+        </View>
+      ) : (
+        <ChevronRight size={15} color={base.textMuted} />
+      )}
     </TouchableOpacity>
   );
 }

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -2,6 +2,8 @@ export { CarriedForwardBanner } from './CarriedForwardBanner';
 export type { CarriedForwardItem } from './CarriedForwardBanner';
 export { ConfidenceBadge } from './ConfidenceBadge';
 export { ContextGuardBanner } from './ContextGuardBanner';
+export { EvidencePanelSheet } from './EvidencePanelSheet';
+export type { EvidenceSheetItem } from './EvidencePanelSheet';
 export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { NextChapterNudge } from './NextChapterNudge';

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -800,6 +800,15 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE guided_study_sessions ADD COLUMN plan_id TEXT;
     `,
   },
+  {
+    version: 26,
+    description:
+      'Evidence trail state (#1835) — visited_trail_json on guided_study_sessions, plus deferred_trail_json reserved for time-adaptive sessions (#1842; that issue must NOT add its own migration).',
+    sql: `
+      ALTER TABLE guided_study_sessions ADD COLUMN visited_trail_json TEXT;
+      ALTER TABLE guided_study_sessions ADD COLUMN deferred_trail_json TEXT;
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -480,6 +480,37 @@ export async function setSynthesisStrategy(
   );
 }
 
+/**
+ * Append an evidence-trail key to a session's visited set (#1835).
+ * Idempotent: appending an already-visited key is a no-op. Runs in a
+ * transaction so concurrent appends can't drop keys.
+ */
+export async function markGuidedTrailItemVisited(sessionId: number, key: string): Promise<void> {
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    const row = await db.getFirstAsync<{ visited_trail_json: string | null }>(
+      'SELECT visited_trail_json FROM guided_study_sessions WHERE id = ?',
+      [sessionId],
+    );
+    if (!row) return;
+    let visited: string[] = [];
+    try {
+      const parsed: unknown = JSON.parse(row.visited_trail_json ?? '[]');
+      if (Array.isArray(parsed)) visited = parsed.filter((k): k is string => typeof k === 'string');
+    } catch (err) {
+      logger.warn('userMutations', `Bad visited_trail_json on session ${sessionId} — resetting`, err);
+    }
+    if (visited.includes(key)) return;
+    visited.push(key);
+    await db.runAsync(
+      `UPDATE guided_study_sessions
+       SET visited_trail_json = ?, updated_at = datetime('now')
+       WHERE id = ?`,
+      [JSON.stringify(visited), sessionId],
+    );
+  });
+}
+
 export async function upsertGuidedStudyResponse(
   sessionId: number,
   promptKey: string,

--- a/app/src/hooks/useGuidedStudySession.ts
+++ b/app/src/hooks/useGuidedStudySession.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   createOrResumeGuidedStudySession,
+  markGuidedTrailItemVisited,
   setGuidedStudyStep,
   upsertGuidedStudyResponse,
   upsertGuidedStudySynthesis,
@@ -30,11 +31,22 @@ const EMPTY_SYNTHESIS: GuidedSynthesisDraft = {
   key_connection: '',
 };
 
+/** Parse a visited/deferred trail JSON column into a clean string[]. */
+function parseTrailJson(json: string | null | undefined): string[] {
+  try {
+    const parsed: unknown = JSON.parse(json ?? '[]');
+    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
 export function useGuidedStudySession(chapterId: string | undefined) {
   const [sessionId, setSessionId] = useState<number | null>(null);
   const [currentStep, setCurrentStepState] = useState<GuidedStudyStep>('scene');
   const [responses, setResponses] = useState<Record<string, GuidedStudyResponse>>({});
   const [synthesis, setSynthesis] = useState<GuidedSynthesisDraft>(EMPTY_SYNTHESIS);
+  const [visitedTrail, setVisitedTrail] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -59,6 +71,7 @@ export function useGuidedStudySession(chapterId: string | undefined) {
         setCurrentStepState(session?.current_step ?? 'scene');
         setResponses(Object.fromEntries(responseRows.map((row) => [row.prompt_key, row])));
         setSynthesis(synthesisRowToDraft(synthesisRow));
+        setVisitedTrail(parseTrailJson(session?.visited_trail_json));
       } catch (err) {
         logger.error('useGuidedStudySession', 'Failed to load guided session', err);
       } finally {
@@ -77,6 +90,21 @@ export function useGuidedStudySession(chapterId: string | undefined) {
       if (sessionId != null) {
         await setGuidedStudyStep(sessionId, step).catch((err) =>
           logger.warn('useGuidedStudySession', 'Failed to persist current step', err),
+        );
+      }
+    },
+    [sessionId],
+  );
+
+  // Visited evidence trail (#1835): optimistic in-memory set backed by
+  // guided_study_sessions.visited_trail_json (migration v26) so checks
+  // survive app kill + session resume.
+  const markTrailItemVisited = useCallback(
+    (key: string) => {
+      setVisitedTrail((prev) => (prev.includes(key) ? prev : [...prev, key]));
+      if (sessionId != null) {
+        void markGuidedTrailItemVisited(sessionId, key).catch((err) =>
+          logger.warn('useGuidedStudySession', 'Failed to persist visited trail item', err),
         );
       }
     },
@@ -136,8 +164,10 @@ export function useGuidedStudySession(chapterId: string | undefined) {
       currentStep,
       responses,
       synthesis,
+      visitedTrail,
       isLoading,
       setCurrentStep,
+      markTrailItemVisited,
       saveResponse,
       saveSynthesis,
       savePremiumReview,
@@ -147,8 +177,10 @@ export function useGuidedStudySession(chapterId: string | undefined) {
       currentStep,
       responses,
       synthesis,
+      visitedTrail,
       isLoading,
       setCurrentStep,
+      markTrailItemVisited,
       saveResponse,
       saveSynthesis,
       savePremiumReview,

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -19,8 +19,10 @@ import {
 import { ArrowLeft, MessageSquare } from 'lucide-react-native';
 import {
   CarriedForwardBanner,
+  EvidencePanelSheet,
   EvidenceTrailRow,
   NextChapterNudge,
+  type EvidenceSheetItem,
   PanelRecommendationRow,
   SessionReader,
   StudyModeSelector,
@@ -401,6 +403,37 @@ function StudySessionScreen() {
     [bookId, chapterNum, navigation],
   );
 
+  // Evidence panel sheet (#1835): evidence opens in place; the only way
+  // out of the session is the sheet's explicit "Open full chapter" link.
+  const [sheetItem, setSheetItem] = useState<EvidenceSheetItem | null>(null);
+
+  const findPanelContent = useCallback(
+    (panelType: string, sectionNum?: number): string | null => {
+      if (sectionNum != null) {
+        const section = sections.find((s) => s.section_num === sectionNum);
+        return section?.panels.find((p) => p.panel_type === panelType)?.content_json ?? null;
+      }
+      return chapterPanels.find((p) => p.panel_type === panelType)?.content_json ?? null;
+    },
+    [sections, chapterPanels],
+  );
+
+  const openEvidence = useCallback(
+    (item: EvidenceSheetItem) => {
+      setSheetItem(item);
+      session.markTrailItemVisited(item.key);
+    },
+    [session],
+  );
+
+  const closeEvidenceSheet = useCallback(() => setSheetItem(null), []);
+
+  const openSheetItemFullChapter = useCallback(() => {
+    const item = sheetItem;
+    setSheetItem(null);
+    if (item) openRecommendation(item.panelType, item.sectionNum);
+  }, [openRecommendation, sheetItem]);
+
   const askAmicus = useCallback(async () => {
     if (!isPremium) {
       showUpgrade('feature', 'Companion Study Partner');
@@ -562,16 +595,26 @@ function StudySessionScreen() {
               Open the panels in this order to build context before conclusions.
             </Text>
             {plan.evidenceTrail.length > 0 ? (
-              <View style={styles.trailList}>
-                {plan.evidenceTrail.map((item, index) => (
-                  <EvidenceTrailRow
-                    key={item.key}
-                    item={item}
-                    index={index}
-                    onPress={() => openRecommendation(item.panelType, item.sectionNum)}
-                  />
-                ))}
-              </View>
+              <>
+                <View style={styles.trailList}>
+                  {plan.evidenceTrail.map((item, index) => (
+                    <EvidenceTrailRow
+                      key={item.key}
+                      item={item}
+                      index={index}
+                      visited={session.visitedTrail.includes(item.key)}
+                      onPress={() => openEvidence(item)}
+                    />
+                  ))}
+                </View>
+                <Text style={[styles.trailProgress, { color: base.textMuted }]}>
+                  {
+                    plan.evidenceTrail.filter((item) => session.visitedTrail.includes(item.key))
+                      .length
+                  }{' '}
+                  of {plan.evidenceTrail.length} opened
+                </Text>
+              </>
             ) : (
               <View
                 style={[
@@ -583,7 +626,7 @@ function StudySessionScreen() {
                   <PanelRecommendationRow
                     key={rec.key}
                     recommendation={rec}
-                    onPress={() => openRecommendation(rec.panelType, rec.sectionNum)}
+                    onPress={() => openEvidence(rec)}
                   />
                 ))}
               </View>
@@ -721,6 +764,14 @@ function StudySessionScreen() {
           </View>
         )}
       </ScrollView>
+
+      <EvidencePanelSheet
+        visible={sheetItem != null}
+        item={sheetItem}
+        contentJson={sheetItem ? findPanelContent(sheetItem.panelType, sheetItem.sectionNum) : null}
+        onClose={closeEvidenceSheet}
+        onOpenFullChapter={openSheetItemFullChapter}
+      />
 
       {upgradeRequest && (
         <UpgradePrompt
@@ -911,6 +962,13 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: radii.md,
     paddingHorizontal: spacing.md,
+    marginBottom: spacing.md,
+  },
+  trailProgress: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: -spacing.xs,
     marginBottom: spacing.md,
   },
   trailList: {

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -69,6 +69,10 @@ export interface GuidedStudySession {
   synthesis_strategy?: string | null;
   /** Unified study plans (#1831, migration v25). NULL for sessions started outside a plan. */
   plan_id?: string | null;
+  /** Visited evidence-trail keys, JSON string[] (#1835, migration v26). */
+  visited_trail_json?: string | null;
+  /** Deferred evidence-trail keys for time-adaptive sessions, JSON string[] (#1842; column reserved by migration v26). */
+  deferred_trail_json?: string | null;
 }
 
 // ── Unified study plans (#1831, migration v25) ────────────────────


### PR DESCRIPTION
Depends on #1847 — merge in order.

Fifth PR in the Epic #1830 stack (branched from `feature/1834-session-reader`). Closes #1835.

## Rationale
Kills the pogo stick: evidence taps used to `navigate('Chapter', {openPanel})` once per item, ejecting the user from the session; trail rows had no memory of what was already opened.

- **`EvidencePanelSheet`** (RN `Modal`, pageSheet): renders the tapped panel in place through the **same `PanelRenderer` ChapterScreen uses** — the renderer turned out to be cleanly extractable (props are just `panelType` + `contentJson`), so no forked rendering and no follow-up needed on that front. Content is located from the session's already-loaded section/chapter panels. Footer link "Open full chapter" preserves today's navigate behavior and is now the *only* way an evidence tap leaves the session. Both the ordered trail rows and the fallback recommendation rows route through the sheet.
- **Migration v26** (append-only): `visited_trail_json` + `deferred_trail_json` on `guided_study_sessions`. The deferred column is reserved for #1842 per the card, so that issue adds no migration of its own.
- **Visited state**: `useGuidedStudySession` exposes `visitedTrail` (hydrated from the session row — survives app kill + resume) and `markTrailItemVisited` (optimistic, persisted via an idempotent transactional append). `EvidenceTrailRow` shows a gold check and appends ", visited" to its VoiceOver label; the Explore step footer shows **"n of m opened"**.
- **A11y**: sheet closes via `onRequestClose` (VoiceOver escape/back), is marked `accessibilityViewIsModal` (focus contained on open), and has a labeled ≥44pt close control.
- Note: interactive sub-links inside sheet-rendered panels (scholar/word-study taps) are intentionally inert in the sheet — full interactivity is one tap away via "Open full chapter". Say the word if you'd like them wired to the sheet's context instead.

## Rollback plan
Revert the merge commit. Migration v26 is additive — the two columns simply go unused after a revert; the migration runner never re-runs applied versions. All UI changes are inside the session screen and its components.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **533 suites / 4031 tests passing**, thresholds met (14 new tests: v26 on a v25 DB + idempotency + append-only guard, visited-trail persistence semantics incl. corrupt JSON and missing row, sheet render/actions/fallback, trail-row visited state)

## Process notes
- Kanban: Projects v2 GraphQL blocked by the environment proxy — please drag #1835 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_