### PR TITLE
feat(study): reviews fold-in — saved indicator, resume beat, completion payoff, MyStudy redirect — #1836

### DIFF
--- a/app/__tests__/components/guidedStudy/EvidencePanelSheet.test.tsx
+++ b/app/__tests__/components/guidedStudy/EvidencePanelSheet.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * #1835 — evidence panel sheet. In-place panel rendering via the real
+ * PanelRenderer, close + open-full-chapter actions, missing-content
+ * fallback.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { EvidencePanelSheet } from '@/components/guidedStudy/EvidencePanelSheet';
+
+const ITEM = {
+  key: 'trail-ctx-1',
+  title: 'Literary context',
+  subtitle: 'Section 1 · Context',
+  panelType: 'ctx',
+  sectionNum: 1,
+};
+
+describe('EvidencePanelSheet (#1835)', () => {
+  it('renders the tapped panel content in place via PanelRenderer', () => {
+    const { getByText } = render(
+      <EvidencePanelSheet
+        visible
+        item={ITEM}
+        contentJson={JSON.stringify('The storm scene mirrors the creation account in reverse.')}
+        onClose={jest.fn()}
+        onOpenFullChapter={jest.fn()}
+      />,
+    );
+    expect(getByText('Literary context')).toBeTruthy();
+    expect(getByText('Section 1 · Context')).toBeTruthy();
+    // 'ctx' panels render their string payload through ContextPanel.
+    expect(
+      getByText('The storm scene mirrors the creation account in reverse.', { exact: false }),
+    ).toBeTruthy();
+  });
+
+  it('close and open-full-chapter controls are accessible buttons', () => {
+    const onClose = jest.fn();
+    const onOpenFullChapter = jest.fn();
+    const { getByLabelText } = render(
+      <EvidencePanelSheet
+        visible
+        item={ITEM}
+        contentJson={JSON.stringify('text')}
+        onClose={onClose}
+        onOpenFullChapter={onOpenFullChapter}
+      />,
+    );
+
+    fireEvent.press(getByLabelText('Close panel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(getByLabelText('Open full chapter'));
+    expect(onOpenFullChapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back gracefully when the panel content cannot be located', () => {
+    const { getByText } = render(
+      <EvidencePanelSheet
+        visible
+        item={ITEM}
+        contentJson={null}
+        onClose={jest.fn()}
+        onOpenFullChapter={jest.fn()}
+      />,
+    );
+    expect(getByText('This panel lives in the full chapter view.')).toBeTruthy();
+    expect(getByText('Open full chapter')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/guidedStudy/EvidenceTrailRowVisited.test.tsx
+++ b/app/__tests__/components/guidedStudy/EvidenceTrailRowVisited.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * #1835 — visited state on EvidenceTrailRow (gold check + a11y label).
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { EvidenceTrailRow } from '@/components/guidedStudy/EvidenceTrailRow';
+import type { GuidedEvidenceTrailItem } from '@/services/guidedStudy';
+
+const ITEM: GuidedEvidenceTrailItem = {
+  key: 'trail-hist-2',
+  title: 'Historical context',
+  subtitle: 'Section 2 · Background',
+  panelType: 'hist',
+  sectionNum: 2,
+  badge: 'Required',
+};
+
+describe('EvidenceTrailRow visited state (#1835)', () => {
+  it('unvisited: no check, plain label', () => {
+    const { getByLabelText, queryByTestId } = render(
+      <EvidenceTrailRow item={ITEM} index={0} onPress={jest.fn()} />,
+    );
+    expect(getByLabelText('Open Historical context')).toBeTruthy();
+    expect(queryByTestId('trail-visited-trail-hist-2')).toBeNull();
+  });
+
+  it('visited: gold check icon and ", visited" in the a11y label', () => {
+    const { getByLabelText, getByTestId } = render(
+      <EvidenceTrailRow item={ITEM} index={0} onPress={jest.fn()} visited />,
+    );
+    expect(getByLabelText('Open Historical context, visited')).toBeTruthy();
+    expect(getByTestId('trail-visited-trail-hist-2')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/guidedStudy/ResumeBeat.test.tsx
+++ b/app/__tests__/components/guidedStudy/ResumeBeat.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * #1836 — resume beat line.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { ResumeBeat } from '@/components/guidedStudy/ResumeBeat';
+
+describe('ResumeBeat (#1836)', () => {
+  it('renders the step label from GUIDED_STUDY_STEP_LABELS', () => {
+    const { getByText } = render(<ResumeBeat step="explore" onDismiss={jest.fn()} />);
+    expect(getByText('Picking up where you left off — Explore.')).toBeTruthy();
+  });
+
+  it('is dismissible via an accessible control', () => {
+    const onDismiss = jest.fn();
+    const { getByLabelText } = render(<ResumeBeat step="synthesize" onDismiss={onDismiss} />);
+    fireEvent.press(getByLabelText('Dismiss resume note'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/__tests__/components/guidedStudy/SavedIndicator.test.tsx
+++ b/app/__tests__/components/guidedStudy/SavedIndicator.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * #1836 — Saved indicator. Must appear only after a persist (tick
+ * bump), never at rest, and render statically under reduced motion.
+ */
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+
+const mockUseReducedMotion = jest.fn().mockReturnValue(false);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+import { SavedIndicator } from '@/components/guidedStudy/SavedIndicator';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseReducedMotion.mockReturnValue(false);
+});
+
+describe('SavedIndicator (#1836)', () => {
+  it('renders nothing before any save (tick 0) — never optimistic', () => {
+    const { toJSON } = render(<SavedIndicator savedTick={0} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('shows "Saved" when the tick bumps after a successful persist', () => {
+    const { queryByText, rerender, getByText } = render(<SavedIndicator savedTick={0} />);
+    expect(queryByText('Saved')).toBeNull();
+
+    rerender(<SavedIndicator savedTick={1} />);
+    expect(getByText('Saved')).toBeTruthy();
+  });
+
+  it('under reduced motion: shows statically, then hides after the hold', () => {
+    jest.useFakeTimers();
+    mockUseReducedMotion.mockReturnValue(true);
+    const { rerender, getByText, queryByText } = render(<SavedIndicator savedTick={0} />);
+
+    rerender(<SavedIndicator savedTick={1} />);
+    expect(getByText('Saved')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(queryByText('Saved')).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('re-shows on every subsequent tick', () => {
+    jest.useFakeTimers();
+    mockUseReducedMotion.mockReturnValue(true);
+    const { rerender, getByText, queryByText } = render(<SavedIndicator savedTick={1} />);
+    // Initial state with tick already 1: still hidden (no transition seen).
+    expect(queryByText('Saved')).toBeNull();
+
+    rerender(<SavedIndicator savedTick={2} />);
+    expect(getByText('Saved')).toBeTruthy();
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(queryByText('Saved')).toBeNull();
+
+    rerender(<SavedIndicator savedTick={3} />);
+    expect(getByText('Saved')).toBeTruthy();
+    jest.useRealTimers();
+  });
+});

--- a/app/__tests__/db/migrationV26.test.ts
+++ b/app/__tests__/db/migrationV26.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #1835 — migration v26 (visited_trail_json + deferred_trail_json on
+ * guided_study_sessions). Mirrors migrationV25.test.ts.
+ */
+const mockExecAsync = jest.fn().mockResolvedValue(undefined);
+const mockGetAllAsync = jest.fn().mockResolvedValue([]);
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 0 });
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+const mockOpenDatabaseAsync = jest.fn();
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: (...args: unknown[]) => mockOpenDatabaseAsync(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  mockOpenDatabaseAsync.mockResolvedValue({
+    execAsync: mockExecAsync,
+    getAllAsync: mockGetAllAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  });
+});
+
+describe('migration v26 — evidence trail columns', () => {
+  it('the migration count includes v26', () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT } = require('@/db/userDatabase');
+    expect(MIGRATION_COUNT).toBeGreaterThanOrEqual(26);
+  });
+
+  it('runs v26 (and any later migrations) on a v25 DB', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 25 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).toHaveBeenCalledTimes(MIGRATION_COUNT - 25);
+  });
+
+  it('skips everything when v26 is already applied', async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { MIGRATION_COUNT, initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: MIGRATION_COUNT }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    expect(mockWithTransactionAsync).not.toHaveBeenCalled();
+  });
+
+  it("v26's SQL adds both trail columns and nothing else is dropped/rewritten", async () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'ios' } }));
+    jest.resetModules();
+    const { initUserDatabase } = require('@/db/userDatabase');
+    mockGetAllAsync.mockResolvedValueOnce(
+      Array.from({ length: 25 }, (_, i) => ({ version: i + 1 })),
+    );
+    await initUserDatabase();
+    const allSql = mockExecAsync.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('\n');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN visited_trail_json TEXT');
+    expect(allSql).toContain('ALTER TABLE guided_study_sessions ADD COLUMN deferred_trail_json TEXT');
+    expect(allSql).not.toMatch(/DROP TABLE/i);
+  });
+});

--- a/app/__tests__/db/visitedTrail.test.ts
+++ b/app/__tests__/db/visitedTrail.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #1835 — visited-trail persistence (markGuidedTrailItemVisited).
+ * Exercises the real mutation against an in-memory fake of the
+ * guided_study_sessions row so the acceptance criterion "visited
+ * checks survive app kill + session resume" is backed by the actual
+ * read-append-write path.
+ */
+interface FakeSessionRow {
+  visited_trail_json: string | null;
+}
+
+let mockRow: FakeSessionRow | null;
+const mockGetFirstAsync = jest.fn(async () => mockRow);
+const mockRunAsync = jest.fn(async (_sql: string, params: unknown[]) => {
+  if (mockRow) mockRow.visited_trail_json = params[0] as string;
+  return { changes: 1 };
+});
+const mockWithTransactionAsync = jest
+  .fn()
+  .mockImplementation(async (cb: () => Promise<void>) => cb());
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({
+    getFirstAsync: mockGetFirstAsync,
+    runAsync: mockRunAsync,
+    withTransactionAsync: mockWithTransactionAsync,
+  }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { markGuidedTrailItemVisited } from '@/db/userMutations';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRow = { visited_trail_json: null };
+});
+
+describe('markGuidedTrailItemVisited (#1835)', () => {
+  it('appends the first key to an empty column', async () => {
+    await markGuidedTrailItemVisited(7, 'trail-hist-1');
+    expect(mockRow?.visited_trail_json).toBe(JSON.stringify(['trail-hist-1']));
+  });
+
+  it('accumulates keys across separate calls (persisted, not in-memory)', async () => {
+    await markGuidedTrailItemVisited(7, 'a');
+    await markGuidedTrailItemVisited(7, 'b');
+    await markGuidedTrailItemVisited(7, 'c');
+    expect(mockRow?.visited_trail_json).toBe(JSON.stringify(['a', 'b', 'c']));
+  });
+
+  it('is idempotent for an already-visited key', async () => {
+    await markGuidedTrailItemVisited(7, 'a');
+    const writesAfterFirst = mockRunAsync.mock.calls.length;
+    await markGuidedTrailItemVisited(7, 'a');
+    expect(mockRunAsync.mock.calls.length).toBe(writesAfterFirst);
+    expect(mockRow?.visited_trail_json).toBe(JSON.stringify(['a']));
+  });
+
+  it('recovers from corrupted JSON by starting a fresh set', async () => {
+    mockRow = { visited_trail_json: '{not-json' };
+    await markGuidedTrailItemVisited(7, 'a');
+    expect(mockRow.visited_trail_json).toBe(JSON.stringify(['a']));
+  });
+
+  it('does nothing when the session row is missing', async () => {
+    mockRow = null;
+    await markGuidedTrailItemVisited(999, 'a');
+    expect(mockRunAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/screens/MyStudyRedirect.test.tsx
+++ b/app/__tests__/screens/MyStudyRedirect.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * #1836 — MyStudy → Study hub redirect behind the study_hub flag.
+ * Flag on: thin redirect (pop first — no loop), renders nothing.
+ * Flag off: the screen renders exactly as before.
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockCanGoBack = jest.fn().mockReturnValue(true);
+const mockParentNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+      canGoBack: mockCanGoBack,
+      getParent: () => ({ navigate: mockParentNavigate }),
+    }),
+    useRoute: () => ({ params: {} }),
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+const mockIsFlagEnabled = jest.fn().mockReturnValue(false);
+jest.mock('@/config/featureFlags', () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
+jest.mock('@/hooks', () => ({
+  usePremium: jest.fn().mockReturnValue({
+    isPremium: true,
+    upgradeRequest: null,
+    showUpgrade: jest.fn(),
+    dismissUpgrade: jest.fn(),
+  }),
+  useReviewQueue: jest.fn().mockReturnValue({
+    dueItems: [],
+    allItems: [],
+    concepts: [],
+    activeSessions: [],
+    openQuestions: [],
+    recentTakeaways: [],
+    nextAction: null,
+    completeItem: jest.fn(),
+    resolveQuestion: jest.fn(),
+  }),
+}));
+
+import MyStudyScreen from '@/screens/MyStudyScreen';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCanGoBack.mockReturnValue(true);
+});
+
+describe('MyStudyScreen redirect (#1836)', () => {
+  it('flag off: renders the screen normally, no redirect', () => {
+    mockIsFlagEnabled.mockReturnValue(false);
+    const { getByText } = render(<MyStudyScreen />);
+    expect(getByText('My Study')).toBeTruthy();
+    expect(mockParentNavigate).not.toHaveBeenCalled();
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('flag on: renders nothing, pops itself, then jumps to the Study hub (no loop)', async () => {
+    mockIsFlagEnabled.mockReturnValue(true);
+    const { toJSON } = render(<MyStudyScreen />);
+    expect(toJSON()).toBeNull();
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(mockParentNavigate).toHaveBeenCalledWith('ExploreTab', { screen: 'StudyHub' });
+    });
+    // Pop happens before the cross-tab jump so More never re-lands here.
+    expect(mockGoBack.mock.invocationCallOrder[0]).toBeLessThan(
+      mockParentNavigate.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('flag on with an empty stack: skips the pop but still redirects', async () => {
+    mockIsFlagEnabled.mockReturnValue(true);
+    mockCanGoBack.mockReturnValue(false);
+    render(<MyStudyScreen />);
+    await waitFor(() =>
+      expect(mockParentNavigate).toHaveBeenCalledWith('ExploreTab', { screen: 'StudyHub' }),
+    );
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/services/guidedStudy/reviewCopy.test.ts
+++ b/app/__tests__/services/guidedStudy/reviewCopy.test.ts
@@ -1,0 +1,27 @@
+/**
+ * #1836 — completion payoff copy derives its wording from
+ * REVIEW_INTERVAL_DAYS instead of hardcoding "tomorrow".
+ */
+import { REVIEW_INTERVAL_DAYS } from '@/services/guidedStudy/review';
+import { completionPayoffCopy, reviewReturnPhrase } from '@/services/guidedStudy/reviewCopy';
+
+describe('reviewReturnPhrase (#1836)', () => {
+  it("says 'tomorrow' only for a 1-day interval", () => {
+    expect(reviewReturnPhrase(1)).toBe('tomorrow');
+    expect(reviewReturnPhrase(3)).toBe('in 3 days');
+    expect(reviewReturnPhrase(7)).toBe('in 7 days');
+  });
+
+  it('defaults to the first rung of the actual review ladder', () => {
+    expect(reviewReturnPhrase()).toBe(reviewReturnPhrase(REVIEW_INTERVAL_DAYS[0]));
+  });
+});
+
+describe('completionPayoffCopy (#1836)', () => {
+  it('builds the confirmation from the ladder value', () => {
+    expect(completionPayoffCopy(1)).toBe("Saved. You'll see this takeaway again tomorrow.");
+    expect(completionPayoffCopy(3)).toBe("Saved. You'll see this takeaway again in 3 days.");
+    // Default follows the ladder — with today's ladder ([1, ...]) that reads "tomorrow".
+    expect(completionPayoffCopy()).toBe(completionPayoffCopy(REVIEW_INTERVAL_DAYS[0]));
+  });
+});

--- a/app/src/components/guidedStudy/EvidencePanelSheet.tsx
+++ b/app/src/components/guidedStudy/EvidencePanelSheet.tsx
@@ -1,0 +1,144 @@
+/**
+ * components/guidedStudy/EvidencePanelSheet.tsx — In-place evidence
+ * viewer for guided sessions (#1835). Kills the pogo stick: tapping an
+ * evidence-trail row opens the panel's content in a pageSheet modal
+ * instead of ejecting to ChapterScreen. Reuses the same PanelRenderer
+ * ChapterScreen uses, so panel rendering is not forked. A footer link
+ * preserves today's "open the full chapter" behavior.
+ */
+import React from 'react';
+import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ExternalLink, X } from 'lucide-react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+import { PanelRenderer } from '../panels';
+
+export interface EvidenceSheetItem {
+  key: string;
+  title: string;
+  subtitle: string;
+  panelType: string;
+  sectionNum?: number;
+}
+
+interface Props {
+  visible: boolean;
+  item: EvidenceSheetItem | null;
+  /** Panel content_json for the item, or null when it can't be located. */
+  contentJson: string | null;
+  onClose: () => void;
+  /** Secondary escape hatch — today's navigate('Chapter', {openPanel}). */
+  onOpenFullChapter: () => void;
+}
+
+export function EvidencePanelSheet({
+  visible,
+  item,
+  contentJson,
+  onClose,
+  onOpenFullChapter,
+}: Props) {
+  const { base } = useTheme();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View
+        style={[styles.container, { backgroundColor: base.bg }]}
+        accessibilityViewIsModal
+      >
+        <View style={[styles.header, { borderBottomColor: base.border }]}>
+          <View style={styles.headerText}>
+            <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
+              {item?.title ?? ''}
+            </Text>
+            {item?.subtitle ? (
+              <Text style={[styles.subtitle, { color: base.textMuted }]}>{item.subtitle}</Text>
+            ) : null}
+          </View>
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close panel"
+            style={styles.closeButton}
+          >
+            <X size={20} color={base.textMuted} />
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.content}>
+          {item && contentJson != null ? (
+            <PanelRenderer panelType={item.panelType} contentJson={contentJson} />
+          ) : (
+            <Text style={[styles.missing, { color: base.textMuted }]}>
+              This panel lives in the full chapter view.
+            </Text>
+          )}
+        </ScrollView>
+
+        <TouchableOpacity
+          onPress={onOpenFullChapter}
+          activeOpacity={0.72}
+          accessibilityRole="button"
+          accessibilityLabel="Open full chapter"
+          style={[styles.footer, { borderTopColor: base.border }]}
+        >
+          <ExternalLink size={14} color={base.gold} />
+          <Text style={[styles.footerLabel, { color: base.gold }]}>Open full chapter</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderBottomWidth: 1,
+  },
+  headerText: { flex: 1 },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 17,
+  },
+  subtitle: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  closeButton: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    marginVertical: -spacing.xs,
+  },
+  content: {
+    padding: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  missing: {
+    fontFamily: fontFamily.ui,
+    fontSize: 13,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: 52,
+    borderTopWidth: 1,
+    borderRadius: radii.sm,
+  },
+  footerLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});

--- a/app/src/components/guidedStudy/EvidenceTrailRow.tsx
+++ b/app/src/components/guidedStudy/EvidenceTrailRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { ChevronRight } from 'lucide-react-native';
+import { Check, ChevronRight } from 'lucide-react-native';
 import { fontFamily, MIN_TOUCH_TARGET, radii, spacing, useTheme } from '../../theme';
 import type { GuidedEvidenceTrailItem } from '../../services/guidedStudy';
 import { ConfidenceBadge } from './ConfidenceBadge';
@@ -9,9 +9,11 @@ interface Props {
   item: GuidedEvidenceTrailItem;
   index: number;
   onPress: () => void;
+  /** Gold check when this trail key was already opened (#1835). */
+  visited?: boolean;
 }
 
-export function EvidenceTrailRow({ item, index, onPress }: Props) {
+export function EvidenceTrailRow({ item, index, onPress, visited = false }: Props) {
   const { base } = useTheme();
   const isFirst = index === 0;
 
@@ -27,7 +29,7 @@ export function EvidenceTrailRow({ item, index, onPress }: Props) {
         },
       ]}
       accessibilityRole="button"
-      accessibilityLabel={`Open ${item.title}`}
+      accessibilityLabel={visited ? `Open ${item.title}, visited` : `Open ${item.title}`}
     >
       <View style={[styles.stripe, { backgroundColor: base.gold }]} />
       <View style={[styles.indexPill, { borderColor: `${base.gold}45` }]}>
@@ -43,7 +45,13 @@ export function EvidenceTrailRow({ item, index, onPress }: Props) {
         </View>
         <Text style={[styles.subtitle, { color: base.textMuted }]}>{item.subtitle}</Text>
       </View>
-      <ChevronRight size={15} color={base.textMuted} />
+      {visited ? (
+        <View testID={`trail-visited-${item.key}`}>
+          <Check size={15} color={base.gold} />
+        </View>
+      ) : (
+        <ChevronRight size={15} color={base.textMuted} />
+      )}
     </TouchableOpacity>
   );
 }

--- a/app/src/components/guidedStudy/ResumeBeat.tsx
+++ b/app/src/components/guidedStudy/ResumeBeat.tsx
@@ -1,0 +1,61 @@
+/**
+ * components/guidedStudy/ResumeBeat.tsx — One dismissible line shown
+ * when a session resumes past the scene step with existing responses
+ * (#1836): "Picking up where you left off — {StepLabel}."
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { X } from 'lucide-react-native';
+import { GUIDED_STUDY_STEP_LABELS, type GuidedStudyStep } from '../../services/guidedStudy';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+
+interface Props {
+  step: GuidedStudyStep;
+  onDismiss: () => void;
+}
+
+export function ResumeBeat({ step, onDismiss }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      style={[styles.row, { backgroundColor: `${base.gold}10`, borderColor: `${base.gold}30` }]}
+    >
+      <Text style={[styles.text, { color: base.textDim }]}>
+        Picking up where you left off — {GUIDED_STUDY_STEP_LABELS[step]}.
+      </Text>
+      <TouchableOpacity
+        onPress={onDismiss}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss resume note"
+        style={styles.dismiss}
+      >
+        <X size={14} color={base.textMuted} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingLeft: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  text: {
+    flex: 1,
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 13,
+    paddingVertical: spacing.sm,
+  },
+  dismiss: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/src/components/guidedStudy/SavedIndicator.tsx
+++ b/app/src/components/guidedStudy/SavedIndicator.tsx
@@ -1,0 +1,75 @@
+/**
+ * components/guidedStudy/SavedIndicator.tsx — Quiet "Saved" affordance
+ * (#1836). Appears only AFTER a persist actually succeeds (the parent
+ * bumps `savedTick` in the save promise's resolution — never
+ * optimistically), fades in/out, and renders statically under the OS
+ * reduce-motion setting.
+ */
+import React, { useEffect, useState } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { fontFamily, spacing, useTheme } from '../../theme';
+
+const HOLD_MS = 1400;
+
+interface Props {
+  /** Increment after each successful persist; 0 = nothing saved yet. */
+  savedTick: number;
+}
+
+export function SavedIndicator({ savedTick }: Props) {
+  const { base } = useTheme();
+  const reducedMotion = useReducedMotion();
+  const [opacity] = useState(() => new Animated.Value(0));
+  const [visible, setVisible] = useState(false);
+
+  // Render-phase adjustment (React's derive-state-from-props pattern):
+  // a new tick makes the indicator visible without an effect round-trip.
+  const [seenTick, setSeenTick] = useState(savedTick);
+  if (savedTick !== seenTick) {
+    setSeenTick(savedTick);
+    if (savedTick > 0) setVisible(true);
+  }
+
+  useEffect(() => {
+    if (!visible) return;
+
+    if (reducedMotion) {
+      // Static: show, hold, hide — no fade.
+      opacity.setValue(1);
+      const timer = setTimeout(() => setVisible(false), HOLD_MS);
+      return () => clearTimeout(timer);
+    }
+
+    const anim = Animated.sequence([
+      Animated.timing(opacity, { toValue: 1, duration: 180, useNativeDriver: true }),
+      Animated.delay(HOLD_MS),
+      Animated.timing(opacity, { toValue: 0, duration: 320, useNativeDriver: true }),
+    ]);
+    anim.start(({ finished }) => {
+      if (finished) setVisible(false);
+    });
+    return () => anim.stop();
+  }, [visible, savedTick, reducedMotion, opacity]);
+
+  if (!visible) return null;
+
+  return (
+    <Animated.Text
+      accessibilityLiveRegion="polite"
+      style={[styles.text, { color: base.textMuted, opacity: reducedMotion ? 1 : opacity }]}
+    >
+      Saved
+    </Animated.Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  text: {
+    fontFamily: fontFamily.ui,
+    fontSize: 11,
+    letterSpacing: 0.4,
+    textAlign: 'right',
+    marginTop: spacing.xs,
+  },
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -2,6 +2,8 @@ export { CarriedForwardBanner } from './CarriedForwardBanner';
 export type { CarriedForwardItem } from './CarriedForwardBanner';
 export { ConfidenceBadge } from './ConfidenceBadge';
 export { ContextGuardBanner } from './ContextGuardBanner';
+export { EvidencePanelSheet } from './EvidencePanelSheet';
+export type { EvidenceSheetItem } from './EvidencePanelSheet';
 export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { NextChapterNudge } from './NextChapterNudge';

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -8,6 +8,8 @@ export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { NextChapterNudge } from './NextChapterNudge';
 export { PanelRecommendationRow } from './PanelRecommendationRow';
+export { ResumeBeat } from './ResumeBeat';
+export { SavedIndicator } from './SavedIndicator';
 export { SessionReader } from './SessionReader';
 export { StudyModeSelector } from './StudyModeSelector';
 export { StudySessionCTA } from './StudySessionCTA';

--- a/app/src/db/userDatabase.ts
+++ b/app/src/db/userDatabase.ts
@@ -800,6 +800,15 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE guided_study_sessions ADD COLUMN plan_id TEXT;
     `,
   },
+  {
+    version: 26,
+    description:
+      'Evidence trail state (#1835) — visited_trail_json on guided_study_sessions, plus deferred_trail_json reserved for time-adaptive sessions (#1842; that issue must NOT add its own migration).',
+    sql: `
+      ALTER TABLE guided_study_sessions ADD COLUMN visited_trail_json TEXT;
+      ALTER TABLE guided_study_sessions ADD COLUMN deferred_trail_json TEXT;
+    `,
+  },
 ];
 
 /**

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -480,6 +480,37 @@ export async function setSynthesisStrategy(
   );
 }
 
+/**
+ * Append an evidence-trail key to a session's visited set (#1835).
+ * Idempotent: appending an already-visited key is a no-op. Runs in a
+ * transaction so concurrent appends can't drop keys.
+ */
+export async function markGuidedTrailItemVisited(sessionId: number, key: string): Promise<void> {
+  const db = getUserDb();
+  await db.withTransactionAsync(async () => {
+    const row = await db.getFirstAsync<{ visited_trail_json: string | null }>(
+      'SELECT visited_trail_json FROM guided_study_sessions WHERE id = ?',
+      [sessionId],
+    );
+    if (!row) return;
+    let visited: string[] = [];
+    try {
+      const parsed: unknown = JSON.parse(row.visited_trail_json ?? '[]');
+      if (Array.isArray(parsed)) visited = parsed.filter((k): k is string => typeof k === 'string');
+    } catch (err) {
+      logger.warn('userMutations', `Bad visited_trail_json on session ${sessionId} — resetting`, err);
+    }
+    if (visited.includes(key)) return;
+    visited.push(key);
+    await db.runAsync(
+      `UPDATE guided_study_sessions
+       SET visited_trail_json = ?, updated_at = datetime('now')
+       WHERE id = ?`,
+      [JSON.stringify(visited), sessionId],
+    );
+  });
+}
+
 export async function upsertGuidedStudyResponse(
   sessionId: number,
   promptKey: string,

--- a/app/src/hooks/useGuidedStudySession.ts
+++ b/app/src/hooks/useGuidedStudySession.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   createOrResumeGuidedStudySession,
+  markGuidedTrailItemVisited,
   setGuidedStudyStep,
   upsertGuidedStudyResponse,
   upsertGuidedStudySynthesis,
@@ -30,11 +31,22 @@ const EMPTY_SYNTHESIS: GuidedSynthesisDraft = {
   key_connection: '',
 };
 
+/** Parse a visited/deferred trail JSON column into a clean string[]. */
+function parseTrailJson(json: string | null | undefined): string[] {
+  try {
+    const parsed: unknown = JSON.parse(json ?? '[]');
+    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
 export function useGuidedStudySession(chapterId: string | undefined) {
   const [sessionId, setSessionId] = useState<number | null>(null);
   const [currentStep, setCurrentStepState] = useState<GuidedStudyStep>('scene');
   const [responses, setResponses] = useState<Record<string, GuidedStudyResponse>>({});
   const [synthesis, setSynthesis] = useState<GuidedSynthesisDraft>(EMPTY_SYNTHESIS);
+  const [visitedTrail, setVisitedTrail] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -59,6 +71,7 @@ export function useGuidedStudySession(chapterId: string | undefined) {
         setCurrentStepState(session?.current_step ?? 'scene');
         setResponses(Object.fromEntries(responseRows.map((row) => [row.prompt_key, row])));
         setSynthesis(synthesisRowToDraft(synthesisRow));
+        setVisitedTrail(parseTrailJson(session?.visited_trail_json));
       } catch (err) {
         logger.error('useGuidedStudySession', 'Failed to load guided session', err);
       } finally {
@@ -77,6 +90,21 @@ export function useGuidedStudySession(chapterId: string | undefined) {
       if (sessionId != null) {
         await setGuidedStudyStep(sessionId, step).catch((err) =>
           logger.warn('useGuidedStudySession', 'Failed to persist current step', err),
+        );
+      }
+    },
+    [sessionId],
+  );
+
+  // Visited evidence trail (#1835): optimistic in-memory set backed by
+  // guided_study_sessions.visited_trail_json (migration v26) so checks
+  // survive app kill + session resume.
+  const markTrailItemVisited = useCallback(
+    (key: string) => {
+      setVisitedTrail((prev) => (prev.includes(key) ? prev : [...prev, key]));
+      if (sessionId != null) {
+        void markGuidedTrailItemVisited(sessionId, key).catch((err) =>
+          logger.warn('useGuidedStudySession', 'Failed to persist visited trail item', err),
         );
       }
     },
@@ -136,8 +164,10 @@ export function useGuidedStudySession(chapterId: string | undefined) {
       currentStep,
       responses,
       synthesis,
+      visitedTrail,
       isLoading,
       setCurrentStep,
+      markTrailItemVisited,
       saveResponse,
       saveSynthesis,
       savePremiumReview,
@@ -147,8 +177,10 @@ export function useGuidedStudySession(chapterId: string | undefined) {
       currentStep,
       responses,
       synthesis,
+      visitedTrail,
       isLoading,
       setCurrentStep,
+      markTrailItemVisited,
       saveResponse,
       saveSynthesis,
       savePremiumReview,

--- a/app/src/screens/MyStudyScreen.tsx
+++ b/app/src/screens/MyStudyScreen.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, type NavigationProp, type ParamListBase } from '@react-navigation/native';
 import { ArrowLeft, Check, Clock, MessageSquare } from 'lucide-react-native';
+import { isFlagEnabled } from '../config/featureFlags';
 import { usePremium, useReviewQueue } from '../hooks';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { formatChapterRef, getGuidedStudyStepLabel } from '../services/guidedStudy';
@@ -22,6 +23,17 @@ function chapterRouteParams(chapterId: string, initialStep?: string) {
 function MyStudyScreen() {
   const { base } = useTheme();
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
+
+  // #1836: with the study_hub flag on, MyStudy becomes a thin redirect
+  // to the Study tab hub. Pop this screen off its own stack FIRST so
+  // returning to the More tab lands on the previous screen instead of
+  // bouncing back here (no navigation loop). Flag off: unchanged.
+  const redirectToHub = isFlagEnabled('study_hub');
+  useEffect(() => {
+    if (!redirectToHub) return;
+    if (navigation.canGoBack()) navigation.goBack();
+    navigation.getParent()?.navigate('ExploreTab', { screen: 'StudyHub' });
+  }, [navigation, redirectToHub]);
   const {
     dueItems,
     allItems,
@@ -99,6 +111,9 @@ function MyStudyScreen() {
           : `Help me continue my guided study of ${formatChapterRef(session.chapter_id)}. I am currently at ${getGuidedStudyStepLabel(session.current_step)}.`,
     });
   }
+
+  // Render nothing while the flag-on redirect (#1836) is in flight.
+  if (redirectToHub) return null;
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: base.bg }]}>

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -19,8 +19,10 @@ import {
 import { ArrowLeft, MessageSquare } from 'lucide-react-native';
 import {
   CarriedForwardBanner,
+  EvidencePanelSheet,
   EvidenceTrailRow,
   NextChapterNudge,
+  type EvidenceSheetItem,
   PanelRecommendationRow,
   SessionReader,
   StudyModeSelector,
@@ -401,6 +403,37 @@ function StudySessionScreen() {
     [bookId, chapterNum, navigation],
   );
 
+  // Evidence panel sheet (#1835): evidence opens in place; the only way
+  // out of the session is the sheet's explicit "Open full chapter" link.
+  const [sheetItem, setSheetItem] = useState<EvidenceSheetItem | null>(null);
+
+  const findPanelContent = useCallback(
+    (panelType: string, sectionNum?: number): string | null => {
+      if (sectionNum != null) {
+        const section = sections.find((s) => s.section_num === sectionNum);
+        return section?.panels.find((p) => p.panel_type === panelType)?.content_json ?? null;
+      }
+      return chapterPanels.find((p) => p.panel_type === panelType)?.content_json ?? null;
+    },
+    [sections, chapterPanels],
+  );
+
+  const openEvidence = useCallback(
+    (item: EvidenceSheetItem) => {
+      setSheetItem(item);
+      session.markTrailItemVisited(item.key);
+    },
+    [session],
+  );
+
+  const closeEvidenceSheet = useCallback(() => setSheetItem(null), []);
+
+  const openSheetItemFullChapter = useCallback(() => {
+    const item = sheetItem;
+    setSheetItem(null);
+    if (item) openRecommendation(item.panelType, item.sectionNum);
+  }, [openRecommendation, sheetItem]);
+
   const askAmicus = useCallback(async () => {
     if (!isPremium) {
       showUpgrade('feature', 'Companion Study Partner');
@@ -562,16 +595,26 @@ function StudySessionScreen() {
               Open the panels in this order to build context before conclusions.
             </Text>
             {plan.evidenceTrail.length > 0 ? (
-              <View style={styles.trailList}>
-                {plan.evidenceTrail.map((item, index) => (
-                  <EvidenceTrailRow
-                    key={item.key}
-                    item={item}
-                    index={index}
-                    onPress={() => openRecommendation(item.panelType, item.sectionNum)}
-                  />
-                ))}
-              </View>
+              <>
+                <View style={styles.trailList}>
+                  {plan.evidenceTrail.map((item, index) => (
+                    <EvidenceTrailRow
+                      key={item.key}
+                      item={item}
+                      index={index}
+                      visited={session.visitedTrail.includes(item.key)}
+                      onPress={() => openEvidence(item)}
+                    />
+                  ))}
+                </View>
+                <Text style={[styles.trailProgress, { color: base.textMuted }]}>
+                  {
+                    plan.evidenceTrail.filter((item) => session.visitedTrail.includes(item.key))
+                      .length
+                  }{' '}
+                  of {plan.evidenceTrail.length} opened
+                </Text>
+              </>
             ) : (
               <View
                 style={[
@@ -583,7 +626,7 @@ function StudySessionScreen() {
                   <PanelRecommendationRow
                     key={rec.key}
                     recommendation={rec}
-                    onPress={() => openRecommendation(rec.panelType, rec.sectionNum)}
+                    onPress={() => openEvidence(rec)}
                   />
                 ))}
               </View>
@@ -721,6 +764,14 @@ function StudySessionScreen() {
           </View>
         )}
       </ScrollView>
+
+      <EvidencePanelSheet
+        visible={sheetItem != null}
+        item={sheetItem}
+        contentJson={sheetItem ? findPanelContent(sheetItem.panelType, sheetItem.sectionNum) : null}
+        onClose={closeEvidenceSheet}
+        onOpenFullChapter={openSheetItemFullChapter}
+      />
 
       {upgradeRequest && (
         <UpgradePrompt
@@ -911,6 +962,13 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: radii.md,
     paddingHorizontal: spacing.md,
+    marginBottom: spacing.md,
+  },
+  trailProgress: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: -spacing.xs,
     marginBottom: spacing.md,
   },
   trailList: {

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -24,6 +24,8 @@ import {
   NextChapterNudge,
   type EvidenceSheetItem,
   PanelRecommendationRow,
+  ResumeBeat,
+  SavedIndicator,
   SessionReader,
   StudyModeSelector,
   StudySessionStepper,
@@ -49,6 +51,7 @@ import { completeGuidedStudySession } from '../db/userMutations';
 import {
   buildCarryForwardItems,
   buildGuidedStudyPlan,
+  completionPayoffCopy,
   formatChapterRef,
   getPromptBinding,
   setCapturedText,
@@ -120,6 +123,11 @@ function StudySessionScreen() {
   // Reader expand preference (#1834) — per-session component state
   // only; survives step switches because the screen owns it.
   const [readerExpanded, setReaderExpanded] = useState(false);
+  // Saved indicator (#1836): bumped ONLY after a capture persist
+  // resolves — never optimistically.
+  const [captureSavedTick, setCaptureSavedTick] = useState(0);
+  // Resume beat (#1836): step to announce when resuming mid-session.
+  const [resumeBeatStep, setResumeBeatStep] = useState<GuidedStudyStep | null>(null);
   const [capturedInputs, setCapturedInputsState] = useState<CapturedInputs>({});
   const captureSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -205,7 +213,13 @@ function StudySessionScreen() {
         if (sid != null) {
           if (captureSaveTimerRef.current) clearTimeout(captureSaveTimerRef.current);
           captureSaveTimerRef.current = setTimeout(() => {
-            void setCapturedInputs(sid, next);
+            // Saved indicator (#1836) bumps only when the persist
+            // actually resolved — a failed write shows nothing.
+            void setCapturedInputs(sid, next)
+              .then(() => setCaptureSavedTick((tick) => tick + 1))
+              .catch((err) =>
+                logger.warn('StudySessionScreen', 'Failed to persist captured inputs', err),
+              );
           }, 500);
         }
         return next;
@@ -245,6 +259,20 @@ function StudySessionScreen() {
       void setSessionStep(initialStep);
     }
   }, [currentStep, initialStep, sessionId, setSessionStep]);
+
+  // Resume beat (#1836): once per session load, when the session comes
+  // back past the scene step with existing responses, surface one
+  // dismissible "picking up where you left off" line. Ref-guarded like
+  // the initialStep sync so step taps never re-trigger it.
+  const resumeBeatShownForSessionRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (sessionId == null || session.isLoading) return;
+    if (resumeBeatShownForSessionRef.current === sessionId) return;
+    resumeBeatShownForSessionRef.current = sessionId;
+    if (currentStep !== 'scene' && Object.keys(session.responses).length > 0) {
+      setResumeBeatStep(currentStep);
+    }
+  }, [currentStep, session.isLoading, session.responses, sessionId]);
 
   // Soft "after 3 sessions" upgrade nudge (#1742). Fires once per device
   // for free users who reach the review step with >= 3 completed sessions.
@@ -513,6 +541,10 @@ function StudySessionScreen() {
           carryForwardSteps={stepsWithCarryForward(plan.mode, capturedInputs)}
         />
         <StudyModeSelector value={studyMode} onChange={handleModeChange} />
+        {resumeBeatStep && (
+          <ResumeBeat step={resumeBeatStep} onDismiss={() => setResumeBeatStep(null)} />
+        )}
+        <SavedIndicator savedTick={captureSavedTick} />
 
         {session.currentStep === 'scene' && (
           <View style={styles.section}>
@@ -717,7 +749,7 @@ function StudySessionScreen() {
             <ModePromptList step="review" />
             <Text style={[styles.body, { color: base.textDim }]}>
               {reviewSaved
-                ? 'Saved. Your review prompts and concept vocabulary are ready in My Study.'
+                ? completionPayoffCopy()
                 : isPremium
                   ? 'Save your synthesis to create spaced review prompts for this chapter.'
                   : 'Review prompts and concept vocabulary are included with Companion+.'}

--- a/app/src/services/guidedStudy/index.ts
+++ b/app/src/services/guidedStudy/index.ts
@@ -3,6 +3,7 @@ export { MODE_DEFINITIONS, getModeDefinition } from './modes/definitions';
 export { buildGuidedStudyPlan } from './plan';
 export { buildGuidedStudyNextAction, formatChapterRef, getGuidedStudyStepLabel } from './personal';
 export { buildReviewItemsFromSynthesis, nextIntervalAfter, REVIEW_INTERVAL_DAYS } from './review';
+export { completionPayoffCopy, reviewReturnPhrase } from './reviewCopy';
 export {
   buildCarryForwardItems,
   getCapturedText,

--- a/app/src/services/guidedStudy/reviewCopy.ts
+++ b/app/src/services/guidedStudy/reviewCopy.ts
@@ -1,0 +1,17 @@
+/**
+ * services/guidedStudy/reviewCopy.ts — Completion-payoff wording
+ * (#1836). Derives "tomorrow"/"in N days" from the first rung of the
+ * spaced-review ladder so the copy stays honest if
+ * REVIEW_INTERVAL_DAYS ever changes.
+ */
+import { REVIEW_INTERVAL_DAYS } from './review';
+
+/** "tomorrow" for a 1-day interval, otherwise "in N days". */
+export function reviewReturnPhrase(days: number = REVIEW_INTERVAL_DAYS[0]): string {
+  return days === 1 ? 'tomorrow' : `in ${days} days`;
+}
+
+/** The review-step save confirmation line. */
+export function completionPayoffCopy(days: number = REVIEW_INTERVAL_DAYS[0]): string {
+  return `Saved. You'll see this takeaway again ${reviewReturnPhrase(days)}.`;
+}

--- a/app/src/types/user.ts
+++ b/app/src/types/user.ts
@@ -69,6 +69,10 @@ export interface GuidedStudySession {
   synthesis_strategy?: string | null;
   /** Unified study plans (#1831, migration v25). NULL for sessions started outside a plan. */
   plan_id?: string | null;
+  /** Visited evidence-trail keys, JSON string[] (#1835, migration v26). */
+  visited_trail_json?: string | null;
+  /** Deferred evidence-trail keys for time-adaptive sessions, JSON string[] (#1842; column reserved by migration v26). */
+  deferred_trail_json?: string | null;
 }
 
 // ── Unified study plans (#1831, migration v25) ────────────────────


### PR DESCRIPTION
Depends on #1848 — merge in order.

Sixth PR in the Epic #1830 stack (branched from `feature/1835-evidence-sheet`) — completes the spine before the P2 tail. Closes #1836.

## Rationale
Makes persistence and the review contract visible.

- **Saved indicator** (`SavedIndicator`): quiet textMuted "Saved" near the session inputs. The tick that reveals it is bumped **inside the debounced persist's `.then()`** — a failed write shows nothing, never optimistic. Fades in/out via RN Animated; renders statically (show → hold → hide, no fade) under OS reduce-motion.
- **Resume beat** (`ResumeBeat`): opening a session that's past the scene step with existing responses shows one dismissible italic line — "Picking up where you left off — {StepLabel}." from `GUIDED_STUDY_STEP_LABELS`, ref-guarded to fire once per session load so stepper taps never re-trigger it.
- **Completion payoff**: the review-step save confirmation is now `completionPayoffCopy()` from a new `services/guidedStudy/reviewCopy.ts` — wording derives from `REVIEW_INTERVAL_DAYS[0]` ("tomorrow" only when the first rung is 1 day; "in N days" otherwise). No hardcoded "tomorrow". (`review.ts` itself untouched, per the card's no-touch list.)
- **MyStudy redirect**: with `study_hub` on, `MyStudyScreen` renders nothing and redirects to the Study hub — it **pops itself off the More stack before** the cross-tab jump, so returning to the More tab lands on the previous screen instead of bouncing (test asserts the call ordering). Flag off: byte-identical behavior, screen not deleted.

## Rollback plan
Revert the merge commit. Three additive components + one helper + a flag-gated redirect; no DB, route, or service-contract changes. OTA-safe.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **537 suites / 4043 tests passing**, thresholds met (12 new tests: non-optimistic indicator incl. reduced-motion and re-show, resume beat render/dismiss, ladder-derived copy, redirect flag-on/flag-off/empty-stack with pop-before-jump ordering)
- `npx expo export --platform ios` bundles cleanly
- **Flag-off parity checkpoint (per the epic)**: no dev client exists in this cloud env, so the interactive on-device pass is yours; CI-level parity evidence is the flag-off MyStudy test (renders unchanged, zero navigation calls) plus every pre-existing suite passing untouched. The whole spine (#1831→#1836) is now stacked and ready for your on-device verification before #1838.

## Process notes
- Kanban: Projects v2 GraphQL blocked by the environment proxy — please drag #1836 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_