### PR TITLE
feat(study): review-due nudges via app_notifications — #1841

### DIFF
--- a/app/__tests__/components/guidedStudy/ObservationChips.test.tsx
+++ b/app/__tests__/components/guidedStudy/ObservationChips.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * #1839 — ObservationChips: toggle buttons with announced selected
+ * state; renders nothing with no candidates.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { ObservationChips } from '@/components/guidedStudy/ObservationChips';
+
+const CHIPS = [
+  { id: 'covenant', label: 'Covenant' },
+  { id: 'repeat:water', label: 'Water' },
+];
+
+describe('ObservationChips (#1839)', () => {
+  it('renders chips as toggle buttons and reports presses', () => {
+    const onToggle = jest.fn();
+    const { getByLabelText } = render(
+      <ObservationChips chips={CHIPS} selected={[]} onToggle={onToggle} />,
+    );
+
+    const covenant = getByLabelText('Covenant');
+    expect(covenant.props.accessibilityState).toMatchObject({ selected: false });
+    fireEvent.press(covenant);
+    expect(onToggle).toHaveBeenCalledWith('Covenant');
+  });
+
+  it('announces the selected state on marked chips', () => {
+    const { getByLabelText } = render(
+      <ObservationChips chips={CHIPS} selected={['Water']} onToggle={jest.fn()} />,
+    );
+    const water = getByLabelText('Water, marked');
+    expect(water.props.accessibilityState).toMatchObject({ selected: true });
+    expect(getByLabelText('Covenant').props.accessibilityState).toMatchObject({
+      selected: false,
+    });
+  });
+
+  it('labels the group as optional and renders nothing without candidates', () => {
+    const { getByText } = render(
+      <ObservationChips chips={CHIPS} selected={[]} onToggle={jest.fn()} />,
+    );
+    expect(getByText('MARK WHAT YOU NOTICED — OPTIONAL')).toBeTruthy();
+
+    const { toJSON } = render(<ObservationChips chips={[]} selected={[]} onToggle={jest.fn()} />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/__tests__/screens/NotificationFeedRouting.test.tsx
+++ b/app/__tests__/screens/NotificationFeedRouting.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * #1841 — tapping a review-due nudge in the notification feed routes
+ * to the Study tab hub (flag-aware) and marks it read.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockParentNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      getParent: () => ({ navigate: mockParentNavigate }),
+    }),
+    useRoute: () => ({ params: {} }),
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+const mockIsFlagEnabled = jest.fn().mockReturnValue(true);
+jest.mock('@/config/featureFlags', () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
+const mockMarkRead = jest.fn();
+jest.mock('@/hooks/useNotifications', () => ({
+  useNotifications: jest.fn(),
+}));
+
+function stubNotifications() {
+  const { useNotifications } = require('@/hooks/useNotifications');
+  useNotifications.mockReturnValue({
+    notifications: [
+      {
+        id: 'review_due_2026-07-02',
+        type: 'review_due',
+        title: 'Ready to revisit',
+        body: '3 review prompts are ready when you are.',
+        target_type: 'study_hub',
+        is_read: false,
+        created_at: '2026-07-02 08:00:00',
+      },
+    ],
+    unreadCount: 1,
+    markRead: mockMarkRead,
+    markAllRead: jest.fn(),
+    loading: false,
+  });
+}
+
+jest.mock('@/components/ScreenHeader', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    const RN = require('react-native');
+    return <RN.Text>{title}</RN.Text>;
+  },
+}));
+jest.mock('@/components/LoadingSkeleton', () => ({ LoadingSkeleton: () => null }));
+
+import NotificationFeedScreen from '@/screens/NotificationFeedScreen';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsFlagEnabled.mockReturnValue(true);
+  stubNotifications();
+});
+
+describe('NotificationFeedScreen review-nudge routing (#1841)', () => {
+  it('flag on: tapping the nudge marks it read and lands on the Study hub', () => {
+    const { getByText } = render(<NotificationFeedScreen />);
+    fireEvent.press(getByText('3 review prompts are ready when you are.'));
+    expect(mockMarkRead).toHaveBeenCalledWith('review_due_2026-07-02');
+    expect(mockParentNavigate).toHaveBeenCalledWith('ExploreTab', { screen: 'StudyHub' });
+  });
+
+  it('flag off: the same tap falls back to the ExploreMenu root', () => {
+    mockIsFlagEnabled.mockReturnValue(false);
+    const { getByText } = render(<NotificationFeedScreen />);
+    fireEvent.press(getByText('3 review prompts are ready when you are.'));
+    expect(mockParentNavigate).toHaveBeenCalledWith('ExploreTab', { screen: 'ExploreMenu' });
+  });
+});

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -60,8 +60,19 @@ jest.mock('@/hooks/useReviewQueue', () => ({
 }));
 
 const RHYTHM = [{ week: '2026-W27', weekStart: '2026-06-29', sessions: 2, reviews: 1 }];
+const mockStartStudyPlan = jest.fn();
 jest.mock('@/services/study', () => ({
   getWeeklyRhythm: jest.fn().mockResolvedValue(RHYTHM),
+  startStudyPlan: (...args: unknown[]) => mockStartStudyPlan(...args),
+}));
+
+jest.mock('@/hooks', () => ({
+  useBooks: jest.fn().mockReturnValue({
+    liveBooks: [
+      { id: 'genesis', name: 'Genesis', testament: 'ot', total_chapters: 50, book_order: 1, is_live: true },
+      { id: 'john', name: 'John', testament: 'nt', total_chapters: 21, book_order: 43, is_live: true, starter: 1 },
+    ],
+  }),
 }));
 
 import StudyHubScreen from '@/screens/StudyHubScreen';
@@ -106,20 +117,27 @@ function stubReviewQueue(dueItems: GuidedReviewItem[]) {
   mockUseReviewQueue.mockReturnValue({
     dueItems,
     completeItem: mockCompleteItem,
+    isLoading: false,
     reload: jest.fn().mockResolvedValue(undefined),
   });
 }
 
-beforeEach(() => {
-  jest.clearAllMocks();
+function stubContinuePlan(overrides: Record<string, unknown> = {}) {
   mockUseContinuePlan.mockReturnValue({
     plan: PLAN,
     items: ITEMS,
     target: { bookId: 'jonah', chapterNum: 2, step: 'explore' },
     estimateMin: 12,
+    hasAnyPlan: true,
     isLoading: false,
     reload: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
   });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  stubContinuePlan();
   stubReviewQueue([reviewItem(1, 'What did the storm reveal?')]);
 });
 
@@ -163,16 +181,65 @@ describe('StudyHubScreen (#1832)', () => {
     expect(mockNavigate).toHaveBeenCalledWith('PlanPicker', { segment: 'book' });
   });
 
-  it('renders no hero region when there is no active plan', async () => {
-    mockUseContinuePlan.mockReturnValue({
-      plan: null, items: [], target: null, estimateMin: null,
-      isLoading: false, reload: jest.fn().mockResolvedValue(undefined),
-    });
+  it('renders no hero region when there is no active plan (but plans existed before)', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: true });
     const { queryByText, getByText } = render(<StudyHubScreen />);
     expect(queryByText('CONTINUE')).toBeNull();
     expect(queryByText('Resume')).toBeNull();
+    // First-run card must NOT reappear once a plan has ever existed.
+    expect(queryByText('Begin your first study')).toBeNull();
     // The rest of the hub still renders.
     await waitFor(() => expect(getByText('The Biblical World')).toBeTruthy());
+  });
+
+  it('first run (#1837): no plan ever + no reviews shows the invitation card', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([]);
+    const { getByText, getByLabelText } = render(<StudyHubScreen />);
+    expect(getByText('Begin your first study')).toBeTruthy();
+    // Starter meta present -> John is the starter book.
+    expect(getByText('Study John')).toBeTruthy();
+    expect(getByLabelText('Choose something else to study')).toBeTruthy();
+  });
+
+  it('first run (#1837): one tap creates the starter plan and opens session 1', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([]);
+    mockStartStudyPlan.mockResolvedValue({
+      planId: 'plan-first',
+      mode: 'deep',
+      firstRef: { bookId: 'john', chapterNum: 1 },
+    });
+    const { getByLabelText } = render(<StudyHubScreen />);
+
+    fireEvent.press(getByLabelText('Study John — begin your first guided session'));
+    await waitFor(() => {
+      expect(mockStartStudyPlan).toHaveBeenCalledWith({
+        planType: 'book',
+        sourceId: 'john',
+        title: 'John',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith('StudySession', {
+        bookId: 'john',
+        chapterNum: 1,
+        planId: 'plan-first',
+      });
+    });
+  });
+
+  it('first run (#1837): secondary action opens the picker on the book segment', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([]);
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Choose something else to study'));
+    expect(mockNavigate).toHaveBeenCalledWith('PlanPicker', { segment: 'book' });
+  });
+
+  it('first run (#1837): a due review suppresses the invitation card', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([reviewItem(1, 'What did the storm reveal?')]);
+    const { queryByText } = render(<StudyHubScreen />);
+    expect(queryByText('Begin your first study')).toBeNull();
   });
 
   it('completes the current review on "Recall it"', async () => {

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -61,9 +61,11 @@ jest.mock('@/hooks/useReviewQueue', () => ({
 
 const RHYTHM = [{ week: '2026-W27', weekStart: '2026-06-29', sessions: 2, reviews: 1 }];
 const mockStartStudyPlan = jest.fn();
+const mockMaybeInsertReviewNudge = jest.fn().mockResolvedValue(true);
 jest.mock('@/services/study', () => ({
   getWeeklyRhythm: jest.fn().mockResolvedValue(RHYTHM),
   startStudyPlan: (...args: unknown[]) => mockStartStudyPlan(...args),
+  maybeInsertReviewNudge: (...args: unknown[]) => mockMaybeInsertReviewNudge(...args),
 }));
 
 jest.mock('@/hooks', () => ({
@@ -270,5 +272,16 @@ describe('StudyHubScreen (#1832)', () => {
     stubReviewQueue([]);
     const { queryByText } = render(<StudyHubScreen />);
     expect(queryByText('Recall it')).toBeNull();
+  });
+
+  it('drops a review nudge when due items exist, none when the queue is empty (#1841)', async () => {
+    render(<StudyHubScreen />);
+    await waitFor(() => expect(mockMaybeInsertReviewNudge).toHaveBeenCalledWith(1));
+
+    jest.clearAllMocks();
+    stubContinuePlan();
+    stubReviewQueue([]);
+    render(<StudyHubScreen />);
+    expect(mockMaybeInsertReviewNudge).not.toHaveBeenCalled();
   });
 });

--- a/app/__tests__/services/guidedStudy/observationChips.test.ts
+++ b/app/__tests__/services/guidedStudy/observationChips.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #1839 — observation chip candidates (repetition extraction + merge)
+ * and CapturedInputs backward compatibility.
+ */
+import {
+  buildRepetitionChips,
+  mergeObservationChips,
+} from '@/services/guidedStudy/observationChips';
+import { safeParseCapturedInputs } from '@/services/guidedStudy/capturedInputs';
+import { buildCarryForwardItems } from '@/services/guidedStudy/stepBindings';
+import type { Verse } from '@/types';
+
+function verse(num: number, text: string): Verse {
+  return { id: num, book_id: 'jonah', chapter_num: 1, verse_num: num, translation: 'kjv', text };
+}
+
+describe('buildRepetitionChips (#1839)', () => {
+  it('surfaces words repeated three or more times, most frequent first', () => {
+    const verses = [
+      verse(1, 'The covenant stood. The covenant held. A covenant of peace.'),
+      verse(2, 'Water rose and water fell, and the water covered the deep.'),
+      verse(3, 'Peace came once.'),
+    ];
+    const chips = buildRepetitionChips(verses);
+    expect(chips.map((c) => c.label)).toEqual(['Covenant', 'Water']);
+    expect(chips[0].id).toBe('repeat:covenant');
+  });
+
+  it('ignores stopwords and short words regardless of frequency', () => {
+    const verses = [
+      verse(1, 'And the and the and the said said said unto unto unto sea sea sea.'),
+    ];
+    // 'sea' repeats but is under the 4-letter floor; the rest are stopwords.
+    expect(buildRepetitionChips(verses)).toEqual([]);
+  });
+
+  it('caps the candidate list', () => {
+    const words = ['storm', 'vessel', 'prayer', 'mercy', 'signs', 'winds'];
+    const text = words.map((w) => `${w} ${w} ${w}`).join(' ');
+    const chips = buildRepetitionChips([verse(1, text)]);
+    expect(chips.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('mergeObservationChips (#1839)', () => {
+  it('dedupes by label (concept chips win) and caps the merged list', () => {
+    const concept = [
+      { id: 'covenant', label: 'Covenant' },
+      { id: 'genre:poetry', label: 'Poetry' },
+    ];
+    const repeats = [
+      { id: 'repeat:covenant', label: 'Covenant' }, // dup — dropped
+      { id: 'repeat:water', label: 'Water' },
+    ];
+    const merged = mergeObservationChips(concept, repeats);
+    expect(merged.map((c) => c.id)).toEqual(['covenant', 'genre:poetry', 'repeat:water']);
+  });
+});
+
+describe('CapturedInputs.observeSelections compatibility (#1839)', () => {
+  it('old stored JSON without observeSelections parses without error', () => {
+    const legacyJson = JSON.stringify({
+      scene: { genre_response: 'A storm narrative' },
+      observe: { surprises: 'The sailors pray first' },
+      synthesize: { takeaway: 'x', open_question: 'y', key_connection: 'z' },
+    });
+    const parsed = safeParseCapturedInputs(legacyJson);
+    expect(parsed.observe?.surprises).toBe('The sailors pray first');
+    expect(parsed.observeSelections).toBeUndefined();
+  });
+
+  it('round-trips selections through serialize/parse', () => {
+    const parsed = safeParseCapturedInputs(
+      JSON.stringify({ observeSelections: ['Covenant', 'Water'] }),
+    );
+    expect(parsed.observeSelections).toEqual(['Covenant', 'Water']);
+  });
+});
+
+describe('carry-forward integration (#1839)', () => {
+  it('selections appear as a chip item on explore and synthesize, alongside typed text', () => {
+    const captured = {
+      observe: { surprises: 'The sailors pray before Jonah does' },
+      observeSelections: ['Covenant', 'Water'],
+    };
+    const explore = buildCarryForwardItems('deep', 'explore', captured);
+    expect(explore).toEqual([
+      {
+        sourceStep: 'observe',
+        label: 'What you noticed',
+        content: 'The sailors pray before Jonah does',
+      },
+      {
+        sourceStep: 'observe',
+        label: 'What you marked',
+        content: 'Covenant · Water',
+        chips: ['Covenant', 'Water'],
+      },
+    ]);
+
+    const synthesize = buildCarryForwardItems('quick', 'synthesize', captured);
+    expect(synthesize.some((i) => i.chips?.length === 2)).toBe(true);
+  });
+
+  it('adds nothing when no chips are selected (skipping carries no punishment)', () => {
+    expect(buildCarryForwardItems('deep', 'explore', {})).toEqual([]);
+    expect(
+      buildCarryForwardItems('deep', 'explore', { observeSelections: [] }),
+    ).toEqual([]);
+  });
+
+  it('does not leak selections into scene/observe/review steps', () => {
+    const captured = { observeSelections: ['Covenant'] };
+    expect(buildCarryForwardItems('deep', 'observe', captured)).toEqual([]);
+    expect(
+      buildCarryForwardItems('deep', 'review', captured).some((i) => i.chips),
+    ).toBe(false);
+  });
+});

--- a/app/__tests__/services/study/migrateLegacyPlans.test.ts
+++ b/app/__tests__/services/study/migrateLegacyPlans.test.ts
@@ -37,6 +37,15 @@ const LEGACY_PLANS: ReadingPlan[] = [
     total_days: 1,
     chapters_json: JSON.stringify([{ day: 1, chapters: ['1_samuel_16', '1_samuel_17'] }]),
   },
+  {
+    // Curated seed the user never started (no plan_progress rows) —
+    // must NOT migrate, or every fresh install "has plans" (#1837).
+    id: 'untouched_seed',
+    name: 'Untouched Seed',
+    description: 'Shipped with the app, never started.',
+    total_days: 1,
+    chapters_json: JSON.stringify([{ day: 1, chapters: ['genesis_1'] }]),
+  },
 ];
 
 const LEGACY_PROGRESS: PlanProgress[] = [
@@ -105,7 +114,7 @@ beforeEach(() => {
 });
 
 describe('migrateLegacyPlans (#1831)', () => {
-  it('seeds one custom study plan per legacy reading plan', async () => {
+  it('seeds one custom study plan per STARTED legacy reading plan', async () => {
     await migrateLegacyPlans();
 
     expect(mockDb.studyPlans.size).toBe(2);
@@ -117,6 +126,14 @@ describe('migrateLegacyPlans (#1831)', () => {
     )?.[0] as string;
     expect(insertPlanSql).toContain("'custom'");
     expect(insertPlanSql).toContain("'quick'");
+  });
+
+  it('skips curated seeds the user never started (no plan_progress rows)', async () => {
+    await migrateLegacyPlans();
+    expect(mockDb.studyPlans.has('legacy_untouched_seed')).toBe(false);
+    expect(mockDb.planItems.has('legacy_untouched_seed:1')).toBe(false);
+    // Guard still set — the seed is done even when plans are skipped.
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
   });
 
   it('expands chapters_json into reading items and copies day completion onto them', async () => {
@@ -184,7 +201,8 @@ describe('migrateLegacyPlans (#1831)', () => {
           chapters_json: JSON.stringify([{ day: 1, chapters: ['???', 'genesis_1'] }]),
         },
       ],
-      [],
+      // Started (has a progress row) so the plan qualifies for migration.
+      [{ plan_id: 'broken', day_num: 1, completed_at: null }],
     );
 
     await migrateLegacyPlans();

--- a/app/__tests__/services/study/reviewNudge.test.ts
+++ b/app/__tests__/services/study/reviewNudge.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #1841 — review-due nudge dedupe: at most one per calendar day, none
+ * when the queue is empty, rhythm-tone copy.
+ */
+let mockExistingToday: { id: string } | null = null;
+const mockGetFirstAsync = jest.fn(async () => mockExistingToday);
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({ getFirstAsync: mockGetFirstAsync }),
+}));
+
+const mockInsertAppNotification = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/db/userMutations', () => ({
+  insertAppNotification: (...args: unknown[]) => mockInsertAppNotification(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { maybeInsertReviewNudge, reviewNudgeBody } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExistingToday = null;
+});
+
+describe('reviewNudgeBody (#1841)', () => {
+  it('uses the card copy with grammatical singular, no urgency words', () => {
+    expect(reviewNudgeBody(3)).toBe('3 review prompts are ready when you are.');
+    expect(reviewNudgeBody(1)).toBe('1 review prompt is ready when you are.');
+    expect(reviewNudgeBody(3)).not.toMatch(/miss|overdue|streak|now!|hurry/i);
+  });
+});
+
+describe('maybeInsertReviewNudge (#1841)', () => {
+  it('inserts exactly one nudge with a deterministic per-day id', async () => {
+    const inserted = await maybeInsertReviewNudge(3);
+    expect(inserted).toBe(true);
+    expect(mockInsertAppNotification).toHaveBeenCalledTimes(1);
+    const args = mockInsertAppNotification.mock.calls[0][0];
+    expect(args.type).toBe('review_due');
+    expect(args.targetType).toBe('study_hub');
+    expect(args.body).toBe('3 review prompts are ready when you are.');
+    expect(args.id).toMatch(/^review_due_\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('does nothing when the queue is empty', async () => {
+    expect(await maybeInsertReviewNudge(0)).toBe(false);
+    expect(mockGetFirstAsync).not.toHaveBeenCalled();
+    expect(mockInsertAppNotification).not.toHaveBeenCalled();
+  });
+
+  it('dedupes: a nudge already created today blocks a second one', async () => {
+    mockExistingToday = { id: 'review_due_2026-07-02' };
+    expect(await maybeInsertReviewNudge(5)).toBe(false);
+    expect(mockInsertAppNotification).not.toHaveBeenCalled();
+  });
+
+  it('queries by type and calendar day before inserting', async () => {
+    await maybeInsertReviewNudge(2);
+    const [sql, params] = mockGetFirstAsync.mock.calls[0] as unknown as [string, unknown[]];
+    expect(sql).toContain("date(created_at) = date('now')");
+    expect(params).toEqual(['review_due']);
+  });
+
+  it('swallows storage failures without throwing', async () => {
+    mockGetFirstAsync.mockRejectedValueOnce(new Error('db closed'));
+    await expect(maybeInsertReviewNudge(2)).resolves.toBe(false);
+  });
+});

--- a/app/src/components/guidedStudy/CarriedForwardBanner.tsx
+++ b/app/src/components/guidedStudy/CarriedForwardBanner.tsx
@@ -22,6 +22,12 @@ export interface CarriedForwardItem {
   sourceStep: GuidedStudyStep;
   label: string;
   content: string;
+  /**
+   * Observation-chip selections (#1839). When present, the expanded
+   * banner renders these as pills; `content` stays as the collapsed
+   * preview / screen-reader text.
+   */
+  chips?: string[];
 }
 
 interface CarriedForwardBannerProps {
@@ -78,9 +84,19 @@ export function CarriedForwardBanner({
           <Text style={[styles.itemLabel, { color: base.textMuted }]}>
             {item.label.toUpperCase()}
           </Text>
-          <Text style={[styles.itemContent, { color: base.textDim }]}>
-            {collapsed ? previewOf(item.content) : item.content}
-          </Text>
+          {item.chips && item.chips.length > 0 && !collapsed ? (
+            <View style={styles.chipRow}>
+              {item.chips.map((chip) => (
+                <View key={chip} style={[styles.chip, { borderColor: `${base.gold}35` }]}>
+                  <Text style={[styles.chipText, { color: base.gold }]}>{chip}</Text>
+                </View>
+              ))}
+            </View>
+          ) : (
+            <Text style={[styles.itemContent, { color: base.textDim }]}>
+              {collapsed ? previewOf(item.content) : item.content}
+            </Text>
+          )}
         </View>
       ))}
     </TouchableOpacity>
@@ -119,5 +135,21 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.body,
     fontSize: 13,
     lineHeight: 20,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 2,
+  },
+  chip: {
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  chipText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
   },
 });

--- a/app/src/components/guidedStudy/ObservationChips.tsx
+++ b/app/src/components/guidedStudy/ObservationChips.tsx
@@ -1,0 +1,89 @@
+/**
+ * components/guidedStudy/ObservationChips.tsx — Selectable observation
+ * pills under the Observe prompts (#1839, friction phase A). Chips are
+ * an ADDITION to the free-text inputs, never a replacement; skipping
+ * them carries no visual punishment (no error/em-dash states).
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { GuidedConceptChip } from '../../services/guidedStudy';
+import { fontFamily, spacing, useTheme } from '../../theme';
+
+interface Props {
+  chips: GuidedConceptChip[];
+  /** Selected chip labels (persisted as CapturedInputs.observeSelections). */
+  selected: string[];
+  onToggle: (label: string) => void;
+}
+
+export function ObservationChips({ chips, selected, onToggle }: Props) {
+  const { base } = useTheme();
+
+  if (chips.length === 0) return null;
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.label, { color: base.textMuted }]}>
+        MARK WHAT YOU NOTICED — OPTIONAL
+      </Text>
+      <View style={styles.row}>
+        {chips.map((chip) => {
+          const isSelected = selected.includes(chip.label);
+          return (
+            <TouchableOpacity
+              key={chip.id}
+              onPress={() => onToggle(chip.label)}
+              activeOpacity={0.72}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={`${chip.label}${isSelected ? ', marked' : ''}`}
+              style={[
+                styles.chip,
+                {
+                  borderColor: isSelected ? base.gold : base.border,
+                  backgroundColor: isSelected ? `${base.gold}18` : 'transparent',
+                },
+              ]}
+            >
+              <Text
+                style={[styles.chipText, { color: isSelected ? base.gold : base.textDim }]}
+              >
+                {chip.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginTop: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 1,
+    marginBottom: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  chip: {
+    // borderRadius 16 per the design system's pill spec (#1839).
+    borderRadius: 16,
+    borderWidth: 1,
+    minHeight: 32,
+    paddingHorizontal: spacing.sm,
+    justifyContent: 'center',
+  },
+  chipText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -7,6 +7,7 @@ export type { EvidenceSheetItem } from './EvidencePanelSheet';
 export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { NextChapterNudge } from './NextChapterNudge';
+export { ObservationChips } from './ObservationChips';
 export { PanelRecommendationRow } from './PanelRecommendationRow';
 export { ResumeBeat } from './ResumeBeat';
 export { SavedIndicator } from './SavedIndicator';

--- a/app/src/components/study/FirstRunCard.tsx
+++ b/app/src/components/study/FirstRunCard.tsx
@@ -1,0 +1,97 @@
+/**
+ * components/study/FirstRunCard.tsx — Study hub first-run state
+ * (#1837). Shown only when the user has never had a plan and nothing
+ * is due for review: invites rather than presenting an empty gold
+ * rectangle. One tap on the primary action reaches a live session.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+
+interface Props {
+  /** Display name of the starter book the primary action studies. */
+  starterBookName: string;
+  onStudyStarter: () => void;
+  onChooseSomethingElse: () => void;
+}
+
+export function FirstRunCard({ starterBookName, onStudyStarter, onChooseSomethingElse }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}
+    >
+      <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
+        Begin your first study
+      </Text>
+      <Text style={[styles.body, { color: base.textDim }]}>
+        A guided session walks you through one chapter — context, close reading, and a takeaway
+        you keep.
+      </Text>
+
+      <TouchableOpacity
+        onPress={onStudyStarter}
+        activeOpacity={0.72}
+        accessibilityRole="button"
+        accessibilityLabel={`Study ${starterBookName} — begin your first guided session`}
+        style={[styles.primary, { backgroundColor: base.gold }]}
+      >
+        <Text style={[styles.primaryLabel, { color: base.bg }]}>Study {starterBookName}</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        onPress={onChooseSomethingElse}
+        activeOpacity={0.72}
+        accessibilityRole="button"
+        accessibilityLabel="Choose something else to study"
+        style={[styles.secondary, { borderColor: base.border }]}
+      >
+        <Text style={[styles.secondaryLabel, { color: base.textMuted }]}>
+          Choose something else
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 20,
+  },
+  body: {
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  primary: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  primaryLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
+  },
+  secondary: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  secondaryLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -723,6 +723,30 @@ export async function recordConceptEncounter(
   );
 }
 
+// ── In-app notifications (write) ──────────────────────────────────
+
+export interface InsertAppNotificationArgs {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  targetId?: string | null;
+  targetType?: string | null;
+}
+
+/**
+ * Insert a row into the in-app notification feed. OR IGNORE on the
+ * caller-supplied id, so deterministic ids double as dedupe keys
+ * (e.g. the daily review nudge, #1841).
+ */
+export async function insertAppNotification(args: InsertAppNotificationArgs): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT OR IGNORE INTO app_notifications (id, type, title, body, target_id, target_type)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [args.id, args.type, args.title, args.body, args.targetId ?? null, args.targetType ?? null],
+  );
+}
+
 export async function flagContent(
   contentId: string,
   contentType: string,

--- a/app/src/hooks/useContinuePlan.ts
+++ b/app/src/hooks/useContinuePlan.ts
@@ -6,7 +6,7 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { getChapterPanels, getSectionPanels, getSections, getVerses } from '../db/content';
-import { getStudyPlanItems } from '../db/userQueries';
+import { getStudyPlanItems, getStudyPlans } from '../db/userQueries';
 import { getStudyDepthEstimate } from '../services/guidedStudy';
 import { getActivePlan, resumeTarget, type ResumeTarget } from '../services/study';
 import type { SectionPanel, StudyPlan, StudyPlanItem } from '../types';
@@ -18,6 +18,12 @@ export interface ContinuePlanState {
   target: ResumeTarget | null;
   /** Estimated minutes for the next chapter (null while loading/unknown). */
   estimateMin: number | null;
+  /**
+   * True when ANY plan exists, including archived/completed ones —
+   * the first-run card (#1837) must never reappear once a plan has
+   * ever existed, even after everything is finished or archived.
+   */
+  hasAnyPlan: boolean;
   isLoading: boolean;
   reload: () => Promise<void>;
 }
@@ -27,12 +33,17 @@ export function useContinuePlan(): ContinuePlanState {
   const [items, setItems] = useState<StudyPlanItem[]>([]);
   const [target, setTarget] = useState<ResumeTarget | null>(null);
   const [estimateMin, setEstimateMin] = useState<number | null>(null);
+  const [hasAnyPlan, setHasAnyPlan] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const reload = useCallback(async () => {
     setIsLoading(true);
     try {
-      const activePlan = await getActivePlan();
+      const [activePlan, allPlans] = await Promise.all([
+        getActivePlan(),
+        getStudyPlans(true), // include archived — see hasAnyPlan doc
+      ]);
+      setHasAnyPlan(allPlans.length > 0);
       if (!activePlan) {
         setPlan(null);
         setItems([]);
@@ -79,5 +90,5 @@ export function useContinuePlan(): ContinuePlanState {
     void reload();
   }, [reload]);
 
-  return { plan, items, target, estimateMin, isLoading, reload };
+  return { plan, items, target, estimateMin, hasAnyPlan, isLoading, reload };
 }

--- a/app/src/screens/NotificationFeedScreen.tsx
+++ b/app/src/screens/NotificationFeedScreen.tsx
@@ -16,6 +16,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Bell, CheckCheck } from 'lucide-react-native';
+import { isFlagEnabled } from '../config/featureFlags';
 import type { ScreenNavProp } from '../navigation/types';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -34,11 +35,18 @@ function NotificationFeedScreen() {
       if (!item.is_read) {
         markRead(item.id);
       }
-      // Navigate to content if target info is available
-      // For now, just mark as read — navigation targets will be added
-      // as content types are defined
+      // Review-due nudge (#1841): land on the Study tab hub. Route
+      // names are stable, so flag-off falls back to ExploreMenu.
+      if (item.target_type === 'study_hub') {
+        navigation.getParent()?.navigate('ExploreTab', {
+          screen: isFlagEnabled('study_hub') ? 'StudyHub' : 'ExploreMenu',
+        });
+        return;
+      }
+      // Other target types: just mark as read — navigation targets
+      // will be added as content types are defined.
     },
-    [markRead],
+    [markRead, navigation],
   );
 
   const renderItem = useCallback(

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -15,6 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
 import { BeginSomethingNew, type PlanPickerSegment } from '../components/study/BeginSomethingNew';
 import { ContinueHero } from '../components/study/ContinueHero';
+import { FirstRunCard } from '../components/study/FirstRunCard';
 import {
   LibrarySections,
   PREMIUM_SCREENS,
@@ -23,12 +24,13 @@ import { ReviewRecallCard } from '../components/study/ReviewRecallCard';
 import { RhythmLine } from '../components/study/RhythmLine';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { useBooks } from '../hooks';
 import { useContinuePlan } from '../hooks/useContinuePlan';
 import { useExploreImages } from '../hooks/useExploreImages';
 import { usePremium } from '../hooks/usePremium';
 import { useReviewQueue } from '../hooks/useReviewQueue';
 import type { ScreenNavProp } from '../navigation/types';
-import { getWeeklyRhythm, type WeeklyRhythm } from '../services/study';
+import { getWeeklyRhythm, startStudyPlan, type WeeklyRhythm } from '../services/study';
 import { fontFamily, spacing, useTheme } from '../theme';
 import { logger } from '../utils/logger';
 
@@ -40,8 +42,17 @@ function StudyHubScreen() {
 
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const imageRegistry = useExploreImages();
-  const { plan, items, target, estimateMin, reload: reloadPlan } = useContinuePlan();
-  const { dueItems, completeItem, reload: reloadReviews } = useReviewQueue();
+  const {
+    plan,
+    items,
+    target,
+    estimateMin,
+    hasAnyPlan,
+    isLoading: planLoading,
+    reload: reloadPlan,
+  } = useContinuePlan();
+  const { dueItems, completeItem, isLoading: reviewsLoading, reload: reloadReviews } = useReviewQueue();
+  const { liveBooks } = useBooks();
 
   const [rhythm, setRhythm] = useState<WeeklyRhythm[]>([]);
   const [reviewIndex, setReviewIndex] = useState(0);
@@ -87,6 +98,38 @@ function StudyHubScreen() {
     [navigation],
   );
 
+  // First-run state (#1837): the user has never had a plan (archived
+  // and completed ones count as "had") and nothing is due for review.
+  // The starter book comes from books meta (`starter: true`); until
+  // the pipeline carries that flag, fall back to the first live book
+  // in canonical order — still content-derived, never hardcoded.
+  const starterBook = liveBooks.find((b) => !!b.starter) ?? liveBooks[0] ?? null;
+  const showFirstRun =
+    !planLoading && !reviewsLoading && !hasAnyPlan && dueItems.length === 0 && starterBook != null;
+  const [startingFirstPlan, setStartingFirstPlan] = useState(false);
+
+  const handleStudyStarter = useCallback(async () => {
+    if (!starterBook || startingFirstPlan) return;
+    setStartingFirstPlan(true);
+    try {
+      const started = await startStudyPlan({
+        planType: 'book',
+        sourceId: starterBook.id,
+        title: starterBook.name,
+      });
+      if (!started) return;
+      navigation.navigate('StudySession', {
+        bookId: started.firstRef.bookId,
+        chapterNum: started.firstRef.chapterNum,
+        planId: started.planId,
+      });
+    } catch (err) {
+      logger.warn('StudyHub', 'Failed to start first study plan', err);
+    } finally {
+      setStartingFirstPlan(false);
+    }
+  }, [navigation, starterBook, startingFirstPlan]);
+
   const currentReview =
     dueItems.length > 0 ? dueItems[reviewIndex % dueItems.length] : null;
 
@@ -129,6 +172,17 @@ function StudyHubScreen() {
         <Text style={[styles.title, { color: base.gold }]} accessibilityRole="header">
           Study
         </Text>
+
+        {/* ── First-run invitation (#1837): no plan ever + no reviews ─── */}
+        {showFirstRun && starterBook && (
+          <View style={styles.block}>
+            <FirstRunCard
+              starterBookName={starterBook.name}
+              onStudyStarter={handleStudyStarter}
+              onChooseSomethingElse={() => handlePickSegment('book')}
+            />
+          </View>
+        )}
 
         {/* ── Continue hero (hidden entirely when no active plan) ─── */}
         {plan && target && (

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -9,7 +9,7 @@
  * With no active plan the hero region renders nothing (the first-run
  * empty state is #1837; the plan picker row is #1833).
  */
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
@@ -30,7 +30,12 @@ import { useExploreImages } from '../hooks/useExploreImages';
 import { usePremium } from '../hooks/usePremium';
 import { useReviewQueue } from '../hooks/useReviewQueue';
 import type { ScreenNavProp } from '../navigation/types';
-import { getWeeklyRhythm, startStudyPlan, type WeeklyRhythm } from '../services/study';
+import {
+  getWeeklyRhythm,
+  maybeInsertReviewNudge,
+  startStudyPlan,
+  type WeeklyRhythm,
+} from '../services/study';
 import { fontFamily, spacing, useTheme } from '../theme';
 import { logger } from '../utils/logger';
 
@@ -75,6 +80,15 @@ function StudyHubScreen() {
       void reloadRhythm();
     }, [reloadPlan, reloadReviews, reloadRhythm]),
   );
+
+  // Review-due nudge (#1841): when the hub sees due items, drop at
+  // most one quiet in-app notification per calendar day (the service
+  // dedupes; repeated focus/reloads are no-ops).
+  useEffect(() => {
+    if (dueItems.length > 0) {
+      void maybeInsertReviewNudge(dueItems.length);
+    }
+  }, [dueItems.length]);
 
   const handleResume = useCallback(() => {
     if (!target || !plan) return;

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -23,6 +23,7 @@ import {
   EvidenceTrailRow,
   NextChapterNudge,
   type EvidenceSheetItem,
+  ObservationChips,
   PanelRecommendationRow,
   ResumeBeat,
   SavedIndicator,
@@ -231,6 +232,36 @@ function StudySessionScreen() {
   const updateSceneInput = useCallback(
     (key: SceneInputKey, value: string) => updateCapturedField({ step: 'scene', key }, value),
     [updateCapturedField],
+  );
+
+  // Observation chips (#1839): toggle a chip label in/out of
+  // observeSelections with the same debounced persist + saved tick the
+  // text captures use.
+  const toggleObserveSelection = useCallback(
+    (label: string) => {
+      const sid = sessionId;
+      setCapturedInputsState((prev) => {
+        const current = prev.observeSelections ?? [];
+        const next: CapturedInputs = {
+          ...prev,
+          observeSelections: current.includes(label)
+            ? current.filter((l) => l !== label)
+            : [...current, label],
+        };
+        if (sid != null) {
+          if (captureSaveTimerRef.current) clearTimeout(captureSaveTimerRef.current);
+          captureSaveTimerRef.current = setTimeout(() => {
+            void setCapturedInputs(sid, next)
+              .then(() => setCaptureSavedTick((tick) => tick + 1))
+              .catch((err) =>
+                logger.warn('StudySessionScreen', 'Failed to persist observation chips', err),
+              );
+          }, 500);
+        }
+        return next;
+      });
+    },
+    [sessionId],
   );
 
   // Remember the chosen mode so the one-decision plan picker (#1833)
@@ -614,6 +645,11 @@ function StudySessionScreen() {
                 />
               </View>
             ))}
+            <ObservationChips
+              chips={plan.observationChips}
+              selected={capturedInputs.observeSelections ?? []}
+              onToggle={toggleObserveSelection}
+            />
             <PrimaryButton label="Explore study panels" onPress={() => goStep('explore')} />
           </View>
         )}

--- a/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
+++ b/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
@@ -64,6 +64,20 @@ exports[`plan parity for mode=deep chapter gen_1 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -238,6 +252,24 @@ exports[`plan parity for mode=deep chapter isa_53 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -401,6 +433,16 @@ exports[`plan parity for mode=deep chapter prov_3 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -556,6 +598,12 @@ exports[`plan parity for mode=deep chapter psa_23 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -723,6 +771,16 @@ exports[`plan parity for mode=deep chapter rom_8 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -885,6 +943,20 @@ exports[`plan parity for mode=devotional chapter gen_1 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1035,6 +1107,24 @@ exports[`plan parity for mode=devotional chapter isa_53 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1180,6 +1270,16 @@ exports[`plan parity for mode=devotional chapter prov_3 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1317,6 +1417,12 @@ exports[`plan parity for mode=devotional chapter psa_23 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1458,6 +1564,16 @@ exports[`plan parity for mode=devotional chapter rom_8 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1604,6 +1720,20 @@ exports[`plan parity for mode=quick chapter gen_1 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1748,6 +1878,24 @@ exports[`plan parity for mode=quick chapter isa_53 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1888,6 +2036,16 @@ exports[`plan parity for mode=quick chapter prov_3 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2019,6 +2177,12 @@ exports[`plan parity for mode=quick chapter psa_23 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2154,6 +2318,16 @@ exports[`plan parity for mode=quick chapter rom_8 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2301,6 +2475,20 @@ exports[`plan parity for mode=teaching chapter gen_1 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2479,6 +2667,24 @@ exports[`plan parity for mode=teaching chapter isa_53 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2653,6 +2859,16 @@ exports[`plan parity for mode=teaching chapter prov_3 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2819,6 +3035,12 @@ exports[`plan parity for mode=teaching chapter psa_23 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2997,6 +3219,16 @@ exports[`plan parity for mode=teaching chapter rom_8 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,

--- a/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
+++ b/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
@@ -33,6 +33,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/capturedInputs.ts
+++ b/app/src/services/guidedStudy/capturedInputs.ts
@@ -48,6 +48,12 @@ export interface CapturedInputs {
     artifact_generated?: boolean;
     next_chapter_accepted?: boolean;
   };
+  /**
+   * Observation-chip selections (#1839) — chip labels the user marked
+   * on the Observe step. Additive: absent in pre-#1839 stored JSON,
+   * which safeParseCapturedInputs tolerates by design.
+   */
+  observeSelections?: string[];
 }
 
 export function emptyCapturedInputs(): CapturedInputs {

--- a/app/src/services/guidedStudy/observationChips.ts
+++ b/app/src/services/guidedStudy/observationChips.ts
@@ -1,0 +1,73 @@
+/**
+ * services/guidedStudy/observationChips.ts — Chip candidates for the
+ * Observe step (#1839, friction phase A). Combines the plan's concept
+ * chips with repeated-word candidates derived from the chapter's own
+ * verse text, so a reader can mark what they noticed without typing.
+ */
+import type { Verse } from '../../types';
+import type { GuidedConceptChip } from './types';
+
+/** Words too common (English or KJV-flavored) to count as repetition. */
+const STOPWORDS = new Set([
+  'the', 'and', 'that', 'unto', 'shall', 'with', 'them', 'they', 'have', 'from',
+  'were', 'which', 'their', 'there', 'this', 'then', 'when', 'thou', 'thee',
+  'thine', 'hath', 'upon', 'also', 'said', 'saying', 'came', 'come', 'went',
+  'will', 'been', 'because', 'before', 'after', 'against', 'into', 'over',
+  'under', 'again', 'more', 'most', 'other', 'some', 'such', 'than', 'very',
+  'yet', 'not', 'but', 'for', 'his', 'her', 'him', 'she', 'you', 'your',
+  'yours', 'our', 'ours', 'out', 'all', 'are', 'was', 'what', 'who', 'whom',
+  'shalt', 'thereof', 'therefore', 'behold', 'even', 'every', 'let', 'made',
+  'make', 'may', 'now', 'one', 'own', 'so', 'to', 'of', 'in', 'a', 'is', 'it',
+  'be', 'as', 'at', 'by', 'or', 'an', 'no', 'nor', 'on', 'up', 'we', 'us',
+  'me', 'my', 'i', 'he', 'do', 'did', 'done', 'has', 'had', 'ye', 'o',
+]);
+
+const MIN_WORD_LENGTH = 4;
+const MIN_REPETITIONS = 3;
+const MAX_REPETITION_CHIPS = 4;
+const MAX_OBSERVATION_CHIPS = 8;
+
+/**
+ * Repeated-word candidates from the chapter text: words of at least
+ * four letters that appear three or more times, most frequent first.
+ */
+export function buildRepetitionChips(verses: Verse[]): GuidedConceptChip[] {
+  const counts = new Map<string, number>();
+  for (const verse of verses) {
+    const words = verse.text.toLowerCase().match(/[a-z']+/g) ?? [];
+    for (const raw of words) {
+      const word = raw.replace(/^'+|'+$/g, '');
+      if (word.length < MIN_WORD_LENGTH || STOPWORDS.has(word)) continue;
+      counts.set(word, (counts.get(word) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .filter(([, count]) => count >= MIN_REPETITIONS)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, MAX_REPETITION_CHIPS)
+    .map(([word]) => ({
+      id: `repeat:${word}`,
+      label: word.replace(/^\w/, (c) => c.toUpperCase()),
+    }));
+}
+
+/**
+ * Concept chips + repetition chips, deduped by label (case-insensitive,
+ * concept chips win) and capped so the Observe step stays scannable.
+ */
+export function mergeObservationChips(
+  conceptChips: GuidedConceptChip[],
+  repetitionChips: GuidedConceptChip[],
+): GuidedConceptChip[] {
+  const seen = new Set<string>();
+  const merged: GuidedConceptChip[] = [];
+  for (const chip of [...conceptChips, ...repetitionChips]) {
+    const key = chip.label.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(chip);
+    if (merged.length >= MAX_OBSERVATION_CHIPS) break;
+  }
+  return merged;
+}

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,6 +1,7 @@
 import type { SectionPanel } from '../../types';
 import { resolveGenre } from '../../utils/genre';
 import { getModeDefinition } from './modes/definitions';
+import { buildRepetitionChips, mergeObservationChips } from './observationChips';
 import {
   GUIDED_STUDY_STEPS,
   type ConfidenceLevel,
@@ -365,6 +366,8 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
     });
   }
 
+  const conceptChips = buildConceptChips(input);
+
   return {
     chapterId: input.chapter.id,
     title: chapterTitle,
@@ -376,6 +379,8 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
     recommendations: allRecommendations.slice(0, def.recommendationLimit),
     evidenceTrail: buildEvidenceTrail(mode, allRecommendations),
     betterQuestionPrompt: betterQuestion,
-    conceptChips: buildConceptChips(input),
+    conceptChips,
+    // #1839 (additive field only — see issue card): Observe-step chips.
+    observationChips: mergeObservationChips(conceptChips, buildRepetitionChips(input.verses)),
   };
 }

--- a/app/src/services/guidedStudy/stepBindings.ts
+++ b/app/src/services/guidedStudy/stepBindings.ts
@@ -169,6 +169,23 @@ export function buildCarryForwardItems(
     if (!content) continue;
     items.push({ sourceStep: spec.ref.step, label: spec.label, content });
   }
+
+  // Observation-chip selections (#1839) carry into Explore/Synthesize
+  // alongside typed text, rendered as a chip list by the banner.
+  if (step === 'explore' || step === 'synthesize') {
+    const selections = (captured.observeSelections ?? []).filter(
+      (s) => typeof s === 'string' && s.trim().length > 0,
+    );
+    if (selections.length > 0) {
+      items.push({
+        sourceStep: 'observe',
+        label: 'What you marked',
+        content: selections.join(' · '),
+        chips: selections,
+      });
+    }
+  }
+
   return items;
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
@@ -35,6 +35,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
@@ -43,6 +43,7 @@ function planFor(mode: GuidedStudyMode, title = 'Romans 8'): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumStructured.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumStructured.test.ts
@@ -24,6 +24,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
@@ -18,6 +18,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/types.ts
+++ b/app/src/services/guidedStudy/types.ts
@@ -125,6 +125,11 @@ export interface GuidedStudyPlan {
   evidenceTrail: GuidedEvidenceTrailItem[];
   betterQuestionPrompt: string;
   conceptChips: GuidedConceptChip[];
+  /**
+   * Selectable Observe-step chips (#1839): concept chips merged with
+   * repeated-word candidates from the chapter text.
+   */
+  observationChips: GuidedConceptChip[];
 }
 
 export interface GuidedStudyPlanInput {

--- a/app/src/services/study/index.ts
+++ b/app/src/services/study/index.ts
@@ -27,6 +27,7 @@ export {
   type WeeklyRhythm,
 } from './rhythm';
 export { migrateLegacyPlans } from './migrateLegacyPlans';
+export { maybeInsertReviewNudge, REVIEW_NUDGE_TYPE, reviewNudgeBody } from './reviewNudge';
 export {
   completePlanItemForSession,
   getDefaultStudyMode,

--- a/app/src/services/study/migrateLegacyPlans.ts
+++ b/app/src/services/study/migrateLegacyPlans.ts
@@ -3,11 +3,17 @@
  * reading plans into the unified study-plan tables (#1831).
  *
  * Runs once at startup after migrations, guarded by the `app_meta`
- * key `legacy_plans_migrated = '1'`. Every `reading_plans` row becomes
- * a `study_plans` row (plan_type 'custom', source_id = legacy id,
- * default_mode 'quick'); its `chapters_json` days become
+ * key `legacy_plans_migrated = '1'`. Every STARTED `reading_plans` row
+ * (one with plan_progress rows — `startPlan` seeds a row per day)
+ * becomes a `study_plans` row (plan_type 'custom', source_id = legacy
+ * id, default_mode 'quick'); its `chapters_json` days become
  * `study_plan_items` rows (kind 'reading', one per chapter); and
  * `plan_progress.completed_at` is copied onto the matching items.
+ *
+ * Untouched curated seeds (migration v6 ships 10 to every install) do
+ * NOT migrate — otherwise every fresh install would "have plans",
+ * polluting getActivePlan()/the hub hero and making the first-run
+ * state (#1837) unreachable. See the #1837 issue comment.
  *
  * The legacy tables are never dropped or altered — they stay readable
  * until #1838 retires the write paths. Idempotency comes from three
@@ -62,8 +68,18 @@ export async function migrateLegacyPlans(): Promise<void> {
 
   const legacyPlans = await db.getAllAsync<ReadingPlan>('SELECT * FROM reading_plans');
 
+  let migratedCount = 0;
   await db.withTransactionAsync(async () => {
     for (const legacy of legacyPlans) {
+      const progress = await db.getAllAsync<PlanProgress>(
+        'SELECT * FROM plan_progress WHERE plan_id = ?',
+        [legacy.id],
+      );
+      // Only plans the user actually started carry over. Untouched
+      // curated seeds stay legacy-only (readable until #1838).
+      if (progress.length === 0) continue;
+      migratedCount++;
+
       const planId = `legacy_${legacy.id}`;
       await db.runAsync(
         `INSERT OR IGNORE INTO study_plans
@@ -72,10 +88,6 @@ export async function migrateLegacyPlans(): Promise<void> {
         [planId, legacy.id, legacy.name],
       );
 
-      const progress = await db.getAllAsync<PlanProgress>(
-        'SELECT * FROM plan_progress WHERE plan_id = ?',
-        [legacy.id],
-      );
       const completedByDay = new Map<number, string>();
       for (const p of progress) {
         if (p.completed_at) completedByDay.set(p.day_num, p.completed_at);
@@ -110,5 +122,8 @@ export async function migrateLegacyPlans(): Promise<void> {
     );
   });
 
-  logger.info('studyPlans', `migrateLegacyPlans: seeded ${legacyPlans.length} legacy plan(s)`);
+  logger.info(
+    'studyPlans',
+    `migrateLegacyPlans: seeded ${migratedCount} started legacy plan(s) of ${legacyPlans.length}`,
+  );
 }

--- a/app/src/services/study/reviewNudge.ts
+++ b/app/src/services/study/reviewNudge.ts
@@ -1,0 +1,53 @@
+/**
+ * services/study/reviewNudge.ts — Review-due nudges (#1841).
+ *
+ * Due reviews surface as ONE quiet in-app notification per calendar
+ * day. Rhythm tone on purpose: no urgency words, no missed-day counts.
+ * OS push is out of scope — this only writes to app_notifications.
+ */
+import { getUserDb } from '../../db/userDatabase';
+import { insertAppNotification } from '../../db/userMutations';
+import { logger } from '../../utils/logger';
+
+export const REVIEW_NUDGE_TYPE = 'review_due';
+
+/** "3 review prompts are ready when you are." (grammatical for n=1). */
+export function reviewNudgeBody(dueCount: number): string {
+  return dueCount === 1
+    ? '1 review prompt is ready when you are.'
+    : `${dueCount} review prompts are ready when you are.`;
+}
+
+/**
+ * Insert today's review nudge if there are due items and none exists
+ * for today yet. Dedupe is double-layered: a query before insert (per
+ * the card) plus a deterministic per-day id with INSERT OR IGNORE.
+ * Returns true when a nudge was inserted.
+ */
+export async function maybeInsertReviewNudge(dueCount: number): Promise<boolean> {
+  if (dueCount <= 0) return false;
+
+  try {
+    const db = getUserDb();
+    const existing = await db.getFirstAsync<{ id: string }>(
+      `SELECT id FROM app_notifications
+       WHERE type = ? AND date(created_at) = date('now')
+       LIMIT 1`,
+      [REVIEW_NUDGE_TYPE],
+    );
+    if (existing) return false;
+
+    const today = new Date().toISOString().slice(0, 10);
+    await insertAppNotification({
+      id: `review_due_${today}`,
+      type: REVIEW_NUDGE_TYPE,
+      title: 'Ready to revisit',
+      body: reviewNudgeBody(dueCount),
+      targetType: 'study_hub',
+    });
+    return true;
+  } catch (err) {
+    logger.warn('reviewNudge', 'Failed to insert review nudge', err);
+    return false;
+  }
+}

--- a/app/src/types/explore.ts
+++ b/app/src/types/explore.ts
@@ -236,7 +236,13 @@ export interface Submission {
 
 export interface AppNotification {
   id: string;
-  type: 'new_submission' | 'submission_approved' | 'submission_rejected' | 'trust_upgraded';
+  type:
+    | 'new_submission'
+    | 'submission_approved'
+    | 'submission_rejected'
+    | 'trust_upgraded'
+    // Review-due nudge (#1841) — taps route to the Study hub.
+    | 'review_due';
   title: string;
   body: string;
   target_id?: string;


### PR DESCRIPTION
Depends on #1851 — merge in order.

Ninth PR in the Epic #1830 stack (branched from `feature/1839-observation-chips`). Closes #1841.

## Rationale
Due reviews surface as a quiet in-app notification — OS push explicitly out of scope.

- **`services/study/reviewNudge.ts`**: when the hub sees due items, `maybeInsertReviewNudge` drops one row into the existing `app_notifications` table via a new `insertAppNotification` mutation. Copy is the card's rhythm tone — "{n} review prompts are ready when you are." (grammatical singular for n=1; test asserts no urgency words / missed-day counts).
- **Dedupe, double-layered**: a query for today's nudge before insert (per the card), plus a deterministic per-day id (`review_due_YYYY-MM-DD`) with `INSERT OR IGNORE` so even a racing double-mount can't produce two rows. At most one per calendar day; zero when the queue is empty.
- **Routing**: tapping the nudge in the existing notification feed marks it read and lands on the Study tab — `StudyHub` when the flag is on, `ExploreMenu` fallback when off (route names stable). The hub's review card is the first thing rendered when reviews are due, satisfying "review card visible".
- `AppNotification.type` union gains `'review_due'` (additive).

## Rollback plan
Revert the merge commit. One service + one mutation + a hub effect + a feed tap branch; no schema change (the table exists since migration v13). Any already-inserted nudges remain as inert feed rows.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **541 suites / 4069 tests passing**, thresholds met (9 new tests: dedupe one-per-day + empty-queue silence + deterministic id + failure tolerance, copy tone, hub trigger, feed routing flag on/off)

## Process notes
- Kanban: Projects v2 GraphQL blocked by the environment proxy — please drag #1841 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_