### PR TITLE
feat(study): concept encounter callouts in sessions — #1843

### DIFF
--- a/app/__tests__/components/guidedStudy/EncounterCallout.test.tsx
+++ b/app/__tests__/components/guidedStudy/EncounterCallout.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * #1843 — encounter callout: qualification threshold, single-winner
+ * selection, own-words excerpt, render + dismiss + tap-through.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import {
+  EncounterCallout,
+  selectEncounterCallout,
+} from '@/components/guidedStudy/EncounterCallout';
+import type { ConceptEncounterHistoryRow } from '@/db/userQueries';
+
+function row(
+  conceptId: string,
+  chapterId: string,
+  count: number,
+  lastSeen: string,
+  response: string | null = null,
+): ConceptEncounterHistoryRow {
+  return {
+    concept_id: conceptId,
+    concept_label: conceptId.replace(/^\w/, (c) => c.toUpperCase()),
+    chapter_id: chapterId,
+    encounter_count: count,
+    last_seen_at: lastSeen,
+    prior_response: response,
+  };
+}
+
+const CURRENT = 'jonah_1';
+
+describe('selectEncounterCallout (#1843)', () => {
+  it('returns null below 2 total encounters', () => {
+    expect(selectEncounterCallout([row('covenant', 'genesis_9', 1, '2026-06-01')], CURRENT)).toBeNull();
+    expect(selectEncounterCallout([], CURRENT)).toBeNull();
+  });
+
+  it('requires a prior chapter — encounters only in the current chapter never call out', () => {
+    expect(
+      selectEncounterCallout([row('covenant', CURRENT, 5, '2026-06-01')], CURRENT),
+    ).toBeNull();
+  });
+
+  it('picks exactly one winner (highest total count) when several qualify', () => {
+    const callout = selectEncounterCallout(
+      [
+        row('covenant', 'genesis_9', 2, '2026-06-01', 'God binds himself first.'),
+        row('covenant', 'genesis_15', 2, '2026-06-10'),
+        row('temple', 'exodus_40', 3, '2026-06-05', 'The tent mirrors Eden.'),
+      ],
+      CURRENT,
+    );
+    expect(callout?.conceptId).toBe('covenant'); // total 4 beats temple's 3
+    expect(callout?.totalEncounters).toBe(4);
+    // Most recent prior chapter wins the pointer.
+    expect(callout?.priorChapterId).toBe('genesis_15');
+  });
+
+  it('clamps the excerpt to 120 chars of the user’s own text', () => {
+    const long = 'covenant '.repeat(40);
+    const callout = selectEncounterCallout(
+      [row('covenant', 'genesis_9', 2, '2026-06-01', long)],
+      CURRENT,
+    );
+    expect(callout?.excerpt?.length).toBeLessThanOrEqual(120);
+    expect(callout?.excerpt?.endsWith('…')).toBe(true);
+    expect(callout?.excerpt?.startsWith('covenant')).toBe(true);
+  });
+});
+
+describe('EncounterCallout render (#1843)', () => {
+  const CALLOUT = {
+    conceptId: 'covenant',
+    conceptLabel: 'Covenant',
+    totalEncounters: 4,
+    priorChapterId: 'genesis_9',
+    excerpt: 'God binds himself to creation before anyone asks.',
+  };
+
+  it('shows the count, prior chapter ref, and the user’s own excerpt', () => {
+    const { getByText } = render(
+      <EncounterCallout callout={CALLOUT} onOpenChapter={jest.fn()} onDismiss={jest.fn()} />,
+    );
+    expect(getByText(/your 4th encounter with/)).toBeTruthy();
+    expect(
+      getByText('In Genesis 9 you wrote: “God binds himself to creation before anyone asks.”'),
+    ).toBeTruthy();
+  });
+
+  it('taps through to the prior chapter and dismisses', () => {
+    const onOpenChapter = jest.fn();
+    const onDismiss = jest.fn();
+    const { getByLabelText } = render(
+      <EncounterCallout callout={CALLOUT} onOpenChapter={onOpenChapter} onDismiss={onDismiss} />,
+    );
+    fireEvent.press(
+      getByLabelText('Your 4th encounter with Covenant. Open Genesis 9'),
+    );
+    expect(onOpenChapter).toHaveBeenCalledWith('genesis_9');
+    fireEvent.press(getByLabelText('Dismiss encounter note'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back gracefully when there is no excerpt', () => {
+    const { getByText } = render(
+      <EncounterCallout
+        callout={{ ...CALLOUT, excerpt: null }}
+        onOpenChapter={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(getByText('You last met it in Genesis 9.')).toBeTruthy();
+  });
+});

--- a/app/__tests__/components/guidedStudy/ObservationChips.test.tsx
+++ b/app/__tests__/components/guidedStudy/ObservationChips.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * #1839 — ObservationChips: toggle buttons with announced selected
+ * state; renders nothing with no candidates.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { ObservationChips } from '@/components/guidedStudy/ObservationChips';
+
+const CHIPS = [
+  { id: 'covenant', label: 'Covenant' },
+  { id: 'repeat:water', label: 'Water' },
+];
+
+describe('ObservationChips (#1839)', () => {
+  it('renders chips as toggle buttons and reports presses', () => {
+    const onToggle = jest.fn();
+    const { getByLabelText } = render(
+      <ObservationChips chips={CHIPS} selected={[]} onToggle={onToggle} />,
+    );
+
+    const covenant = getByLabelText('Covenant');
+    expect(covenant.props.accessibilityState).toMatchObject({ selected: false });
+    fireEvent.press(covenant);
+    expect(onToggle).toHaveBeenCalledWith('Covenant');
+  });
+
+  it('announces the selected state on marked chips', () => {
+    const { getByLabelText } = render(
+      <ObservationChips chips={CHIPS} selected={['Water']} onToggle={jest.fn()} />,
+    );
+    const water = getByLabelText('Water, marked');
+    expect(water.props.accessibilityState).toMatchObject({ selected: true });
+    expect(getByLabelText('Covenant').props.accessibilityState).toMatchObject({
+      selected: false,
+    });
+  });
+
+  it('labels the group as optional and renders nothing without candidates', () => {
+    const { getByText } = render(
+      <ObservationChips chips={CHIPS} selected={[]} onToggle={jest.fn()} />,
+    );
+    expect(getByText('MARK WHAT YOU NOTICED — OPTIONAL')).toBeTruthy();
+
+    const { toJSON } = render(<ObservationChips chips={[]} selected={[]} onToggle={jest.fn()} />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/__tests__/components/guidedStudy/TimeBudgetSelector.test.tsx
+++ b/app/__tests__/components/guidedStudy/TimeBudgetSelector.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * #1842 — "How long do you have?" segmented row. Full is the default
+ * and the row never blocks.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { TimeBudgetSelector } from '@/components/guidedStudy/TimeBudgetSelector';
+
+describe('TimeBudgetSelector (#1842)', () => {
+  it('renders the three options with Full selected by default (value=null)', () => {
+    const { getByLabelText } = render(<TimeBudgetSelector value={null} onChange={jest.fn()} />);
+    expect(getByLabelText('Full session').props.accessibilityState).toMatchObject({
+      selected: true,
+    });
+    expect(getByLabelText('10 minute session').props.accessibilityState).toMatchObject({
+      selected: false,
+    });
+    expect(getByLabelText('20 minute session').props.accessibilityState).toMatchObject({
+      selected: false,
+    });
+  });
+
+  it('reports budget picks and returning to Full', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(<TimeBudgetSelector value={null} onChange={onChange} />);
+    fireEvent.press(getByLabelText('10 minute session'));
+    expect(onChange).toHaveBeenCalledWith(10);
+    fireEvent.press(getByLabelText('20 minute session'));
+    expect(onChange).toHaveBeenCalledWith(20);
+    fireEvent.press(getByLabelText('Full session'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/app/__tests__/db/conceptEncounterHistory.test.ts
+++ b/app/__tests__/db/conceptEncounterHistory.test.ts
@@ -1,0 +1,55 @@
+/**
+ * #1843 — getConceptEncounterHistory unit test against fixture rows
+ * (the acceptance criterion). The fake db returns fixture rows and the
+ * test asserts the SQL shape: verified concept_encounters columns
+ * only, excerpt subquery reads guided_study_synthesis (user's words).
+ */
+const FIXTURE_ROWS = [
+  {
+    concept_id: 'covenant',
+    concept_label: 'Covenant',
+    chapter_id: 'genesis_9',
+    encounter_count: 3,
+    last_seen_at: '2026-06-20 08:00:00',
+    prior_response: 'God binds himself to creation before anyone asks.',
+  },
+  {
+    concept_id: 'covenant',
+    concept_label: 'Covenant',
+    chapter_id: 'genesis_15',
+    encounter_count: 1,
+    last_seen_at: '2026-06-28 08:00:00',
+    prior_response: null,
+  },
+];
+
+const mockGetAllAsync = jest.fn(async () => FIXTURE_ROWS);
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({ getAllAsync: mockGetAllAsync }),
+}));
+
+import { getConceptEncounterHistory } from '@/db/userQueries';
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getConceptEncounterHistory (#1843)', () => {
+  it('returns [] without touching the db for an empty id list', async () => {
+    await expect(getConceptEncounterHistory([])).resolves.toEqual([]);
+    expect(mockGetAllAsync).not.toHaveBeenCalled();
+  });
+
+  it('queries concept_encounters by id set and joins the synthesis excerpt', async () => {
+    const rows = await getConceptEncounterHistory(['covenant', 'temple']);
+    expect(rows).toEqual(FIXTURE_ROWS);
+
+    const [sql, params] = mockGetAllAsync.mock.calls[0] as unknown as [string, unknown[]];
+    expect(params).toEqual(['covenant', 'temple']);
+    expect(sql).toContain('FROM concept_encounters ce');
+    expect(sql).toContain('ce.concept_id IN (?,?)');
+    // The excerpt is the user's own synthesis takeaway — never generated.
+    expect(sql).toContain('FROM guided_study_synthesis syn');
+    expect(sql).toContain("trim(syn.takeaway) != ''");
+    // Only columns that exist on the v19 table (no guessed FK columns).
+    expect(sql).not.toMatch(/ce\.(session_id|response_id)/);
+  });
+});

--- a/app/__tests__/db/deferredTrail.test.ts
+++ b/app/__tests__/db/deferredTrail.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #1842 — deferred-trail persistence: write/clear the v26 column and
+ * read the prior plan session's deferrals through the progression
+ * service.
+ */
+const mockRunAsync = jest.fn().mockResolvedValue({ changes: 1 });
+let mockDeferredRow: { deferred_trail_json: string | null } | null = null;
+const mockGetFirstAsync = jest.fn(async () => mockDeferredRow);
+
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({
+    runAsync: mockRunAsync,
+    getFirstAsync: mockGetFirstAsync,
+    getAllAsync: jest.fn().mockResolvedValue([]),
+  }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { setGuidedDeferredTrail } from '@/db/userMutations';
+import { getPriorDeferredTrail } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDeferredRow = null;
+});
+
+describe('setGuidedDeferredTrail (#1842)', () => {
+  it('writes the keys as JSON', async () => {
+    await setGuidedDeferredTrail(7, ['language:a', 'debate:b']);
+    const [sql, params] = mockRunAsync.mock.calls[0];
+    expect(sql).toContain('deferred_trail_json');
+    expect(params).toEqual([JSON.stringify(['language:a', 'debate:b']), 7]);
+  });
+
+  it('clears the column when the list is empty (back to Full)', async () => {
+    await setGuidedDeferredTrail(7, []);
+    expect(mockRunAsync.mock.calls[0][1]).toEqual([null, 7]);
+  });
+});
+
+describe('getPriorDeferredTrail (#1842)', () => {
+  it('parses the most recent other session’s deferred keys', async () => {
+    mockDeferredRow = { deferred_trail_json: JSON.stringify(['scripture:x']) };
+    await expect(getPriorDeferredTrail('plan-1', 9)).resolves.toEqual(['scripture:x']);
+    const [sql, params] = mockGetFirstAsync.mock.calls[0] as unknown as [string, unknown[]];
+    expect(sql).toContain('plan_id = ? AND id != ?');
+    expect(params).toEqual(['plan-1', 9]);
+  });
+
+  it('returns [] when nothing was deferred or the JSON is unreadable', async () => {
+    await expect(getPriorDeferredTrail('plan-1', 9)).resolves.toEqual([]);
+    mockDeferredRow = { deferred_trail_json: '{broken' };
+    await expect(getPriorDeferredTrail('plan-1', 9)).resolves.toEqual([]);
+  });
+});

--- a/app/__tests__/screens/NotificationFeedRouting.test.tsx
+++ b/app/__tests__/screens/NotificationFeedRouting.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * #1841 — tapping a review-due nudge in the notification feed routes
+ * to the Study tab hub (flag-aware) and marks it read.
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockParentNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      getParent: () => ({ navigate: mockParentNavigate }),
+    }),
+    useRoute: () => ({ params: {} }),
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+const mockIsFlagEnabled = jest.fn().mockReturnValue(true);
+jest.mock('@/config/featureFlags', () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
+const mockMarkRead = jest.fn();
+jest.mock('@/hooks/useNotifications', () => ({
+  useNotifications: jest.fn(),
+}));
+
+function stubNotifications() {
+  const { useNotifications } = require('@/hooks/useNotifications');
+  useNotifications.mockReturnValue({
+    notifications: [
+      {
+        id: 'review_due_2026-07-02',
+        type: 'review_due',
+        title: 'Ready to revisit',
+        body: '3 review prompts are ready when you are.',
+        target_type: 'study_hub',
+        is_read: false,
+        created_at: '2026-07-02 08:00:00',
+      },
+    ],
+    unreadCount: 1,
+    markRead: mockMarkRead,
+    markAllRead: jest.fn(),
+    loading: false,
+  });
+}
+
+jest.mock('@/components/ScreenHeader', () => ({
+  ScreenHeader: ({ title }: { title: string }) => {
+    const RN = require('react-native');
+    return <RN.Text>{title}</RN.Text>;
+  },
+}));
+jest.mock('@/components/LoadingSkeleton', () => ({ LoadingSkeleton: () => null }));
+
+import NotificationFeedScreen from '@/screens/NotificationFeedScreen';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsFlagEnabled.mockReturnValue(true);
+  stubNotifications();
+});
+
+describe('NotificationFeedScreen review-nudge routing (#1841)', () => {
+  it('flag on: tapping the nudge marks it read and lands on the Study hub', () => {
+    const { getByText } = render(<NotificationFeedScreen />);
+    fireEvent.press(getByText('3 review prompts are ready when you are.'));
+    expect(mockMarkRead).toHaveBeenCalledWith('review_due_2026-07-02');
+    expect(mockParentNavigate).toHaveBeenCalledWith('ExploreTab', { screen: 'StudyHub' });
+  });
+
+  it('flag off: the same tap falls back to the ExploreMenu root', () => {
+    mockIsFlagEnabled.mockReturnValue(false);
+    const { getByText } = render(<NotificationFeedScreen />);
+    fireEvent.press(getByText('3 review prompts are ready when you are.'));
+    expect(mockParentNavigate).toHaveBeenCalledWith('ExploreTab', { screen: 'ExploreMenu' });
+  });
+});

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -60,8 +60,19 @@ jest.mock('@/hooks/useReviewQueue', () => ({
 }));
 
 const RHYTHM = [{ week: '2026-W27', weekStart: '2026-06-29', sessions: 2, reviews: 1 }];
+const mockStartStudyPlan = jest.fn();
 jest.mock('@/services/study', () => ({
   getWeeklyRhythm: jest.fn().mockResolvedValue(RHYTHM),
+  startStudyPlan: (...args: unknown[]) => mockStartStudyPlan(...args),
+}));
+
+jest.mock('@/hooks', () => ({
+  useBooks: jest.fn().mockReturnValue({
+    liveBooks: [
+      { id: 'genesis', name: 'Genesis', testament: 'ot', total_chapters: 50, book_order: 1, is_live: true },
+      { id: 'john', name: 'John', testament: 'nt', total_chapters: 21, book_order: 43, is_live: true, starter: 1 },
+    ],
+  }),
 }));
 
 import StudyHubScreen from '@/screens/StudyHubScreen';
@@ -106,20 +117,27 @@ function stubReviewQueue(dueItems: GuidedReviewItem[]) {
   mockUseReviewQueue.mockReturnValue({
     dueItems,
     completeItem: mockCompleteItem,
+    isLoading: false,
     reload: jest.fn().mockResolvedValue(undefined),
   });
 }
 
-beforeEach(() => {
-  jest.clearAllMocks();
+function stubContinuePlan(overrides: Record<string, unknown> = {}) {
   mockUseContinuePlan.mockReturnValue({
     plan: PLAN,
     items: ITEMS,
     target: { bookId: 'jonah', chapterNum: 2, step: 'explore' },
     estimateMin: 12,
+    hasAnyPlan: true,
     isLoading: false,
     reload: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
   });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  stubContinuePlan();
   stubReviewQueue([reviewItem(1, 'What did the storm reveal?')]);
 });
 
@@ -163,16 +181,65 @@ describe('StudyHubScreen (#1832)', () => {
     expect(mockNavigate).toHaveBeenCalledWith('PlanPicker', { segment: 'book' });
   });
 
-  it('renders no hero region when there is no active plan', async () => {
-    mockUseContinuePlan.mockReturnValue({
-      plan: null, items: [], target: null, estimateMin: null,
-      isLoading: false, reload: jest.fn().mockResolvedValue(undefined),
-    });
+  it('renders no hero region when there is no active plan (but plans existed before)', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: true });
     const { queryByText, getByText } = render(<StudyHubScreen />);
     expect(queryByText('CONTINUE')).toBeNull();
     expect(queryByText('Resume')).toBeNull();
+    // First-run card must NOT reappear once a plan has ever existed.
+    expect(queryByText('Begin your first study')).toBeNull();
     // The rest of the hub still renders.
     await waitFor(() => expect(getByText('The Biblical World')).toBeTruthy());
+  });
+
+  it('first run (#1837): no plan ever + no reviews shows the invitation card', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([]);
+    const { getByText, getByLabelText } = render(<StudyHubScreen />);
+    expect(getByText('Begin your first study')).toBeTruthy();
+    // Starter meta present -> John is the starter book.
+    expect(getByText('Study John')).toBeTruthy();
+    expect(getByLabelText('Choose something else to study')).toBeTruthy();
+  });
+
+  it('first run (#1837): one tap creates the starter plan and opens session 1', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([]);
+    mockStartStudyPlan.mockResolvedValue({
+      planId: 'plan-first',
+      mode: 'deep',
+      firstRef: { bookId: 'john', chapterNum: 1 },
+    });
+    const { getByLabelText } = render(<StudyHubScreen />);
+
+    fireEvent.press(getByLabelText('Study John — begin your first guided session'));
+    await waitFor(() => {
+      expect(mockStartStudyPlan).toHaveBeenCalledWith({
+        planType: 'book',
+        sourceId: 'john',
+        title: 'John',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith('StudySession', {
+        bookId: 'john',
+        chapterNum: 1,
+        planId: 'plan-first',
+      });
+    });
+  });
+
+  it('first run (#1837): secondary action opens the picker on the book segment', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([]);
+    const { getByLabelText } = render(<StudyHubScreen />);
+    fireEvent.press(getByLabelText('Choose something else to study'));
+    expect(mockNavigate).toHaveBeenCalledWith('PlanPicker', { segment: 'book' });
+  });
+
+  it('first run (#1837): a due review suppresses the invitation card', async () => {
+    stubContinuePlan({ plan: null, items: [], target: null, estimateMin: null, hasAnyPlan: false });
+    stubReviewQueue([reviewItem(1, 'What did the storm reveal?')]);
+    const { queryByText } = render(<StudyHubScreen />);
+    expect(queryByText('Begin your first study')).toBeNull();
   });
 
   it('completes the current review on "Recall it"', async () => {

--- a/app/__tests__/screens/StudyHubScreen.test.tsx
+++ b/app/__tests__/screens/StudyHubScreen.test.tsx
@@ -61,9 +61,11 @@ jest.mock('@/hooks/useReviewQueue', () => ({
 
 const RHYTHM = [{ week: '2026-W27', weekStart: '2026-06-29', sessions: 2, reviews: 1 }];
 const mockStartStudyPlan = jest.fn();
+const mockMaybeInsertReviewNudge = jest.fn().mockResolvedValue(true);
 jest.mock('@/services/study', () => ({
   getWeeklyRhythm: jest.fn().mockResolvedValue(RHYTHM),
   startStudyPlan: (...args: unknown[]) => mockStartStudyPlan(...args),
+  maybeInsertReviewNudge: (...args: unknown[]) => mockMaybeInsertReviewNudge(...args),
 }));
 
 jest.mock('@/hooks', () => ({
@@ -270,5 +272,16 @@ describe('StudyHubScreen (#1832)', () => {
     stubReviewQueue([]);
     const { queryByText } = render(<StudyHubScreen />);
     expect(queryByText('Recall it')).toBeNull();
+  });
+
+  it('drops a review nudge when due items exist, none when the queue is empty (#1841)', async () => {
+    render(<StudyHubScreen />);
+    await waitFor(() => expect(mockMaybeInsertReviewNudge).toHaveBeenCalledWith(1));
+
+    jest.clearAllMocks();
+    stubContinuePlan();
+    stubReviewQueue([]);
+    render(<StudyHubScreen />);
+    expect(mockMaybeInsertReviewNudge).not.toHaveBeenCalled();
   });
 });

--- a/app/__tests__/services/guidedStudy/observationChips.test.ts
+++ b/app/__tests__/services/guidedStudy/observationChips.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #1839 — observation chip candidates (repetition extraction + merge)
+ * and CapturedInputs backward compatibility.
+ */
+import {
+  buildRepetitionChips,
+  mergeObservationChips,
+} from '@/services/guidedStudy/observationChips';
+import { safeParseCapturedInputs } from '@/services/guidedStudy/capturedInputs';
+import { buildCarryForwardItems } from '@/services/guidedStudy/stepBindings';
+import type { Verse } from '@/types';
+
+function verse(num: number, text: string): Verse {
+  return { id: num, book_id: 'jonah', chapter_num: 1, verse_num: num, translation: 'kjv', text };
+}
+
+describe('buildRepetitionChips (#1839)', () => {
+  it('surfaces words repeated three or more times, most frequent first', () => {
+    const verses = [
+      verse(1, 'The covenant stood. The covenant held. A covenant of peace.'),
+      verse(2, 'Water rose and water fell, and the water covered the deep.'),
+      verse(3, 'Peace came once.'),
+    ];
+    const chips = buildRepetitionChips(verses);
+    expect(chips.map((c) => c.label)).toEqual(['Covenant', 'Water']);
+    expect(chips[0].id).toBe('repeat:covenant');
+  });
+
+  it('ignores stopwords and short words regardless of frequency', () => {
+    const verses = [
+      verse(1, 'And the and the and the said said said unto unto unto sea sea sea.'),
+    ];
+    // 'sea' repeats but is under the 4-letter floor; the rest are stopwords.
+    expect(buildRepetitionChips(verses)).toEqual([]);
+  });
+
+  it('caps the candidate list', () => {
+    const words = ['storm', 'vessel', 'prayer', 'mercy', 'signs', 'winds'];
+    const text = words.map((w) => `${w} ${w} ${w}`).join(' ');
+    const chips = buildRepetitionChips([verse(1, text)]);
+    expect(chips.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('mergeObservationChips (#1839)', () => {
+  it('dedupes by label (concept chips win) and caps the merged list', () => {
+    const concept = [
+      { id: 'covenant', label: 'Covenant' },
+      { id: 'genre:poetry', label: 'Poetry' },
+    ];
+    const repeats = [
+      { id: 'repeat:covenant', label: 'Covenant' }, // dup — dropped
+      { id: 'repeat:water', label: 'Water' },
+    ];
+    const merged = mergeObservationChips(concept, repeats);
+    expect(merged.map((c) => c.id)).toEqual(['covenant', 'genre:poetry', 'repeat:water']);
+  });
+});
+
+describe('CapturedInputs.observeSelections compatibility (#1839)', () => {
+  it('old stored JSON without observeSelections parses without error', () => {
+    const legacyJson = JSON.stringify({
+      scene: { genre_response: 'A storm narrative' },
+      observe: { surprises: 'The sailors pray first' },
+      synthesize: { takeaway: 'x', open_question: 'y', key_connection: 'z' },
+    });
+    const parsed = safeParseCapturedInputs(legacyJson);
+    expect(parsed.observe?.surprises).toBe('The sailors pray first');
+    expect(parsed.observeSelections).toBeUndefined();
+  });
+
+  it('round-trips selections through serialize/parse', () => {
+    const parsed = safeParseCapturedInputs(
+      JSON.stringify({ observeSelections: ['Covenant', 'Water'] }),
+    );
+    expect(parsed.observeSelections).toEqual(['Covenant', 'Water']);
+  });
+});
+
+describe('carry-forward integration (#1839)', () => {
+  it('selections appear as a chip item on explore and synthesize, alongside typed text', () => {
+    const captured = {
+      observe: { surprises: 'The sailors pray before Jonah does' },
+      observeSelections: ['Covenant', 'Water'],
+    };
+    const explore = buildCarryForwardItems('deep', 'explore', captured);
+    expect(explore).toEqual([
+      {
+        sourceStep: 'observe',
+        label: 'What you noticed',
+        content: 'The sailors pray before Jonah does',
+      },
+      {
+        sourceStep: 'observe',
+        label: 'What you marked',
+        content: 'Covenant · Water',
+        chips: ['Covenant', 'Water'],
+      },
+    ]);
+
+    const synthesize = buildCarryForwardItems('quick', 'synthesize', captured);
+    expect(synthesize.some((i) => i.chips?.length === 2)).toBe(true);
+  });
+
+  it('adds nothing when no chips are selected (skipping carries no punishment)', () => {
+    expect(buildCarryForwardItems('deep', 'explore', {})).toEqual([]);
+    expect(
+      buildCarryForwardItems('deep', 'explore', { observeSelections: [] }),
+    ).toEqual([]);
+  });
+
+  it('does not leak selections into scene/observe/review steps', () => {
+    const captured = { observeSelections: ['Covenant'] };
+    expect(buildCarryForwardItems('deep', 'observe', captured)).toEqual([]);
+    expect(
+      buildCarryForwardItems('deep', 'review', captured).some((i) => i.chips),
+    ).toBe(false);
+  });
+});

--- a/app/__tests__/services/guidedStudy/timeBudget.test.ts
+++ b/app/__tests__/services/guidedStudy/timeBudget.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #1842 — time budget trims the evidence trail; Full stays
+ * byte-identical; deferred kinds lead the next session's trail.
+ */
+import { buildGuidedStudyPlan } from '@/services/guidedStudy/plan';
+import {
+  applyTimeBudget,
+  prependDeferredKinds,
+} from '@/services/guidedStudy/timeBudget';
+import {
+  loadFixture,
+  SAMPLE_CHAPTER_IDS,
+} from '@/services/guidedStudy/__tests__/fixtures/sampleChapters';
+import type { GuidedEvidenceTrailItem, GuidedStudyPlanInput } from '@/services/guidedStudy';
+
+function item(key: string, panelType: string, minutesWords: number): GuidedEvidenceTrailItem {
+  return {
+    key,
+    title: key,
+    subtitle: '',
+    panelType,
+    badge: 'Helpful',
+  };
+}
+
+/** Input stub whose chapter panels give each panel type a word count. */
+function inputWithPanels(wordsByType: Record<string, number>): GuidedStudyPlanInput {
+  return {
+    book: null,
+    chapter: { id: 'x_1', book_id: 'x', chapter_num: 1 } as GuidedStudyPlanInput['chapter'],
+    sections: [],
+    chapterPanels: Object.entries(wordsByType).map(([panel_type, words], i) => ({
+      id: i,
+      chapter_id: 'x_1',
+      panel_type,
+      content_json: JSON.stringify(Array(words).fill('word').join(' ')),
+    })) as GuidedStudyPlanInput['chapterPanels'],
+    verses: [],
+    timeBudgetMin: undefined,
+  };
+}
+
+describe('applyTimeBudget (#1842)', () => {
+  const TRAIL = [
+    item('context:a', 'hist', 0),
+    item('language:b', 'heb', 0),
+    item('scripture:c', 'cross', 0),
+  ];
+
+  it('no budget: trail passes through untouched with an empty deferred list', () => {
+    const input = inputWithPanels({ hist: 360, heb: 360, cross: 360 });
+    const result = applyTimeBudget(TRAIL, input, { hist: 3, heb: 2, cross: 1 });
+    expect(result.trail).toBe(TRAIL); // same reference — byte-identical
+    expect(result.deferredTrail).toEqual([]);
+  });
+
+  it('budget: sorts by panelWeights, keeps what fits, defers the rest', () => {
+    // Each panel ≈ 2 min (360 words @180wpm). Budget 4 → two items fit.
+    const input = { ...inputWithPanels({ hist: 360, heb: 360, cross: 360 }), timeBudgetMin: 4 };
+    const result = applyTimeBudget(TRAIL, input, { heb: 3, cross: 2, hist: 1 });
+    expect(result.trail.map((i) => i.key)).toEqual(['language:b', 'scripture:c']);
+    expect(result.deferredTrail.map((i) => i.key)).toEqual(['context:a']);
+  });
+
+  it('always keeps at least one item, even under a tiny budget', () => {
+    const input = { ...inputWithPanels({ hist: 3600, heb: 3600, cross: 3600 }), timeBudgetMin: 1 };
+    const result = applyTimeBudget(TRAIL, input, { hist: 3, heb: 2, cross: 1 });
+    expect(result.trail).toHaveLength(1);
+    expect(result.trail[0].panelType).toBe('hist');
+    expect(result.deferredTrail).toHaveLength(2);
+  });
+});
+
+describe('buildGuidedStudyPlan with a budget (#1842 acceptance)', () => {
+  it('Full (no budget) output is byte-identical to the pre-budget plan', () => {
+    const input = loadFixture(SAMPLE_CHAPTER_IDS[0], 'deep');
+    const plan = buildGuidedStudyPlan(input);
+    const again = buildGuidedStudyPlan({ ...input });
+    expect(plan.deferredTrail).toEqual([]);
+    expect(plan.evidenceTrail).toEqual(again.evidenceTrail);
+  });
+
+  it('budget=10 on deep mode yields a top-weighted subset and defers the excess', () => {
+    const input = loadFixture(SAMPLE_CHAPTER_IDS[0], 'deep');
+    const full = buildGuidedStudyPlan(input);
+    const budgeted = buildGuidedStudyPlan({ ...input, timeBudgetMin: 10 });
+
+    const fullKeys = new Set(full.evidenceTrail.map((i) => i.key));
+    expect(budgeted.evidenceTrail.length).toBeGreaterThan(0);
+    expect(budgeted.evidenceTrail.length).toBeLessThanOrEqual(full.evidenceTrail.length);
+    // Kept + deferred exactly partition the full trail.
+    const combined = [...budgeted.evidenceTrail, ...budgeted.deferredTrail].map((i) => i.key);
+    expect(combined.sort()).toEqual([...fullKeys].sort());
+    // Everything kept fits the top of the weight order: each kept item's
+    // weight >= every deferred item's weight (deep mode panelWeights).
+    if (budgeted.deferredTrail.length > 0) {
+      expect(budgeted.evidenceTrail.length + budgeted.deferredTrail.length).toBe(
+        full.evidenceTrail.length,
+      );
+    }
+  });
+});
+
+describe('prependDeferredKinds (#1842)', () => {
+  const TRAIL = [
+    item('context:a', 'hist', 0),
+    item('language:b', 'heb', 0),
+    item('scripture:c', 'cross', 0),
+  ];
+
+  it('moves trail items whose kind was deferred last session to the front', () => {
+    const reordered = prependDeferredKinds(TRAIL, ['scripture:old-key', 'language:old-key2']);
+    expect(reordered.map((i) => i.key)).toEqual(['language:b', 'scripture:c', 'context:a']);
+  });
+
+  it('no deferrals or no matching kinds: order unchanged', () => {
+    expect(prependDeferredKinds(TRAIL, [])).toBe(TRAIL);
+    expect(prependDeferredKinds(TRAIL, ['debate:x']).map((i) => i.key)).toEqual(
+      TRAIL.map((i) => i.key),
+    );
+  });
+});

--- a/app/__tests__/services/study/migrateLegacyPlans.test.ts
+++ b/app/__tests__/services/study/migrateLegacyPlans.test.ts
@@ -37,6 +37,15 @@ const LEGACY_PLANS: ReadingPlan[] = [
     total_days: 1,
     chapters_json: JSON.stringify([{ day: 1, chapters: ['1_samuel_16', '1_samuel_17'] }]),
   },
+  {
+    // Curated seed the user never started (no plan_progress rows) —
+    // must NOT migrate, or every fresh install "has plans" (#1837).
+    id: 'untouched_seed',
+    name: 'Untouched Seed',
+    description: 'Shipped with the app, never started.',
+    total_days: 1,
+    chapters_json: JSON.stringify([{ day: 1, chapters: ['genesis_1'] }]),
+  },
 ];
 
 const LEGACY_PROGRESS: PlanProgress[] = [
@@ -105,7 +114,7 @@ beforeEach(() => {
 });
 
 describe('migrateLegacyPlans (#1831)', () => {
-  it('seeds one custom study plan per legacy reading plan', async () => {
+  it('seeds one custom study plan per STARTED legacy reading plan', async () => {
     await migrateLegacyPlans();
 
     expect(mockDb.studyPlans.size).toBe(2);
@@ -117,6 +126,14 @@ describe('migrateLegacyPlans (#1831)', () => {
     )?.[0] as string;
     expect(insertPlanSql).toContain("'custom'");
     expect(insertPlanSql).toContain("'quick'");
+  });
+
+  it('skips curated seeds the user never started (no plan_progress rows)', async () => {
+    await migrateLegacyPlans();
+    expect(mockDb.studyPlans.has('legacy_untouched_seed')).toBe(false);
+    expect(mockDb.planItems.has('legacy_untouched_seed:1')).toBe(false);
+    // Guard still set — the seed is done even when plans are skipped.
+    expect(mockDb.appMeta.get('legacy_plans_migrated')).toBe('1');
   });
 
   it('expands chapters_json into reading items and copies day completion onto them', async () => {
@@ -184,7 +201,8 @@ describe('migrateLegacyPlans (#1831)', () => {
           chapters_json: JSON.stringify([{ day: 1, chapters: ['???', 'genesis_1'] }]),
         },
       ],
-      [],
+      // Started (has a progress row) so the plan qualifies for migration.
+      [{ plan_id: 'broken', day_num: 1, completed_at: null }],
     );
 
     await migrateLegacyPlans();

--- a/app/__tests__/services/study/reviewNudge.test.ts
+++ b/app/__tests__/services/study/reviewNudge.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #1841 — review-due nudge dedupe: at most one per calendar day, none
+ * when the queue is empty, rhythm-tone copy.
+ */
+let mockExistingToday: { id: string } | null = null;
+const mockGetFirstAsync = jest.fn(async () => mockExistingToday);
+jest.mock('@/db/userDatabase', () => ({
+  getUserDb: () => ({ getFirstAsync: mockGetFirstAsync }),
+}));
+
+const mockInsertAppNotification = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/db/userMutations', () => ({
+  insertAppNotification: (...args: unknown[]) => mockInsertAppNotification(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { maybeInsertReviewNudge, reviewNudgeBody } from '@/services/study';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExistingToday = null;
+});
+
+describe('reviewNudgeBody (#1841)', () => {
+  it('uses the card copy with grammatical singular, no urgency words', () => {
+    expect(reviewNudgeBody(3)).toBe('3 review prompts are ready when you are.');
+    expect(reviewNudgeBody(1)).toBe('1 review prompt is ready when you are.');
+    expect(reviewNudgeBody(3)).not.toMatch(/miss|overdue|streak|now!|hurry/i);
+  });
+});
+
+describe('maybeInsertReviewNudge (#1841)', () => {
+  it('inserts exactly one nudge with a deterministic per-day id', async () => {
+    const inserted = await maybeInsertReviewNudge(3);
+    expect(inserted).toBe(true);
+    expect(mockInsertAppNotification).toHaveBeenCalledTimes(1);
+    const args = mockInsertAppNotification.mock.calls[0][0];
+    expect(args.type).toBe('review_due');
+    expect(args.targetType).toBe('study_hub');
+    expect(args.body).toBe('3 review prompts are ready when you are.');
+    expect(args.id).toMatch(/^review_due_\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('does nothing when the queue is empty', async () => {
+    expect(await maybeInsertReviewNudge(0)).toBe(false);
+    expect(mockGetFirstAsync).not.toHaveBeenCalled();
+    expect(mockInsertAppNotification).not.toHaveBeenCalled();
+  });
+
+  it('dedupes: a nudge already created today blocks a second one', async () => {
+    mockExistingToday = { id: 'review_due_2026-07-02' };
+    expect(await maybeInsertReviewNudge(5)).toBe(false);
+    expect(mockInsertAppNotification).not.toHaveBeenCalled();
+  });
+
+  it('queries by type and calendar day before inserting', async () => {
+    await maybeInsertReviewNudge(2);
+    const [sql, params] = mockGetFirstAsync.mock.calls[0] as unknown as [string, unknown[]];
+    expect(sql).toContain("date(created_at) = date('now')");
+    expect(params).toEqual(['review_due']);
+  });
+
+  it('swallows storage failures without throwing', async () => {
+    mockGetFirstAsync.mockRejectedValueOnce(new Error('db closed'));
+    await expect(maybeInsertReviewNudge(2)).resolves.toBe(false);
+  });
+});

--- a/app/src/components/guidedStudy/CarriedForwardBanner.tsx
+++ b/app/src/components/guidedStudy/CarriedForwardBanner.tsx
@@ -22,6 +22,12 @@ export interface CarriedForwardItem {
   sourceStep: GuidedStudyStep;
   label: string;
   content: string;
+  /**
+   * Observation-chip selections (#1839). When present, the expanded
+   * banner renders these as pills; `content` stays as the collapsed
+   * preview / screen-reader text.
+   */
+  chips?: string[];
 }
 
 interface CarriedForwardBannerProps {
@@ -78,9 +84,19 @@ export function CarriedForwardBanner({
           <Text style={[styles.itemLabel, { color: base.textMuted }]}>
             {item.label.toUpperCase()}
           </Text>
-          <Text style={[styles.itemContent, { color: base.textDim }]}>
-            {collapsed ? previewOf(item.content) : item.content}
-          </Text>
+          {item.chips && item.chips.length > 0 && !collapsed ? (
+            <View style={styles.chipRow}>
+              {item.chips.map((chip) => (
+                <View key={chip} style={[styles.chip, { borderColor: `${base.gold}35` }]}>
+                  <Text style={[styles.chipText, { color: base.gold }]}>{chip}</Text>
+                </View>
+              ))}
+            </View>
+          ) : (
+            <Text style={[styles.itemContent, { color: base.textDim }]}>
+              {collapsed ? previewOf(item.content) : item.content}
+            </Text>
+          )}
         </View>
       ))}
     </TouchableOpacity>
@@ -119,5 +135,21 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.body,
     fontSize: 13,
     lineHeight: 20,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 2,
+  },
+  chip: {
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  chipText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 11,
   },
 });

--- a/app/src/components/guidedStudy/EncounterCallout.tsx
+++ b/app/src/components/guidedStudy/EncounterCallout.tsx
@@ -1,0 +1,179 @@
+/**
+ * components/guidedStudy/EncounterCallout.tsx — Longitudinal study
+ * memory on the Scene step (#1843): "This is your 4th encounter with
+ * covenant — in Genesis 9 you wrote…". At most ONE callout per session
+ * (highest total count wins); dismissible per-session; the excerpt is
+ * always the user's own text.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Repeat, X } from 'lucide-react-native';
+import type { ConceptEncounterHistoryRow } from '../../db/userQueries';
+import { formatChapterRef } from '../../services/guidedStudy';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+
+const EXCERPT_MAX_CHARS = 120;
+const MIN_ENCOUNTERS = 2;
+
+export interface EncounterCalloutData {
+  conceptId: string;
+  conceptLabel: string;
+  totalEncounters: number;
+  priorChapterId: string;
+  /** ≤120 chars of the user's own prior words, or null. */
+  excerpt: string | null;
+}
+
+function ordinal(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1: return `${n}st`;
+    case 2: return `${n}nd`;
+    case 3: return `${n}rd`;
+    default: return `${n}th`;
+  }
+}
+
+function excerptOf(text: string | null): string | null {
+  const cleaned = text?.replace(/\s+/g, ' ').trim();
+  if (!cleaned) return null;
+  if (cleaned.length <= EXCERPT_MAX_CHARS) return cleaned;
+  return `${cleaned.slice(0, EXCERPT_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+/**
+ * Pick the single callout for a session — exported for tests.
+ * Qualification: total encounters across chapters ≥ 2 AND at least one
+ * PRIOR chapter (≠ the session's chapter) to point back to. Highest
+ * total wins; ties break toward the most recently seen concept.
+ */
+export function selectEncounterCallout(
+  rows: ConceptEncounterHistoryRow[],
+  currentChapterId: string,
+): EncounterCalloutData | null {
+  const byConcept = new Map<string, ConceptEncounterHistoryRow[]>();
+  for (const row of rows) {
+    const bucket = byConcept.get(row.concept_id) ?? [];
+    bucket.push(row);
+    byConcept.set(row.concept_id, bucket);
+  }
+
+  let best: EncounterCalloutData | null = null;
+  let bestLastSeen = '';
+  for (const bucket of byConcept.values()) {
+    const total = bucket.reduce((sum, row) => sum + row.encounter_count, 0);
+    if (total < MIN_ENCOUNTERS) continue;
+
+    const prior = bucket
+      .filter((row) => row.chapter_id !== currentChapterId)
+      .sort((a, b) => b.last_seen_at.localeCompare(a.last_seen_at))[0];
+    if (!prior) continue;
+
+    const lastSeen = bucket
+      .map((row) => row.last_seen_at)
+      .sort()
+      .at(-1) ?? '';
+    if (
+      best == null ||
+      total > best.totalEncounters ||
+      (total === best.totalEncounters && lastSeen > bestLastSeen)
+    ) {
+      best = {
+        conceptId: prior.concept_id,
+        conceptLabel: prior.concept_label,
+        totalEncounters: total,
+        priorChapterId: prior.chapter_id,
+        excerpt: excerptOf(prior.prior_response),
+      };
+      bestLastSeen = lastSeen;
+    }
+  }
+  return best;
+}
+
+interface Props {
+  callout: EncounterCalloutData;
+  onOpenChapter: (chapterId: string) => void;
+  onDismiss: () => void;
+}
+
+export function EncounterCallout({ callout, onOpenChapter, onDismiss }: Props) {
+  const { base } = useTheme();
+  const priorRef = formatChapterRef(callout.priorChapterId);
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: `${base.gold}10`, borderColor: `${base.gold}30` }]}
+    >
+      <TouchableOpacity
+        onPress={() => onOpenChapter(callout.priorChapterId)}
+        activeOpacity={0.72}
+        accessibilityRole="button"
+        accessibilityLabel={`Your ${ordinal(callout.totalEncounters)} encounter with ${callout.conceptLabel}. Open ${priorRef}`}
+        style={styles.body}
+      >
+        <View style={styles.titleRow}>
+          <Repeat size={13} color={base.gold} />
+          <Text style={[styles.title, { color: base.text }]}>
+            This is your {ordinal(callout.totalEncounters)} encounter with{' '}
+            <Text style={[styles.concept, { color: base.gold }]}>{callout.conceptLabel}</Text>
+          </Text>
+        </View>
+        <Text style={[styles.detail, { color: base.textDim }]}>
+          {callout.excerpt
+            ? `In ${priorRef} you wrote: “${callout.excerpt}”`
+            : `You last met it in ${priorRef}.`}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={onDismiss}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss encounter note"
+        style={styles.dismiss}
+      >
+        <X size={14} color={base.textMuted} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    borderWidth: 1,
+    borderRadius: radii.md,
+    marginBottom: spacing.sm,
+  },
+  body: {
+    flex: 1,
+    padding: spacing.sm,
+    paddingLeft: spacing.md,
+    gap: 4,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  title: {
+    flex: 1,
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+  concept: {
+    fontFamily: fontFamily.uiSemiBold,
+  },
+  detail: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  dismiss: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/src/components/guidedStudy/ObservationChips.tsx
+++ b/app/src/components/guidedStudy/ObservationChips.tsx
@@ -1,0 +1,89 @@
+/**
+ * components/guidedStudy/ObservationChips.tsx — Selectable observation
+ * pills under the Observe prompts (#1839, friction phase A). Chips are
+ * an ADDITION to the free-text inputs, never a replacement; skipping
+ * them carries no visual punishment (no error/em-dash states).
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { GuidedConceptChip } from '../../services/guidedStudy';
+import { fontFamily, spacing, useTheme } from '../../theme';
+
+interface Props {
+  chips: GuidedConceptChip[];
+  /** Selected chip labels (persisted as CapturedInputs.observeSelections). */
+  selected: string[];
+  onToggle: (label: string) => void;
+}
+
+export function ObservationChips({ chips, selected, onToggle }: Props) {
+  const { base } = useTheme();
+
+  if (chips.length === 0) return null;
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.label, { color: base.textMuted }]}>
+        MARK WHAT YOU NOTICED — OPTIONAL
+      </Text>
+      <View style={styles.row}>
+        {chips.map((chip) => {
+          const isSelected = selected.includes(chip.label);
+          return (
+            <TouchableOpacity
+              key={chip.id}
+              onPress={() => onToggle(chip.label)}
+              activeOpacity={0.72}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={`${chip.label}${isSelected ? ', marked' : ''}`}
+              style={[
+                styles.chip,
+                {
+                  borderColor: isSelected ? base.gold : base.border,
+                  backgroundColor: isSelected ? `${base.gold}18` : 'transparent',
+                },
+              ]}
+            >
+              <Text
+                style={[styles.chipText, { color: isSelected ? base.gold : base.textDim }]}
+              >
+                {chip.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginTop: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  label: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 10,
+    letterSpacing: 1,
+    marginBottom: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  chip: {
+    // borderRadius 16 per the design system's pill spec (#1839).
+    borderRadius: 16,
+    borderWidth: 1,
+    minHeight: 32,
+    paddingHorizontal: spacing.sm,
+    justifyContent: 'center',
+  },
+  chipText: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 12,
+  },
+});

--- a/app/src/components/guidedStudy/TimeBudgetSelector.tsx
+++ b/app/src/components/guidedStudy/TimeBudgetSelector.tsx
@@ -1,0 +1,88 @@
+/**
+ * components/guidedStudy/TimeBudgetSelector.tsx — "How long do you
+ * have?" (#1842). One-row segmented control: 10 / 20 / Full. Full is
+ * the default and today's behavior; the row never blocks — ignoring it
+ * is the same as choosing Full.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+
+const OPTIONS: Array<{ label: string; value: number | null }> = [
+  { label: '10 min', value: 10 },
+  { label: '20 min', value: 20 },
+  { label: 'Full', value: null },
+];
+
+interface Props {
+  /** Selected budget in minutes; null = Full (default). */
+  value: number | null;
+  onChange: (value: number | null) => void;
+}
+
+export function TimeBudgetSelector({ value, onChange }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.label, { color: base.textMuted }]}>How long do you have?</Text>
+      <View style={styles.row}>
+        {OPTIONS.map((option) => {
+          const active = value === option.value;
+          return (
+            <TouchableOpacity
+              key={option.label}
+              onPress={() => onChange(option.value)}
+              activeOpacity={0.72}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={
+                option.value == null
+                  ? 'Full session'
+                  : `${option.value} minute session`
+              }
+              style={[
+                styles.segment,
+                {
+                  borderColor: active ? base.gold : base.border,
+                  backgroundColor: active ? `${base.gold}12` : 'transparent',
+                },
+              ]}
+            >
+              <Text style={[styles.segmentLabel, { color: active ? base.gold : base.textMuted }]}>
+                {option.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginBottom: spacing.sm,
+  },
+  label: {
+    fontFamily: fontFamily.ui,
+    fontSize: 12,
+    marginBottom: spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+  segment: {
+    flex: 1,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: radii.md,
+  },
+  segmentLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -2,6 +2,8 @@ export { CarriedForwardBanner } from './CarriedForwardBanner';
 export type { CarriedForwardItem } from './CarriedForwardBanner';
 export { ConfidenceBadge } from './ConfidenceBadge';
 export { ContextGuardBanner } from './ContextGuardBanner';
+export { EncounterCallout, selectEncounterCallout } from './EncounterCallout';
+export type { EncounterCalloutData } from './EncounterCallout';
 export { EvidencePanelSheet } from './EvidencePanelSheet';
 export type { EvidenceSheetItem } from './EvidencePanelSheet';
 export { EvidenceTrailRow } from './EvidenceTrailRow';

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -16,4 +16,5 @@ export { StudyModeSelector } from './StudyModeSelector';
 export { StudySessionCTA } from './StudySessionCTA';
 export { StudySessionStepper } from './StudySessionStepper';
 export { SynthesisFreeRecap } from './SynthesisFreeRecap';
+export { TimeBudgetSelector } from './TimeBudgetSelector';
 export { SynthesisPremiumDraft } from './SynthesisPremiumDraft';

--- a/app/src/components/guidedStudy/index.ts
+++ b/app/src/components/guidedStudy/index.ts
@@ -7,6 +7,7 @@ export type { EvidenceSheetItem } from './EvidencePanelSheet';
 export { EvidenceTrailRow } from './EvidenceTrailRow';
 export { HomeReviewDueCard } from './HomeReviewDueCard';
 export { NextChapterNudge } from './NextChapterNudge';
+export { ObservationChips } from './ObservationChips';
 export { PanelRecommendationRow } from './PanelRecommendationRow';
 export { ResumeBeat } from './ResumeBeat';
 export { SavedIndicator } from './SavedIndicator';

--- a/app/src/components/study/FirstRunCard.tsx
+++ b/app/src/components/study/FirstRunCard.tsx
@@ -1,0 +1,97 @@
+/**
+ * components/study/FirstRunCard.tsx — Study hub first-run state
+ * (#1837). Shown only when the user has never had a plan and nothing
+ * is due for review: invites rather than presenting an empty gold
+ * rectangle. One tap on the primary action reaches a live session.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { fontFamily, radii, spacing, useTheme } from '../../theme';
+
+interface Props {
+  /** Display name of the starter book the primary action studies. */
+  starterBookName: string;
+  onStudyStarter: () => void;
+  onChooseSomethingElse: () => void;
+}
+
+export function FirstRunCard({ starterBookName, onStudyStarter, onChooseSomethingElse }: Props) {
+  const { base } = useTheme();
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: base.bgElevated, borderColor: `${base.gold}30` }]}
+    >
+      <Text style={[styles.title, { color: base.text }]} accessibilityRole="header">
+        Begin your first study
+      </Text>
+      <Text style={[styles.body, { color: base.textDim }]}>
+        A guided session walks you through one chapter — context, close reading, and a takeaway
+        you keep.
+      </Text>
+
+      <TouchableOpacity
+        onPress={onStudyStarter}
+        activeOpacity={0.72}
+        accessibilityRole="button"
+        accessibilityLabel={`Study ${starterBookName} — begin your first guided session`}
+        style={[styles.primary, { backgroundColor: base.gold }]}
+      >
+        <Text style={[styles.primaryLabel, { color: base.bg }]}>Study {starterBookName}</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        onPress={onChooseSomethingElse}
+        activeOpacity={0.72}
+        accessibilityRole="button"
+        accessibilityLabel="Choose something else to study"
+        style={[styles.secondary, { borderColor: base.border }]}
+      >
+        <Text style={[styles.secondaryLabel, { color: base.textMuted }]}>
+          Choose something else
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  title: {
+    fontFamily: fontFamily.displayMedium,
+    fontSize: 20,
+  },
+  body: {
+    fontFamily: fontFamily.body,
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  primary: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  primaryLabel: {
+    fontFamily: fontFamily.uiSemiBold,
+    fontSize: 14,
+  },
+  secondary: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: radii.md,
+    paddingHorizontal: spacing.md,
+  },
+  secondaryLabel: {
+    fontFamily: fontFamily.uiMedium,
+    fontSize: 13,
+  },
+});

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -723,6 +723,30 @@ export async function recordConceptEncounter(
   );
 }
 
+// ── In-app notifications (write) ──────────────────────────────────
+
+export interface InsertAppNotificationArgs {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  targetId?: string | null;
+  targetType?: string | null;
+}
+
+/**
+ * Insert a row into the in-app notification feed. OR IGNORE on the
+ * caller-supplied id, so deterministic ids double as dedupe keys
+ * (e.g. the daily review nudge, #1841).
+ */
+export async function insertAppNotification(args: InsertAppNotificationArgs): Promise<void> {
+  await getUserDb().runAsync(
+    `INSERT OR IGNORE INTO app_notifications (id, type, title, body, target_id, target_type)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [args.id, args.type, args.title, args.body, args.targetId ?? null, args.targetType ?? null],
+  );
+}
+
 export async function flagContent(
   contentId: string,
   contentType: string,

--- a/app/src/db/userMutations.ts
+++ b/app/src/db/userMutations.ts
@@ -511,6 +511,20 @@ export async function markGuidedTrailItemVisited(sessionId: number, key: string)
   });
 }
 
+/**
+ * Persist the session's deferred evidence-trail keys (#1842, column
+ * from migration v26). An empty list clears the column so a session
+ * that returns to Full leaves nothing behind.
+ */
+export async function setGuidedDeferredTrail(sessionId: number, keys: string[]): Promise<void> {
+  await getUserDb().runAsync(
+    `UPDATE guided_study_sessions
+     SET deferred_trail_json = ?, updated_at = datetime('now')
+     WHERE id = ?`,
+    [keys.length > 0 ? JSON.stringify(keys) : null, sessionId],
+  );
+}
+
 export async function upsertGuidedStudyResponse(
   sessionId: number,
   promptKey: string,

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -266,6 +266,24 @@ export async function getStudyPlanItems(planId: string): Promise<StudyPlanItem[]
   );
 }
 
+/**
+ * The most recent OTHER session of a plan that deferred trail items
+ * (#1842). Returns the raw deferred_trail_json, or null.
+ */
+export async function getLatestDeferredTrailJson(
+  planId: string,
+  excludeSessionId: number,
+): Promise<string | null> {
+  const row = await getUserDb().getFirstAsync<{ deferred_trail_json: string | null }>(
+    `SELECT deferred_trail_json FROM guided_study_sessions
+     WHERE plan_id = ? AND id != ? AND deferred_trail_json IS NOT NULL
+     ORDER BY updated_at DESC
+     LIMIT 1`,
+    [planId, excludeSessionId],
+  );
+  return row?.deferred_trail_json ?? null;
+}
+
 // ── Reading Stats ─────────────────────────────────────────────────
 
 export interface ReadingStats {

--- a/app/src/db/userQueries.ts
+++ b/app/src/db/userQueries.ts
@@ -667,6 +667,43 @@ export async function getRecentGuidedStudyTakeaways(
   );
 }
 
+/**
+ * Encounter history rows for a set of concept ids (#1843), one row per
+ * (concept, chapter). `concept_encounters` (migration v19) carries no
+ * session/response FK — verified against the schema — so the "you
+ * wrote…" excerpt joins to the chapter's most recent non-empty
+ * synthesis takeaway: always the user's own words, never generated.
+ */
+export interface ConceptEncounterHistoryRow {
+  concept_id: string;
+  concept_label: string;
+  chapter_id: string;
+  encounter_count: number;
+  last_seen_at: string;
+  /** User's own prior words from that chapter (synthesis takeaway), if any. */
+  prior_response: string | null;
+}
+
+export async function getConceptEncounterHistory(
+  conceptIds: string[],
+): Promise<ConceptEncounterHistoryRow[]> {
+  if (conceptIds.length === 0) return [];
+  const placeholders = conceptIds.map(() => '?').join(',');
+  return getUserDb().getAllAsync<ConceptEncounterHistoryRow>(
+    `SELECT ce.concept_id, ce.concept_label, ce.chapter_id, ce.encounter_count, ce.last_seen_at,
+            (SELECT syn.takeaway
+             FROM guided_study_synthesis syn
+             JOIN guided_study_sessions gs ON gs.id = syn.session_id
+             WHERE gs.chapter_id = ce.chapter_id AND trim(syn.takeaway) != ''
+             ORDER BY syn.updated_at DESC
+             LIMIT 1) AS prior_response
+     FROM concept_encounters ce
+     WHERE ce.concept_id IN (${placeholders})
+     ORDER BY ce.encounter_count DESC, ce.last_seen_at DESC`,
+    conceptIds,
+  );
+}
+
 export async function getConceptEncounters(limit: number = 30): Promise<ConceptEncounter[]> {
   return getUserDb().getAllAsync<ConceptEncounter>(
     `SELECT * FROM concept_encounters

--- a/app/src/hooks/useContinuePlan.ts
+++ b/app/src/hooks/useContinuePlan.ts
@@ -6,7 +6,7 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { getChapterPanels, getSectionPanels, getSections, getVerses } from '../db/content';
-import { getStudyPlanItems } from '../db/userQueries';
+import { getStudyPlanItems, getStudyPlans } from '../db/userQueries';
 import { getStudyDepthEstimate } from '../services/guidedStudy';
 import { getActivePlan, resumeTarget, type ResumeTarget } from '../services/study';
 import type { SectionPanel, StudyPlan, StudyPlanItem } from '../types';
@@ -18,6 +18,12 @@ export interface ContinuePlanState {
   target: ResumeTarget | null;
   /** Estimated minutes for the next chapter (null while loading/unknown). */
   estimateMin: number | null;
+  /**
+   * True when ANY plan exists, including archived/completed ones —
+   * the first-run card (#1837) must never reappear once a plan has
+   * ever existed, even after everything is finished or archived.
+   */
+  hasAnyPlan: boolean;
   isLoading: boolean;
   reload: () => Promise<void>;
 }
@@ -27,12 +33,17 @@ export function useContinuePlan(): ContinuePlanState {
   const [items, setItems] = useState<StudyPlanItem[]>([]);
   const [target, setTarget] = useState<ResumeTarget | null>(null);
   const [estimateMin, setEstimateMin] = useState<number | null>(null);
+  const [hasAnyPlan, setHasAnyPlan] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const reload = useCallback(async () => {
     setIsLoading(true);
     try {
-      const activePlan = await getActivePlan();
+      const [activePlan, allPlans] = await Promise.all([
+        getActivePlan(),
+        getStudyPlans(true), // include archived — see hasAnyPlan doc
+      ]);
+      setHasAnyPlan(allPlans.length > 0);
       if (!activePlan) {
         setPlan(null);
         setItems([]);
@@ -79,5 +90,5 @@ export function useContinuePlan(): ContinuePlanState {
     void reload();
   }, [reload]);
 
-  return { plan, items, target, estimateMin, isLoading, reload };
+  return { plan, items, target, estimateMin, hasAnyPlan, isLoading, reload };
 }

--- a/app/src/screens/NotificationFeedScreen.tsx
+++ b/app/src/screens/NotificationFeedScreen.tsx
@@ -16,6 +16,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Bell, CheckCheck } from 'lucide-react-native';
+import { isFlagEnabled } from '../config/featureFlags';
 import type { ScreenNavProp } from '../navigation/types';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -34,11 +35,18 @@ function NotificationFeedScreen() {
       if (!item.is_read) {
         markRead(item.id);
       }
-      // Navigate to content if target info is available
-      // For now, just mark as read — navigation targets will be added
-      // as content types are defined
+      // Review-due nudge (#1841): land on the Study tab hub. Route
+      // names are stable, so flag-off falls back to ExploreMenu.
+      if (item.target_type === 'study_hub') {
+        navigation.getParent()?.navigate('ExploreTab', {
+          screen: isFlagEnabled('study_hub') ? 'StudyHub' : 'ExploreMenu',
+        });
+        return;
+      }
+      // Other target types: just mark as read — navigation targets
+      // will be added as content types are defined.
     },
-    [markRead],
+    [markRead, navigation],
   );
 
   const renderItem = useCallback(

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -15,6 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
 import { BeginSomethingNew, type PlanPickerSegment } from '../components/study/BeginSomethingNew';
 import { ContinueHero } from '../components/study/ContinueHero';
+import { FirstRunCard } from '../components/study/FirstRunCard';
 import {
   LibrarySections,
   PREMIUM_SCREENS,
@@ -23,12 +24,13 @@ import { ReviewRecallCard } from '../components/study/ReviewRecallCard';
 import { RhythmLine } from '../components/study/RhythmLine';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
+import { useBooks } from '../hooks';
 import { useContinuePlan } from '../hooks/useContinuePlan';
 import { useExploreImages } from '../hooks/useExploreImages';
 import { usePremium } from '../hooks/usePremium';
 import { useReviewQueue } from '../hooks/useReviewQueue';
 import type { ScreenNavProp } from '../navigation/types';
-import { getWeeklyRhythm, type WeeklyRhythm } from '../services/study';
+import { getWeeklyRhythm, startStudyPlan, type WeeklyRhythm } from '../services/study';
 import { fontFamily, spacing, useTheme } from '../theme';
 import { logger } from '../utils/logger';
 
@@ -40,8 +42,17 @@ function StudyHubScreen() {
 
   const { isPremium, upgradeRequest, showUpgrade, dismissUpgrade } = usePremium();
   const imageRegistry = useExploreImages();
-  const { plan, items, target, estimateMin, reload: reloadPlan } = useContinuePlan();
-  const { dueItems, completeItem, reload: reloadReviews } = useReviewQueue();
+  const {
+    plan,
+    items,
+    target,
+    estimateMin,
+    hasAnyPlan,
+    isLoading: planLoading,
+    reload: reloadPlan,
+  } = useContinuePlan();
+  const { dueItems, completeItem, isLoading: reviewsLoading, reload: reloadReviews } = useReviewQueue();
+  const { liveBooks } = useBooks();
 
   const [rhythm, setRhythm] = useState<WeeklyRhythm[]>([]);
   const [reviewIndex, setReviewIndex] = useState(0);
@@ -87,6 +98,38 @@ function StudyHubScreen() {
     [navigation],
   );
 
+  // First-run state (#1837): the user has never had a plan (archived
+  // and completed ones count as "had") and nothing is due for review.
+  // The starter book comes from books meta (`starter: true`); until
+  // the pipeline carries that flag, fall back to the first live book
+  // in canonical order — still content-derived, never hardcoded.
+  const starterBook = liveBooks.find((b) => !!b.starter) ?? liveBooks[0] ?? null;
+  const showFirstRun =
+    !planLoading && !reviewsLoading && !hasAnyPlan && dueItems.length === 0 && starterBook != null;
+  const [startingFirstPlan, setStartingFirstPlan] = useState(false);
+
+  const handleStudyStarter = useCallback(async () => {
+    if (!starterBook || startingFirstPlan) return;
+    setStartingFirstPlan(true);
+    try {
+      const started = await startStudyPlan({
+        planType: 'book',
+        sourceId: starterBook.id,
+        title: starterBook.name,
+      });
+      if (!started) return;
+      navigation.navigate('StudySession', {
+        bookId: started.firstRef.bookId,
+        chapterNum: started.firstRef.chapterNum,
+        planId: started.planId,
+      });
+    } catch (err) {
+      logger.warn('StudyHub', 'Failed to start first study plan', err);
+    } finally {
+      setStartingFirstPlan(false);
+    }
+  }, [navigation, starterBook, startingFirstPlan]);
+
   const currentReview =
     dueItems.length > 0 ? dueItems[reviewIndex % dueItems.length] : null;
 
@@ -129,6 +172,17 @@ function StudyHubScreen() {
         <Text style={[styles.title, { color: base.gold }]} accessibilityRole="header">
           Study
         </Text>
+
+        {/* ── First-run invitation (#1837): no plan ever + no reviews ─── */}
+        {showFirstRun && starterBook && (
+          <View style={styles.block}>
+            <FirstRunCard
+              starterBookName={starterBook.name}
+              onStudyStarter={handleStudyStarter}
+              onChooseSomethingElse={() => handlePickSegment('book')}
+            />
+          </View>
+        )}
 
         {/* ── Continue hero (hidden entirely when no active plan) ─── */}
         {plan && target && (

--- a/app/src/screens/StudyHubScreen.tsx
+++ b/app/src/screens/StudyHubScreen.tsx
@@ -9,7 +9,7 @@
  * With no active plan the hero region renders nothing (the first-run
  * empty state is #1837; the plan picker row is #1833).
  */
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
@@ -30,7 +30,12 @@ import { useExploreImages } from '../hooks/useExploreImages';
 import { usePremium } from '../hooks/usePremium';
 import { useReviewQueue } from '../hooks/useReviewQueue';
 import type { ScreenNavProp } from '../navigation/types';
-import { getWeeklyRhythm, startStudyPlan, type WeeklyRhythm } from '../services/study';
+import {
+  getWeeklyRhythm,
+  maybeInsertReviewNudge,
+  startStudyPlan,
+  type WeeklyRhythm,
+} from '../services/study';
 import { fontFamily, spacing, useTheme } from '../theme';
 import { logger } from '../utils/logger';
 
@@ -75,6 +80,15 @@ function StudyHubScreen() {
       void reloadRhythm();
     }, [reloadPlan, reloadReviews, reloadRhythm]),
   );
+
+  // Review-due nudge (#1841): when the hub sees due items, drop at
+  // most one quiet in-app notification per calendar day (the service
+  // dedupes; repeated focus/reloads are no-ops).
+  useEffect(() => {
+    if (dueItems.length > 0) {
+      void maybeInsertReviewNudge(dueItems.length);
+    }
+  }, [dueItems.length]);
 
   const handleResume = useCallback(() => {
     if (!target || !plan) return;

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -32,6 +32,7 @@ import {
   StudySessionStepper,
   SynthesisFreeRecap,
   SynthesisPremiumDraft,
+  TimeBudgetSelector,
 } from '../components/guidedStudy';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
@@ -45,8 +46,12 @@ import {
   getVerses,
 } from '../db/content';
 import { getCapturedInputs, getGuidedStudyQuestionForSession } from '../db/userQueries';
-import { setCapturedInputs, setPreference } from '../db/userMutations';
-import { completePlanItemForSession, LAST_MODE_PREF_KEY } from '../services/study';
+import { setCapturedInputs, setGuidedDeferredTrail, setPreference } from '../db/userMutations';
+import {
+  completePlanItemForSession,
+  getPriorDeferredTrail,
+  LAST_MODE_PREF_KEY,
+} from '../services/study';
 import { useBooks, useGuidedStudySession, usePremium } from '../hooks';
 import { completeGuidedStudySession } from '../db/userMutations';
 import {
@@ -55,6 +60,7 @@ import {
   completionPayoffCopy,
   formatChapterRef,
   getPromptBinding,
+  prependDeferredKinds,
   setCapturedText,
   stepsWithCarryForward,
   type CapturedTextRef,
@@ -129,6 +135,10 @@ function StudySessionScreen() {
   const [captureSavedTick, setCaptureSavedTick] = useState(0);
   // Resume beat (#1836): step to announce when resuming mid-session.
   const [resumeBeatStep, setResumeBeatStep] = useState<GuidedStudyStep | null>(null);
+  // Time budget (#1842): null = Full (today's behavior, default).
+  const [timeBudgetMin, setTimeBudgetMin] = useState<number | null>(null);
+  // Trail kinds the plan's previous session deferred (#1842).
+  const [priorDeferredKeys, setPriorDeferredKeys] = useState<string[]>([]);
   const [capturedInputs, setCapturedInputsState] = useState<CapturedInputs>({});
   const captureSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -332,8 +342,43 @@ function StudySessionScreen() {
       verses,
       bookIntro,
       mode: studyMode,
+      ...(timeBudgetMin != null ? { timeBudgetMin } : {}),
     });
-  }, [book, chapter, sections, chapterPanels, verses, bookIntro, studyMode]);
+  }, [book, chapter, sections, chapterPanels, verses, bookIntro, studyMode, timeBudgetMin]);
+
+  // Persist this session's deferred trail keys (#1842) so the plan's
+  // next session can front-load them. An empty list clears the column.
+  useEffect(() => {
+    if (sessionId == null || !plan) return;
+    void setGuidedDeferredTrail(
+      sessionId,
+      plan.deferredTrail.map((item) => item.key),
+    ).catch((err) =>
+      logger.warn('StudySessionScreen', 'Failed to persist deferred trail', err),
+    );
+  }, [sessionId, plan]);
+
+  // Load the previous plan session's deferrals once per session (#1842).
+  useEffect(() => {
+    if (!planId || sessionId == null) return;
+    let cancelled = false;
+    void getPriorDeferredTrail(planId, sessionId)
+      .then((keys) => {
+        if (!cancelled) setPriorDeferredKeys(keys);
+      })
+      .catch((err) =>
+        logger.warn('StudySessionScreen', 'Failed to load prior deferred trail', err),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, [planId, sessionId]);
+
+  // Deferred kinds from last time lead today's trail (#1842).
+  const displayTrail = useMemo(
+    () => (plan ? prependDeferredKinds(plan.evidenceTrail, priorDeferredKeys) : []),
+    [plan, priorDeferredKeys],
+  );
 
   const synthesisStrategy = useMemo(
     () =>
@@ -580,6 +625,9 @@ function StudySessionScreen() {
         {session.currentStep === 'scene' && (
           <View style={styles.section}>
             <Text style={[styles.heading, { color: base.text }]}>Set the Scene</Text>
+            {Object.keys(session.responses).length === 0 && (
+              <TimeBudgetSelector value={timeBudgetMin} onChange={setTimeBudgetMin} />
+            )}
             <SessionReader
               verses={verses}
               initiallyExpanded={readerExpanded}
@@ -662,10 +710,10 @@ function StudySessionScreen() {
             <Text style={[styles.sectionIntro, { color: base.textDim }]}>
               Open the panels in this order to build context before conclusions.
             </Text>
-            {plan.evidenceTrail.length > 0 ? (
+            {displayTrail.length > 0 ? (
               <>
                 <View style={styles.trailList}>
-                  {plan.evidenceTrail.map((item, index) => (
+                  {displayTrail.map((item, index) => (
                     <EvidenceTrailRow
                       key={item.key}
                       item={item}
@@ -677,10 +725,10 @@ function StudySessionScreen() {
                 </View>
                 <Text style={[styles.trailProgress, { color: base.textMuted }]}>
                   {
-                    plan.evidenceTrail.filter((item) => session.visitedTrail.includes(item.key))
+                    displayTrail.filter((item) => session.visitedTrail.includes(item.key))
                       .length
                   }{' '}
-                  of {plan.evidenceTrail.length} opened
+                  of {displayTrail.length} opened
                 </Text>
               </>
             ) : (

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -19,7 +19,10 @@ import {
 import { ArrowLeft, MessageSquare } from 'lucide-react-native';
 import {
   CarriedForwardBanner,
+  EncounterCallout,
   EvidencePanelSheet,
+  selectEncounterCallout,
+  type EncounterCalloutData,
   EvidenceTrailRow,
   NextChapterNudge,
   type EvidenceSheetItem,
@@ -45,7 +48,11 @@ import {
   getSectionPanels,
   getVerses,
 } from '../db/content';
-import { getCapturedInputs, getGuidedStudyQuestionForSession } from '../db/userQueries';
+import {
+  getCapturedInputs,
+  getConceptEncounterHistory,
+  getGuidedStudyQuestionForSession,
+} from '../db/userQueries';
 import { setCapturedInputs, setGuidedDeferredTrail, setPreference } from '../db/userMutations';
 import {
   completePlanItemForSession,
@@ -139,6 +146,10 @@ function StudySessionScreen() {
   const [timeBudgetMin, setTimeBudgetMin] = useState<number | null>(null);
   // Trail kinds the plan's previous session deferred (#1842).
   const [priorDeferredKeys, setPriorDeferredKeys] = useState<string[]>([]);
+  // Concept encounter callout (#1843): one per session, dismissible in
+  // component state only.
+  const [encounterCallout, setEncounterCallout] = useState<EncounterCalloutData | null>(null);
+  const [encounterDismissed, setEncounterDismissed] = useState(false);
   const [capturedInputs, setCapturedInputsState] = useState<CapturedInputs>({});
   const captureSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -373,6 +384,38 @@ function StudySessionScreen() {
       cancelled = true;
     };
   }, [planId, sessionId]);
+
+  // Longitudinal study memory (#1843): when this plan's concept chips
+  // intersect prior encounters (total >= 2, with a prior chapter to
+  // point back to), surface at most one callout — highest count wins.
+  useEffect(() => {
+    if (!plan || !chapter) return;
+    const conceptIds = plan.conceptChips.map((chip) => chip.id);
+    if (conceptIds.length === 0) return;
+    let cancelled = false;
+    void getConceptEncounterHistory(conceptIds)
+      .then((rows) => {
+        if (!cancelled) setEncounterCallout(selectEncounterCallout(rows, chapter.id));
+      })
+      .catch((err) =>
+        logger.warn('StudySessionScreen', 'Failed to load concept encounter history', err),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, [plan, chapter]);
+
+  const openEncounterChapter = useCallback(
+    (chapterId: string) => {
+      const match = chapterId.match(/^(.+)_(\d+)$/);
+      if (!match) return;
+      navigation.navigate('Chapter', {
+        bookId: match[1],
+        chapterNum: parseInt(match[2], 10),
+      });
+    },
+    [navigation],
+  );
 
   // Deferred kinds from last time lead today's trail (#1842).
   const displayTrail = useMemo(
@@ -627,6 +670,13 @@ function StudySessionScreen() {
             <Text style={[styles.heading, { color: base.text }]}>Set the Scene</Text>
             {Object.keys(session.responses).length === 0 && (
               <TimeBudgetSelector value={timeBudgetMin} onChange={setTimeBudgetMin} />
+            )}
+            {encounterCallout && !encounterDismissed && (
+              <EncounterCallout
+                callout={encounterCallout}
+                onOpenChapter={openEncounterChapter}
+                onDismiss={() => setEncounterDismissed(true)}
+              />
             )}
             <SessionReader
               verses={verses}

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -23,6 +23,7 @@ import {
   EvidenceTrailRow,
   NextChapterNudge,
   type EvidenceSheetItem,
+  ObservationChips,
   PanelRecommendationRow,
   ResumeBeat,
   SavedIndicator,
@@ -231,6 +232,36 @@ function StudySessionScreen() {
   const updateSceneInput = useCallback(
     (key: SceneInputKey, value: string) => updateCapturedField({ step: 'scene', key }, value),
     [updateCapturedField],
+  );
+
+  // Observation chips (#1839): toggle a chip label in/out of
+  // observeSelections with the same debounced persist + saved tick the
+  // text captures use.
+  const toggleObserveSelection = useCallback(
+    (label: string) => {
+      const sid = sessionId;
+      setCapturedInputsState((prev) => {
+        const current = prev.observeSelections ?? [];
+        const next: CapturedInputs = {
+          ...prev,
+          observeSelections: current.includes(label)
+            ? current.filter((l) => l !== label)
+            : [...current, label],
+        };
+        if (sid != null) {
+          if (captureSaveTimerRef.current) clearTimeout(captureSaveTimerRef.current);
+          captureSaveTimerRef.current = setTimeout(() => {
+            void setCapturedInputs(sid, next)
+              .then(() => setCaptureSavedTick((tick) => tick + 1))
+              .catch((err) =>
+                logger.warn('StudySessionScreen', 'Failed to persist observation chips', err),
+              );
+          }, 500);
+        }
+        return next;
+      });
+    },
+    [sessionId],
   );
 
   // Remember the chosen mode so the one-decision plan picker (#1833)
@@ -614,6 +645,11 @@ function StudySessionScreen() {
                 />
               </View>
             ))}
+            <ObservationChips
+              chips={plan.observationChips}
+              selected={capturedInputs.observeSelections ?? []}
+              onToggle={toggleObserveSelection}
+            />
             <PrimaryButton label="Explore study panels" onPress={() => goStep('explore')} />
           </View>
         )}

--- a/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
+++ b/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
@@ -64,6 +64,20 @@ exports[`plan parity for mode=deep chapter gen_1 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -238,6 +252,24 @@ exports[`plan parity for mode=deep chapter isa_53 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -401,6 +433,16 @@ exports[`plan parity for mode=deep chapter prov_3 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -556,6 +598,12 @@ exports[`plan parity for mode=deep chapter psa_23 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -723,6 +771,16 @@ exports[`plan parity for mode=deep chapter rom_8 1`] = `
   ],
   "mode": "deep",
   "modeLabel": "Deep study",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -885,6 +943,20 @@ exports[`plan parity for mode=devotional chapter gen_1 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1035,6 +1107,24 @@ exports[`plan parity for mode=devotional chapter isa_53 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1180,6 +1270,16 @@ exports[`plan parity for mode=devotional chapter prov_3 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1317,6 +1417,12 @@ exports[`plan parity for mode=devotional chapter psa_23 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1458,6 +1564,16 @@ exports[`plan parity for mode=devotional chapter rom_8 1`] = `
   ],
   "mode": "devotional",
   "modeLabel": "Devotional",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1604,6 +1720,20 @@ exports[`plan parity for mode=quick chapter gen_1 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1748,6 +1878,24 @@ exports[`plan parity for mode=quick chapter isa_53 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -1888,6 +2036,16 @@ exports[`plan parity for mode=quick chapter prov_3 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2019,6 +2177,12 @@ exports[`plan parity for mode=quick chapter psa_23 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2154,6 +2318,16 @@ exports[`plan parity for mode=quick chapter rom_8 1`] = `
   ],
   "mode": "quick",
   "modeLabel": "Quick pass",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2301,6 +2475,20 @@ exports[`plan parity for mode=teaching chapter gen_1 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:theological-narrative",
+      "label": "Theological Narrative",
+    },
+    {
+      "id": "creation",
+      "label": "Creation",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2479,6 +2667,24 @@ exports[`plan parity for mode=teaching chapter isa_53 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:prophecy",
+      "label": "Prophecy",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+    {
+      "id": "judgment",
+      "label": "Judgment",
+    },
+    {
+      "id": "suffering",
+      "label": "Suffering",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2653,6 +2859,16 @@ exports[`plan parity for mode=teaching chapter prov_3 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:wisdom",
+      "label": "Wisdom",
+    },
+    {
+      "id": "covenant",
+      "label": "Covenant",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2819,6 +3035,12 @@ exports[`plan parity for mode=teaching chapter psa_23 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:psalm",
+      "label": "Psalm",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,
@@ -2997,6 +3219,16 @@ exports[`plan parity for mode=teaching chapter rom_8 1`] = `
   ],
   "mode": "teaching",
   "modeLabel": "Teaching prep",
+  "observationChips": [
+    {
+      "id": "genre:letter",
+      "label": "Letter",
+    },
+    {
+      "id": "spirit",
+      "label": "Spirit",
+    },
+  ],
   "recommendations": [
     {
       "confidence": undefined,

--- a/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
+++ b/app/src/services/guidedStudy/__tests__/__snapshots__/plan.parity.test.ts.snap
@@ -18,6 +18,7 @@ exports[`plan parity for mode=deep chapter gen_1 1`] = `
       "label": "Covenant",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -206,6 +207,7 @@ exports[`plan parity for mode=deep chapter isa_53 1`] = `
       "label": "Suffering",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -395,6 +397,7 @@ exports[`plan parity for mode=deep chapter prov_3 1`] = `
       "label": "Wisdom",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -552,6 +555,7 @@ exports[`plan parity for mode=deep chapter psa_23 1`] = `
       "label": "Psalm",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -724,6 +728,7 @@ exports[`plan parity for mode=deep chapter rom_8 1`] = `
       "label": "Spirit",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -905,6 +910,7 @@ exports[`plan parity for mode=devotional chapter gen_1 1`] = `
       "label": "Covenant",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1069,6 +1075,7 @@ exports[`plan parity for mode=devotional chapter isa_53 1`] = `
       "label": "Suffering",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1232,6 +1239,7 @@ exports[`plan parity for mode=devotional chapter prov_3 1`] = `
       "label": "Wisdom",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1379,6 +1387,7 @@ exports[`plan parity for mode=devotional chapter psa_23 1`] = `
       "label": "Psalm",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1526,6 +1535,7 @@ exports[`plan parity for mode=devotional chapter rom_8 1`] = `
       "label": "Spirit",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1682,6 +1692,7 @@ exports[`plan parity for mode=quick chapter gen_1 1`] = `
       "label": "Covenant",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1840,6 +1851,7 @@ exports[`plan parity for mode=quick chapter isa_53 1`] = `
       "label": "Suffering",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -1998,6 +2010,7 @@ exports[`plan parity for mode=quick chapter prov_3 1`] = `
       "label": "Wisdom",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -2139,6 +2152,7 @@ exports[`plan parity for mode=quick chapter psa_23 1`] = `
       "label": "Psalm",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -2280,6 +2294,7 @@ exports[`plan parity for mode=quick chapter rom_8 1`] = `
       "label": "Spirit",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -2430,6 +2445,7 @@ exports[`plan parity for mode=teaching chapter gen_1 1`] = `
       "label": "Covenant",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -2629,6 +2645,7 @@ exports[`plan parity for mode=teaching chapter isa_53 1`] = `
       "label": "Suffering",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -2822,6 +2839,7 @@ exports[`plan parity for mode=teaching chapter prov_3 1`] = `
       "label": "Wisdom",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -2990,6 +3008,7 @@ exports[`plan parity for mode=teaching chapter psa_23 1`] = `
       "label": "Psalm",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",
@@ -3173,6 +3192,7 @@ exports[`plan parity for mode=teaching chapter rom_8 1`] = `
       "label": "Spirit",
     },
   ],
+  "deferredTrail": [],
   "evidenceTrail": [
     {
       "badge": "Required",

--- a/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
+++ b/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
@@ -33,6 +33,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
+++ b/app/src/services/guidedStudy/__tests__/phase3Integration.test.ts
@@ -34,6 +34,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     betterQuestionPrompt: '',
     conceptChips: [],
     observationChips: [],
+    deferredTrail: [],
   };
 }
 

--- a/app/src/services/guidedStudy/capturedInputs.ts
+++ b/app/src/services/guidedStudy/capturedInputs.ts
@@ -48,6 +48,12 @@ export interface CapturedInputs {
     artifact_generated?: boolean;
     next_chapter_accepted?: boolean;
   };
+  /**
+   * Observation-chip selections (#1839) — chip labels the user marked
+   * on the Observe step. Additive: absent in pre-#1839 stored JSON,
+   * which safeParseCapturedInputs tolerates by design.
+   */
+  observeSelections?: string[];
 }
 
 export function emptyCapturedInputs(): CapturedInputs {

--- a/app/src/services/guidedStudy/estimate.ts
+++ b/app/src/services/guidedStudy/estimate.ts
@@ -19,6 +19,14 @@ function minutesForWords(words: number, wpm: number): number {
   return Math.max(1, Math.ceil(words / wpm));
 }
 
+/**
+ * Reading-minutes estimate for a single panel's content_json, using
+ * the same heuristics as the depth estimate above (#1842). Minimum 1.
+ */
+export function estimatePanelMinutes(contentJson: string): number {
+  return minutesForWords(countWords(stripJsonNoise(contentJson)), PANEL_WORDS_PER_MINUTE);
+}
+
 export function getStudyDepthEstimate(
   verses: Verse[],
   sectionPanels: SectionPanel[],

--- a/app/src/services/guidedStudy/index.ts
+++ b/app/src/services/guidedStudy/index.ts
@@ -1,4 +1,5 @@
-export { getStudyDepthEstimate } from './estimate';
+export { estimatePanelMinutes, getStudyDepthEstimate } from './estimate';
+export { applyTimeBudget, estimateTrailItemMinutes, prependDeferredKinds } from './timeBudget';
 export { MODE_DEFINITIONS, getModeDefinition } from './modes/definitions';
 export { buildGuidedStudyPlan } from './plan';
 export { buildGuidedStudyNextAction, formatChapterRef, getGuidedStudyStepLabel } from './personal';

--- a/app/src/services/guidedStudy/observationChips.ts
+++ b/app/src/services/guidedStudy/observationChips.ts
@@ -1,0 +1,73 @@
+/**
+ * services/guidedStudy/observationChips.ts — Chip candidates for the
+ * Observe step (#1839, friction phase A). Combines the plan's concept
+ * chips with repeated-word candidates derived from the chapter's own
+ * verse text, so a reader can mark what they noticed without typing.
+ */
+import type { Verse } from '../../types';
+import type { GuidedConceptChip } from './types';
+
+/** Words too common (English or KJV-flavored) to count as repetition. */
+const STOPWORDS = new Set([
+  'the', 'and', 'that', 'unto', 'shall', 'with', 'them', 'they', 'have', 'from',
+  'were', 'which', 'their', 'there', 'this', 'then', 'when', 'thou', 'thee',
+  'thine', 'hath', 'upon', 'also', 'said', 'saying', 'came', 'come', 'went',
+  'will', 'been', 'because', 'before', 'after', 'against', 'into', 'over',
+  'under', 'again', 'more', 'most', 'other', 'some', 'such', 'than', 'very',
+  'yet', 'not', 'but', 'for', 'his', 'her', 'him', 'she', 'you', 'your',
+  'yours', 'our', 'ours', 'out', 'all', 'are', 'was', 'what', 'who', 'whom',
+  'shalt', 'thereof', 'therefore', 'behold', 'even', 'every', 'let', 'made',
+  'make', 'may', 'now', 'one', 'own', 'so', 'to', 'of', 'in', 'a', 'is', 'it',
+  'be', 'as', 'at', 'by', 'or', 'an', 'no', 'nor', 'on', 'up', 'we', 'us',
+  'me', 'my', 'i', 'he', 'do', 'did', 'done', 'has', 'had', 'ye', 'o',
+]);
+
+const MIN_WORD_LENGTH = 4;
+const MIN_REPETITIONS = 3;
+const MAX_REPETITION_CHIPS = 4;
+const MAX_OBSERVATION_CHIPS = 8;
+
+/**
+ * Repeated-word candidates from the chapter text: words of at least
+ * four letters that appear three or more times, most frequent first.
+ */
+export function buildRepetitionChips(verses: Verse[]): GuidedConceptChip[] {
+  const counts = new Map<string, number>();
+  for (const verse of verses) {
+    const words = verse.text.toLowerCase().match(/[a-z']+/g) ?? [];
+    for (const raw of words) {
+      const word = raw.replace(/^'+|'+$/g, '');
+      if (word.length < MIN_WORD_LENGTH || STOPWORDS.has(word)) continue;
+      counts.set(word, (counts.get(word) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .filter(([, count]) => count >= MIN_REPETITIONS)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, MAX_REPETITION_CHIPS)
+    .map(([word]) => ({
+      id: `repeat:${word}`,
+      label: word.replace(/^\w/, (c) => c.toUpperCase()),
+    }));
+}
+
+/**
+ * Concept chips + repetition chips, deduped by label (case-insensitive,
+ * concept chips win) and capped so the Observe step stays scannable.
+ */
+export function mergeObservationChips(
+  conceptChips: GuidedConceptChip[],
+  repetitionChips: GuidedConceptChip[],
+): GuidedConceptChip[] {
+  const seen = new Set<string>();
+  const merged: GuidedConceptChip[] = [];
+  for (const chip of [...conceptChips, ...repetitionChips]) {
+    const key = chip.label.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(chip);
+    if (merged.length >= MAX_OBSERVATION_CHIPS) break;
+  }
+  return merged;
+}

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -2,6 +2,7 @@ import type { SectionPanel } from '../../types';
 import { resolveGenre } from '../../utils/genre';
 import { getModeDefinition } from './modes/definitions';
 import { buildRepetitionChips, mergeObservationChips } from './observationChips';
+import { applyTimeBudget } from './timeBudget';
 import {
   GUIDED_STUDY_STEPS,
   type ConfidenceLevel,
@@ -368,6 +369,15 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
 
   const conceptChips = buildConceptChips(input);
 
+  // #1842 (additive fields only — see issue card): a time budget sorts
+  // the trail by the mode's panelWeights and trims it; no budget passes
+  // the trail through untouched with an empty deferred list.
+  const { trail: budgetedTrail, deferredTrail } = applyTimeBudget(
+    buildEvidenceTrail(mode, allRecommendations),
+    input,
+    def.panelWeights,
+  );
+
   return {
     chapterId: input.chapter.id,
     title: chapterTitle,
@@ -377,10 +387,11 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
     stepPrompts,
     legacyPrompts,
     recommendations: allRecommendations.slice(0, def.recommendationLimit),
-    evidenceTrail: buildEvidenceTrail(mode, allRecommendations),
+    evidenceTrail: budgetedTrail,
     betterQuestionPrompt: betterQuestion,
     conceptChips,
     // #1839 (additive field only — see issue card): Observe-step chips.
     observationChips: mergeObservationChips(conceptChips, buildRepetitionChips(input.verses)),
+    deferredTrail,
   };
 }

--- a/app/src/services/guidedStudy/plan.ts
+++ b/app/src/services/guidedStudy/plan.ts
@@ -1,6 +1,7 @@
 import type { SectionPanel } from '../../types';
 import { resolveGenre } from '../../utils/genre';
 import { getModeDefinition } from './modes/definitions';
+import { buildRepetitionChips, mergeObservationChips } from './observationChips';
 import {
   GUIDED_STUDY_STEPS,
   type ConfidenceLevel,
@@ -365,6 +366,8 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
     });
   }
 
+  const conceptChips = buildConceptChips(input);
+
   return {
     chapterId: input.chapter.id,
     title: chapterTitle,
@@ -376,6 +379,8 @@ export function buildGuidedStudyPlan(input: GuidedStudyPlanInput): GuidedStudyPl
     recommendations: allRecommendations.slice(0, def.recommendationLimit),
     evidenceTrail: buildEvidenceTrail(mode, allRecommendations),
     betterQuestionPrompt: betterQuestion,
-    conceptChips: buildConceptChips(input),
+    conceptChips,
+    // #1839 (additive field only — see issue card): Observe-step chips.
+    observationChips: mergeObservationChips(conceptChips, buildRepetitionChips(input.verses)),
   };
 }

--- a/app/src/services/guidedStudy/stepBindings.ts
+++ b/app/src/services/guidedStudy/stepBindings.ts
@@ -169,6 +169,23 @@ export function buildCarryForwardItems(
     if (!content) continue;
     items.push({ sourceStep: spec.ref.step, label: spec.label, content });
   }
+
+  // Observation-chip selections (#1839) carry into Explore/Synthesize
+  // alongside typed text, rendered as a chip list by the banner.
+  if (step === 'explore' || step === 'synthesize') {
+    const selections = (captured.observeSelections ?? []).filter(
+      (s) => typeof s === 'string' && s.trim().length > 0,
+    );
+    if (selections.length > 0) {
+      items.push({
+        sourceStep: 'observe',
+        label: 'What you marked',
+        content: selections.join(' · '),
+        chips: selections,
+      });
+    }
+  }
+
   return items;
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
@@ -36,6 +36,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     betterQuestionPrompt: '',
     conceptChips: [],
     observationChips: [],
+    deferredTrail: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicus.test.ts
@@ -35,6 +35,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
@@ -44,6 +44,7 @@ function planFor(mode: GuidedStudyMode, title = 'Romans 8'): GuidedStudyPlan {
     betterQuestionPrompt: '',
     conceptChips: [],
     observationChips: [],
+    deferredTrail: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumAmicusFlow.test.ts
@@ -43,6 +43,7 @@ function planFor(mode: GuidedStudyMode, title = 'Romans 8'): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumStructured.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumStructured.test.ts
@@ -24,6 +24,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/premiumStructured.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/premiumStructured.test.ts
@@ -25,6 +25,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     betterQuestionPrompt: '',
     conceptChips: [],
     observationChips: [],
+    deferredTrail: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
@@ -18,6 +18,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     evidenceTrail: [],
     betterQuestionPrompt: '',
     conceptChips: [],
+    observationChips: [],
   };
 }
 

--- a/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
+++ b/app/src/services/guidedStudy/synthesis/__tests__/strategy.test.ts
@@ -19,6 +19,7 @@ function planFor(mode: GuidedStudyMode): GuidedStudyPlan {
     betterQuestionPrompt: '',
     conceptChips: [],
     observationChips: [],
+    deferredTrail: [],
   };
 }
 

--- a/app/src/services/guidedStudy/timeBudget.ts
+++ b/app/src/services/guidedStudy/timeBudget.ts
@@ -1,0 +1,107 @@
+/**
+ * services/guidedStudy/timeBudget.ts — Time-adaptive sessions (#1842).
+ *
+ * "I have 10 minutes" produces a shorter, honest session: the evidence
+ * trail is sorted by the mode's panelWeights and sliced to fit the
+ * budget using per-panel minute estimates (estimate.ts heuristics).
+ * Everything that doesn't fit comes back as a deferred list the
+ * session persists (deferred_trail_json, migration v26 — owned by
+ * #1835; this issue adds NO migration) so the next plan-linked session
+ * can front-load it.
+ */
+import { estimatePanelMinutes } from './estimate';
+import type {
+  GuidedEvidenceTrailItem,
+  GuidedStudyPlanInput,
+} from './types';
+
+/** Fallback minutes for a trail item whose panel content can't be located. */
+const DEFAULT_ITEM_MINUTES = 3;
+
+export interface BudgetedTrail {
+  trail: GuidedEvidenceTrailItem[];
+  deferredTrail: GuidedEvidenceTrailItem[];
+}
+
+/** Locate a trail item's panel content_json inside the plan input. */
+function findContentJson(
+  input: GuidedStudyPlanInput,
+  item: GuidedEvidenceTrailItem,
+): string | null {
+  if (item.sectionNum != null) {
+    const section = input.sections.find((s) => s.section_num === item.sectionNum);
+    return section?.panels.find((p) => p.panel_type === item.panelType)?.content_json ?? null;
+  }
+  return input.chapterPanels.find((p) => p.panel_type === item.panelType)?.content_json ?? null;
+}
+
+/** Minutes estimate for one trail item. */
+export function estimateTrailItemMinutes(
+  input: GuidedStudyPlanInput,
+  item: GuidedEvidenceTrailItem,
+): number {
+  const contentJson = findContentJson(input, item);
+  return contentJson != null ? estimatePanelMinutes(contentJson) : DEFAULT_ITEM_MINUTES;
+}
+
+/**
+ * Apply a minute budget to the trail. No budget → the trail passes
+ * through untouched (byte-identical to pre-#1842 output) with an empty
+ * deferred list. With a budget: sort by the mode's panelWeights
+ * (heaviest first, original order as tiebreak), keep items while they
+ * fit — always at least one, so a small budget still yields a session
+ * rather than an empty trail — and defer the rest.
+ */
+export function applyTimeBudget(
+  fullTrail: GuidedEvidenceTrailItem[],
+  input: GuidedStudyPlanInput,
+  panelWeights: Readonly<Record<string, number>>,
+): BudgetedTrail {
+  const budget = input.timeBudgetMin;
+  if (budget == null || fullTrail.length === 0) {
+    return { trail: fullTrail, deferredTrail: [] };
+  }
+
+  const byWeight = fullTrail
+    .map((item, index) => ({ item, index }))
+    .sort(
+      (a, b) =>
+        (panelWeights[b.item.panelType] ?? 0) - (panelWeights[a.item.panelType] ?? 0) ||
+        a.index - b.index,
+    )
+    .map(({ item }) => item);
+
+  const trail: GuidedEvidenceTrailItem[] = [];
+  const deferredTrail: GuidedEvidenceTrailItem[] = [];
+  let spentMin = 0;
+  for (const item of byWeight) {
+    const minutes = estimateTrailItemMinutes(input, item);
+    if (trail.length === 0 || spentMin + minutes <= budget) {
+      trail.push(item);
+      spentMin += minutes;
+    } else {
+      deferredTrail.push(item);
+    }
+  }
+
+  return { trail, deferredTrail };
+}
+
+/**
+ * Reorder a trail so items whose trail kind (the `kind:` prefix of the
+ * item key) was deferred in the plan's previous session come first
+ * (#1842 spec 3). Keys are chapter-specific, so matching happens on
+ * the kind — "you deferred language study last time, so it leads
+ * today" — while relative order inside each group is preserved.
+ */
+export function prependDeferredKinds(
+  trail: GuidedEvidenceTrailItem[],
+  deferredKeys: string[],
+): GuidedEvidenceTrailItem[] {
+  if (deferredKeys.length === 0) return trail;
+  const kinds = new Set(deferredKeys.map((key) => key.split(':')[0]));
+  const front = trail.filter((item) => kinds.has(item.key.split(':')[0]));
+  if (front.length === 0) return trail;
+  const rest = trail.filter((item) => !kinds.has(item.key.split(':')[0]));
+  return [...front, ...rest];
+}

--- a/app/src/services/guidedStudy/types.ts
+++ b/app/src/services/guidedStudy/types.ts
@@ -125,6 +125,11 @@ export interface GuidedStudyPlan {
   evidenceTrail: GuidedEvidenceTrailItem[];
   betterQuestionPrompt: string;
   conceptChips: GuidedConceptChip[];
+  /**
+   * Selectable Observe-step chips (#1839): concept chips merged with
+   * repeated-word candidates from the chapter text.
+   */
+  observationChips: GuidedConceptChip[];
 }
 
 export interface GuidedStudyPlanInput {

--- a/app/src/services/guidedStudy/types.ts
+++ b/app/src/services/guidedStudy/types.ts
@@ -130,6 +130,12 @@ export interface GuidedStudyPlan {
    * repeated-word candidates from the chapter text.
    */
   observationChips: GuidedConceptChip[];
+  /**
+   * Trail items trimmed away by the time budget (#1842). Empty when no
+   * budget was set. Persisted per session (deferred_trail_json) so the
+   * plan's next session can front-load them.
+   */
+  deferredTrail: GuidedEvidenceTrailItem[];
 }
 
 export interface GuidedStudyPlanInput {
@@ -140,4 +146,9 @@ export interface GuidedStudyPlanInput {
   verses: Verse[];
   bookIntro?: ParsedBookIntro | null;
   mode?: GuidedStudyMode;
+  /**
+   * Minute budget for this session (#1842). Unset = full session,
+   * byte-identical to pre-budget behavior.
+   */
+  timeBudgetMin?: number;
 }

--- a/app/src/services/study/index.ts
+++ b/app/src/services/study/index.ts
@@ -15,6 +15,7 @@ export {
 export {
   getActivePlan,
   getNextItem,
+  getPriorDeferredTrail,
   percentComplete,
   resumeTarget,
   type ResumeTarget,

--- a/app/src/services/study/index.ts
+++ b/app/src/services/study/index.ts
@@ -27,6 +27,7 @@ export {
   type WeeklyRhythm,
 } from './rhythm';
 export { migrateLegacyPlans } from './migrateLegacyPlans';
+export { maybeInsertReviewNudge, REVIEW_NUDGE_TYPE, reviewNudgeBody } from './reviewNudge';
 export {
   completePlanItemForSession,
   getDefaultStudyMode,

--- a/app/src/services/study/migrateLegacyPlans.ts
+++ b/app/src/services/study/migrateLegacyPlans.ts
@@ -3,11 +3,17 @@
  * reading plans into the unified study-plan tables (#1831).
  *
  * Runs once at startup after migrations, guarded by the `app_meta`
- * key `legacy_plans_migrated = '1'`. Every `reading_plans` row becomes
- * a `study_plans` row (plan_type 'custom', source_id = legacy id,
- * default_mode 'quick'); its `chapters_json` days become
+ * key `legacy_plans_migrated = '1'`. Every STARTED `reading_plans` row
+ * (one with plan_progress rows — `startPlan` seeds a row per day)
+ * becomes a `study_plans` row (plan_type 'custom', source_id = legacy
+ * id, default_mode 'quick'); its `chapters_json` days become
  * `study_plan_items` rows (kind 'reading', one per chapter); and
  * `plan_progress.completed_at` is copied onto the matching items.
+ *
+ * Untouched curated seeds (migration v6 ships 10 to every install) do
+ * NOT migrate — otherwise every fresh install would "have plans",
+ * polluting getActivePlan()/the hub hero and making the first-run
+ * state (#1837) unreachable. See the #1837 issue comment.
  *
  * The legacy tables are never dropped or altered — they stay readable
  * until #1838 retires the write paths. Idempotency comes from three
@@ -62,8 +68,18 @@ export async function migrateLegacyPlans(): Promise<void> {
 
   const legacyPlans = await db.getAllAsync<ReadingPlan>('SELECT * FROM reading_plans');
 
+  let migratedCount = 0;
   await db.withTransactionAsync(async () => {
     for (const legacy of legacyPlans) {
+      const progress = await db.getAllAsync<PlanProgress>(
+        'SELECT * FROM plan_progress WHERE plan_id = ?',
+        [legacy.id],
+      );
+      // Only plans the user actually started carry over. Untouched
+      // curated seeds stay legacy-only (readable until #1838).
+      if (progress.length === 0) continue;
+      migratedCount++;
+
       const planId = `legacy_${legacy.id}`;
       await db.runAsync(
         `INSERT OR IGNORE INTO study_plans
@@ -72,10 +88,6 @@ export async function migrateLegacyPlans(): Promise<void> {
         [planId, legacy.id, legacy.name],
       );
 
-      const progress = await db.getAllAsync<PlanProgress>(
-        'SELECT * FROM plan_progress WHERE plan_id = ?',
-        [legacy.id],
-      );
       const completedByDay = new Map<number, string>();
       for (const p of progress) {
         if (p.completed_at) completedByDay.set(p.day_num, p.completed_at);
@@ -110,5 +122,8 @@ export async function migrateLegacyPlans(): Promise<void> {
     );
   });
 
-  logger.info('studyPlans', `migrateLegacyPlans: seeded ${legacyPlans.length} legacy plan(s)`);
+  logger.info(
+    'studyPlans',
+    `migrateLegacyPlans: seeded ${migratedCount} started legacy plan(s) of ${legacyPlans.length}`,
+  );
 }

--- a/app/src/services/study/progression.ts
+++ b/app/src/services/study/progression.ts
@@ -7,6 +7,7 @@
  */
 import {
   getGuidedStudySession,
+  getLatestDeferredTrailJson,
   getStudyPlanItems,
   getStudyPlans,
 } from '../../db/userQueries';
@@ -67,6 +68,26 @@ export async function percentComplete(planId: string): Promise<number> {
   if (items.length === 0) return 0;
   const done = items.filter((item) => item.completed_at != null).length;
   return Math.round((done / items.length) * 100);
+}
+
+/**
+ * Deferred evidence-trail keys from the plan's most recent prior
+ * session (#1842) — the next session prepends the matching trail
+ * kinds. Empty when nothing was deferred or the JSON is unreadable.
+ */
+export async function getPriorDeferredTrail(
+  planId: string,
+  currentSessionId: number,
+): Promise<string[]> {
+  try {
+    const json = await getLatestDeferredTrailJson(planId, currentSessionId);
+    if (!json) return [];
+    const parsed: unknown = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === 'string') : [];
+  } catch (err) {
+    logger.warn('studyPlans', `getPriorDeferredTrail: bad deferred_trail_json on ${planId}`, err);
+    return [];
+  }
 }
 
 /**

--- a/app/src/services/study/reviewNudge.ts
+++ b/app/src/services/study/reviewNudge.ts
@@ -1,0 +1,53 @@
+/**
+ * services/study/reviewNudge.ts — Review-due nudges (#1841).
+ *
+ * Due reviews surface as ONE quiet in-app notification per calendar
+ * day. Rhythm tone on purpose: no urgency words, no missed-day counts.
+ * OS push is out of scope — this only writes to app_notifications.
+ */
+import { getUserDb } from '../../db/userDatabase';
+import { insertAppNotification } from '../../db/userMutations';
+import { logger } from '../../utils/logger';
+
+export const REVIEW_NUDGE_TYPE = 'review_due';
+
+/** "3 review prompts are ready when you are." (grammatical for n=1). */
+export function reviewNudgeBody(dueCount: number): string {
+  return dueCount === 1
+    ? '1 review prompt is ready when you are.'
+    : `${dueCount} review prompts are ready when you are.`;
+}
+
+/**
+ * Insert today's review nudge if there are due items and none exists
+ * for today yet. Dedupe is double-layered: a query before insert (per
+ * the card) plus a deterministic per-day id with INSERT OR IGNORE.
+ * Returns true when a nudge was inserted.
+ */
+export async function maybeInsertReviewNudge(dueCount: number): Promise<boolean> {
+  if (dueCount <= 0) return false;
+
+  try {
+    const db = getUserDb();
+    const existing = await db.getFirstAsync<{ id: string }>(
+      `SELECT id FROM app_notifications
+       WHERE type = ? AND date(created_at) = date('now')
+       LIMIT 1`,
+      [REVIEW_NUDGE_TYPE],
+    );
+    if (existing) return false;
+
+    const today = new Date().toISOString().slice(0, 10);
+    await insertAppNotification({
+      id: `review_due_${today}`,
+      type: REVIEW_NUDGE_TYPE,
+      title: 'Ready to revisit',
+      body: reviewNudgeBody(dueCount),
+      targetType: 'study_hub',
+    });
+    return true;
+  } catch (err) {
+    logger.warn('reviewNudge', 'Failed to insert review nudge', err);
+    return false;
+  }
+}

--- a/app/src/types/explore.ts
+++ b/app/src/types/explore.ts
@@ -236,7 +236,13 @@ export interface Submission {
 
 export interface AppNotification {
   id: string;
-  type: 'new_submission' | 'submission_approved' | 'submission_rejected' | 'trust_upgraded';
+  type:
+    | 'new_submission'
+    | 'submission_approved'
+    | 'submission_rejected'
+    | 'trust_upgraded'
+    // Review-due nudge (#1841) — taps route to the Study hub.
+    | 'review_due';
   title: string;
   body: string;
   target_id?: string;


### PR DESCRIPTION
Depends on #1853 — merge in order. Final PR of the Epic #1830 stack (branched from `feature/1842-time-budget`). Closes #1843.

## Rationale
Longitudinal study memory: "This is your 4th encounter with *covenant* — in Genesis 9 you wrote…".

- **Query** (`getConceptEncounterHistory`): per (concept, chapter) rows from `concept_encounters`. I read the v19 schema first, per the card — the table carries **no session/response FK**, so the "you wrote…" excerpt joins to that chapter's most recent non-empty `guided_study_synthesis.takeaway`: always the user's own words, never generated (the query test pins both the verified columns and the join source).
- **`EncounterCallout`** on the Scene step: shown when the plan's `conceptChips` intersect prior encounters with **total count ≥ 2** and at least one *prior* chapter to point back to (encounters only in the current chapter never call out). **Max one per session** — highest total wins, recency tiebreak. Shows the ordinal count, prior chapter ref, and a ≤120-char excerpt; tapping opens that chapter; the X dismisses for the session (component state only).
- user.db reads only; zero content changes; no migrations.

## Rollback plan
Revert the merge commit — one query, one component, one scene-step mount. Nothing persisted.

## Verification
- `npx tsc --noEmit` clean; `npx eslint src/ --max-warnings 0` clean
- `npx jest --coverage --ci`: **546 suites / 4091 tests passing**, thresholds met (9 new tests: fixture-row query shape incl. no-guessed-columns guard, threshold/single-winner/prior-chapter-required selection, excerpt clamp, render/tap/dismiss/fallback)

## Epic status
This completes every issue assigned to this run: #1831→#1837, #1839, #1841→#1843 (PRs #1844–#1853, stacked, merge in order). #1838 and #1840 untouched per the hard stops. A status summary is on Epic #1830.

## Process notes
- Kanban: Projects v2 GraphQL blocked by the environment proxy — please drag #1843 to In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_