### PR TITLE
feat(content-pipeline): carry books.json starter flag into scripture.db

### DIFF
--- a/_tools/build_sqlite_loaders.py
+++ b/_tools/build_sqlite_loaders.py
@@ -185,10 +185,11 @@ def populate_books(cur):
     books = _load_json(META / 'books.json')
     for b in books:
         cur.execute(
-            'INSERT INTO books (id, name, testament, total_chapters, book_order, is_live, genre, genre_label, genre_guidance) '
-            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO books (id, name, testament, total_chapters, book_order, is_live, genre, genre_label, genre_guidance, starter) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             (b['id'], b['name'], b['testament'], b['total_chapters'],
-             b['book_order'], b['is_live'], b.get('genre'), b.get('genre_label'), b.get('genre_guidance'))
+             b['book_order'], b['is_live'], b.get('genre'), b.get('genre_label'), b.get('genre_guidance'),
+             b.get('starter', False))
         )
     return len(books)
 

--- a/_tools/build_sqlite_schema.py
+++ b/_tools/build_sqlite_schema.py
@@ -21,7 +21,8 @@ CREATE TABLE books (
   is_live BOOLEAN DEFAULT 0,
   genre TEXT,
   genre_label TEXT,
-  genre_guidance TEXT
+  genre_guidance TEXT,
+  starter BOOLEAN DEFAULT 0
 );
 
 CREATE TABLE chapters (


### PR DESCRIPTION
Craig-authorized exception to the _tools no-touch boundary (see #1833 discussion): adds the starter column to the books schema and threads b.get('starter', False) through populate_books, so the picker's starter shelf and the hub's first-run 'Study {starter book}' button light up with real data once content-pipeline CI rebuilds the DB. Verified in-memory against the real books.json: 66 rows, exactly genesis/psalms/proverbs/john/romans flagged, others default 0.


Claude-Session: https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R