### PR TITLE
fix(deps): clear the last Dependabot alert — uuid GHSA-w5hq-g745-h8pq via scoped override

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15267,13 +15267,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/app/package.json
+++ b/app/package.json
@@ -85,7 +85,10 @@
   },
   "overrides": {
     "@tootallnate/once": ">=3.0.1",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "xcode": {
+      "uuid": "^11.1.1"
+    }
   },
   "private": true
 }


### PR DESCRIPTION
Re-lands the one commit that missed #1861 — I pushed the uuid fix to the branch moments after you merged, so it never reached master. This is that single commit rebased onto current master; merging it clears the final open Dependabot alert.

## The fix
`uuid@7.0.3` (moderate, GHSA-w5hq-g745-h8pq — buffer bounds in v3/v5/v6) → **11.1.1** via an override **scoped to `xcode`**, its only real requirer (Dependabot's expo→uuid paths are hoisting artifacts). `xcode` is a build-time pbxproj parser with a single `uuid.v4()` call site; uuid@11 keeps the same CJS export.

Clearing this also collapses the transitive "via" chains, so `npm audit` on app/ goes to **0 vulnerabilities of any severity** — the earlier "needs Expo SDK 57" assessment is void.

## Verification
- Exact tree already validated pre-rebase: full app suite **546 suites / 4091 tests + tsc + eslint + expo export** green with uuid@11
- Post-rebase re-check: `npm audit` → 0 vulnerabilities, uuid resolves to 11.1.1 under xcode, `tsc --noEmit` clean
- Caveat (same as #1861): `xcode` runs during EAS prebuild, which local checks can't exercise — glance at the next EAS build log; reverting is deleting the one override line

## Rollback plan
Revert the merge commit — one overrides entry + lockfile delta, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_