### PR TITLE
chore(ci): allow manual runs of Tests and Lint via workflow_dispatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [master]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [master]
   push:


### PR DESCRIPTION
Two-line change: adds `workflow_dispatch:` to `test.yml` and `lint.yml` so both can be run manually — Actions tab → Tests (or Lint) → **Run workflow** → pick any branch — without opening a PR.

No other changes needed: the test summary already writes to `$GITHUB_STEP_SUMMARY` (shown on the run's Summary page, which is where manual-run results land), and the PR-comment step is already guarded by `github.event_name == 'pull_request'`, so dispatch runs skip it cleanly.

Note: GitHub only shows the Run-workflow button once the trigger exists on the **default branch**, so it appears after this merges. From then on it also works via API/CLI (`gh workflow run tests.yml --ref <branch>`), which means Claude sessions can trigger CI on a branch and report back.

Rollback: revert the merge commit — trigger-only, no job changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R

---
_Generated by [Claude Code](https://claude.ai/code/session_01FShYA5r8tYXbL7v662Zi6R)_