### PR TITLE
fix: hex color regression sweep + eslint guard (#1898)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,5 +33,11 @@ jobs:
       - name: ESLint
         run: npx eslint src/ --max-warnings 0 || echo "::warning::ESLint found issues"
 
+      # Hex color guard (#1898) — error-level rules only, HARD FAIL.
+      # Blocks hardcoded hex color literals in src/screens/ and
+      # src/components/ (no-restricted-syntax override in .eslintrc.json).
+      - name: Hex color guard
+        run: npx eslint src/screens src/components --quiet
+
       - name: Prettier check
         run: npx prettier --check "src/**/*.{ts,tsx}" || echo "::warning::Prettier found formatting issues"

--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -54,5 +54,24 @@
     "no-useless-escape": "warn",
     "prefer-const": "warn"
   },
-  "ignorePatterns": ["node_modules/", "babel.config.js", "metro.config.js", "jest.setup.js", "scripts/"]
+  "ignorePatterns": ["node_modules/", "babel.config.js", "metro.config.js", "jest.setup.js", "scripts/"],
+  "overrides": [
+    {
+      "files": ["src/screens/**/*.ts", "src/screens/**/*.tsx", "src/components/**/*.ts", "src/components/**/*.tsx"],
+      "excludedFiles": ["**/__tests__/**", "**/*.test.*", "src/screens/dev/**", "src/components/GospelColors.ts"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Literal[value=/#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})([^0-9a-zA-Z]|$)/]",
+            "message": "Hardcoded hex color. Use useTheme() tokens (base.*, panels.*, ...) instead; color data belongs in src/theme/colors.ts. See DEV_GUIDE §5 and #1898."
+          },
+          {
+            "selector": "TemplateElement[value.raw=/#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})([^0-9a-zA-Z]|$)/]",
+            "message": "Hardcoded hex color in template string. Use useTheme() tokens instead; color data belongs in src/theme/colors.ts. See DEV_GUIDE §5 and #1898."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/app/__tests__/components/OnboardingDemo.test.tsx
+++ b/app/__tests__/components/OnboardingDemo.test.tsx
@@ -20,6 +20,7 @@ const mockBase: ThemePalette['base'] = {
   verseNum: '#9a8a6a',
   navText: '#d8ccb0',
   danger: '#e05a6a',
+  warning: '#e8a040',
   success: '#81C784',
   redLetter: '#d4847a',
   tintWarm: '#1a1508',

--- a/app/src/components/ChapterNavBar.tsx
+++ b/app/src/components/ChapterNavBar.tsx
@@ -14,7 +14,7 @@ import { View, Text, TouchableOpacity, Modal, StyleSheet, TouchableWithoutFeedba
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ArrowLeft, ChevronLeft, ChevronRight, Info, Volume2, Check, Layers } from 'lucide-react-native';
 import { lightImpact, selectionFeedback } from '../utils/haptics';
-import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET, overlay } from '../theme';
 import { TRANSLATIONS } from '../db/translationRegistry';
 import type { ChapterMode } from '../stores/settingsStore';
 import { CompactDropdown, type DropdownOption } from './CompactDropdown';
@@ -281,7 +281,7 @@ const styles = StyleSheet.create({
     borderRadius: radii.md,
     minWidth: 200,
     overflow: 'hidden',
-    shadowColor: '#000', // overlay-color: intentional (RN shadow must be #000 on iOS)
+    shadowColor: overlay.black, // RN shadow must stay black on iOS
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,

--- a/app/src/components/CollectionPicker.tsx
+++ b/app/src/components/CollectionPicker.tsx
@@ -17,17 +17,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { X, Plus, Check, Folder } from 'lucide-react-native';
 import { getCollections, createCollection } from '../db/user';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, collectionPresetColors } from '../theme';
 import type { StudyCollection } from '../types';
-
-const PRESET_COLORS = [
-  '#bfa050', // data-color: intentional (gold)
-  '#70b8e8', // data-color: intentional (blue)
-  '#70d098', // data-color: intentional (green)
-  '#e890b8', // data-color: intentional (pink)
-  '#c090e0', // data-color: intentional (purple)
-  '#e8a070', // data-color: intentional (orange)
-];
 
 interface Props {
   visible: boolean;
@@ -41,7 +32,7 @@ export function CollectionPicker({ visible, onClose, currentCollectionId, onSele
   const [collections, setCollections] = useState<StudyCollection[]>([]);
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
-  const [newColor, setNewColor] = useState(PRESET_COLORS[0]);
+  const [newColor, setNewColor] = useState(collectionPresetColors[0]);
 
   useEffect(() => {
     if (visible) {
@@ -92,7 +83,7 @@ export function CollectionPicker({ visible, onClose, currentCollectionId, onSele
                 autoFocus
               />
               <View style={styles.colorRow}>
-                {PRESET_COLORS.map((color) => (
+                {collectionPresetColors.map((color) => (
                   <TouchableOpacity
                     key={color}
                     onPress={() => setNewColor(color)}

--- a/app/src/components/CompactDropdown.tsx
+++ b/app/src/components/CompactDropdown.tsx
@@ -14,7 +14,7 @@ import {
   TouchableWithoutFeedback, type LayoutRectangle,
 } from 'react-native';
 import { Check } from 'lucide-react-native';
-import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import { useTheme, spacing, radii, fontFamily, MIN_TOUCH_TARGET, overlay } from '../theme';
 import { selectionFeedback } from '../utils/haptics';
 
 export interface DropdownOption {
@@ -144,7 +144,7 @@ const styles = StyleSheet.create({
     borderRadius: radii.md,
     overflow: 'hidden',
     // Subtle shadow on iOS
-    shadowColor: '#000', // overlay-color: intentional (RN shadow must be #000 on iOS)
+    shadowColor: overlay.black, // RN shadow must stay black on iOS
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,

--- a/app/src/components/ContentImageGallery.tsx
+++ b/app/src/components/ContentImageGallery.tsx
@@ -40,7 +40,7 @@ import {
   Gesture,
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import { ImageCredit } from './ImageCredit';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -424,7 +424,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   closeText: {
-    color: '#fff', // overlay-color: intentional (white text on dark modal)
+    color: overlay.white, // white text on dark modal — mode-invariant
     fontSize: 18,
     fontWeight: '600',
   },

--- a/app/src/components/ContinueReadingHero.tsx
+++ b/app/src/components/ContinueReadingHero.tsx
@@ -15,7 +15,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { ArrowRight } from 'lucide-react-native';
 import { useContentImages } from '../hooks/useContentImages';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import type { ContentImage } from '../types';
 import type { RecentChapter } from '../types';
 
@@ -237,7 +237,7 @@ export function ContinueReadingHero({ mostRecent, onPress }: Props) {
                 <View
                   key={i}
                   style={[styles.dot, {
-                    backgroundColor: i === activeIndex ? '#fff' : 'rgba(255,255,255,0.4)', // overlay-color: intentional
+                    backgroundColor: i === activeIndex ? overlay.white : 'rgba(255,255,255,0.4)', // overlay-color: intentional
                   }]}
                 />
               ))}
@@ -293,7 +293,7 @@ const styles = StyleSheet.create({
     right: 0,
     height: Math.round(IMAGE_HEIGHT * 0.5),
     backgroundColor: 'transparent',
-    shadowColor: '#000', // overlay-color: intentional (RN shadow must be #000 on iOS)
+    shadowColor: overlay.black, // RN shadow must stay black on iOS
     shadowOffset: { width: 0, height: -16 },
     shadowOpacity: 0.65,
     shadowRadius: 16,
@@ -303,7 +303,7 @@ const styles = StyleSheet.create({
     bottom: 6,
     left: 10,
     right: 30,
-    color: '#fff', // overlay-color: intentional (caption on image)
+    color: overlay.white, // caption on image — mode-invariant
     fontFamily: fontFamily.ui,
     fontSize: 11,
     textShadowColor: 'rgba(0,0,0,0.8)', // overlay-color: intentional

--- a/app/src/components/DebatePositionCard.tsx
+++ b/app/src/components/DebatePositionCard.tsx
@@ -12,12 +12,6 @@ import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { families } from '../theme/colors';
 import type { DebatePosition } from '../types';
 
-// Analysis panel colors — semantic green/red for argument strength/weakness
-const STRENGTHS_COLOR = '#4CAF50';   // data-color: intentional (green label — strengths)
-const STRENGTHS_BG    = '#4CAF5010'; // data-color: intentional (green tint — strengths panel)
-const WEAKNESSES_COLOR = '#F44336';  // data-color: intentional (red label — weaknesses)
-const WEAKNESSES_BG   = '#F4433610'; // data-color: intentional (red tint — weaknesses panel)
-
 interface Props {
   position: DebatePosition;
   defaultExpanded?: boolean;
@@ -31,7 +25,7 @@ function DebatePositionCard({
   onScholarPress,
   onVersePress,
 }: Props) {
-  const { base } = useTheme();
+  const { base, debatePosition } = useTheme();
   const [expanded, setExpanded] = useState(defaultExpanded);
   const color = families[position.tradition_family as keyof typeof families] || base.textDim;
 
@@ -83,8 +77,8 @@ function DebatePositionCard({
         <View style={styles.analysis}>
           {/* Strengths — data-color: intentional (green tint and label — analysis colors) */}
           {position.strengths ? (
-            <View style={[styles.analysisCard, { backgroundColor: STRENGTHS_BG }]}>
-              <Text style={[styles.analysisLabel, { color: STRENGTHS_COLOR }]}>Strengths</Text>
+            <View style={[styles.analysisCard, { backgroundColor: debatePosition.strengths + '10' }]}>
+              <Text style={[styles.analysisLabel, { color: debatePosition.strengths }]}>Strengths</Text>
               <Text style={[styles.analysisText, { color: base.text }]}>
                 {position.strengths}
               </Text>
@@ -93,8 +87,8 @@ function DebatePositionCard({
 
           {/* Weaknesses — data-color: intentional (red tint and label — analysis colors) */}
           {position.weaknesses ? (
-            <View style={[styles.analysisCard, { backgroundColor: WEAKNESSES_BG }]}>
-              <Text style={[styles.analysisLabel, { color: WEAKNESSES_COLOR }]}>Weaknesses</Text>
+            <View style={[styles.analysisCard, { backgroundColor: debatePosition.weaknesses + '10' }]}>
+              <Text style={[styles.analysisLabel, { color: debatePosition.weaknesses }]}>Weaknesses</Text>
               <Text style={[styles.analysisText, { color: base.text }]}>
                 {position.weaknesses}
               </Text>

--- a/app/src/components/DebateTraditionFilter.tsx
+++ b/app/src/components/DebateTraditionFilter.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import { families } from '../theme/colors';
 
 interface Props {
@@ -73,7 +73,7 @@ function DebateTraditionFilter({ traditions, activeFilter, onSelect }: Props) {
             <Text
               style={[
                 styles.pillText,
-                { color: isActive ? '#fff' : color }, // data-color: intentional (white text on colored pill)
+                { color: isActive ? overlay.white : color }, // white text on colored pill — mode-invariant
               ]}
             >
               {TRADITION_LABELS[t] || t}

--- a/app/src/components/DetailHeroHeader.tsx
+++ b/app/src/components/DetailHeroHeader.tsx
@@ -18,7 +18,7 @@ import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { ArrowLeft } from 'lucide-react-native';
-import { useTheme, spacing, fontFamily, MIN_TOUCH_TARGET } from '../theme';
+import { useTheme, spacing, fontFamily, MIN_TOUCH_TARGET, overlay } from '../theme';
 
 interface Props {
   title: string;
@@ -36,7 +36,7 @@ interface Props {
 
 const NO_IMAGE_HEIGHT = 100;
 
-const OVERLAY_TITLE = '#ffffff'; // overlay-color: intentional (title over dark gradient)
+const OVERLAY_TITLE = overlay.white; // title over dark gradient — mode-invariant
 const OVERLAY_SUBTITLE = 'rgba(255,255,255,0.85)'; // overlay-color: intentional
 const BACK_BG = 'rgba(0,0,0,0.35)'; // overlay-color: intentional
 
@@ -140,7 +140,7 @@ const styles = StyleSheet.create({
     // a transparent view. Avoids pulling in expo-linear-gradient for this
     // single use case (same approach as GoldSeparator).
     backgroundColor: 'transparent',
-    shadowColor: '#000', // overlay-color: intentional
+    shadowColor: overlay.black,
     shadowOffset: { width: 0, height: -12 },
     shadowOpacity: 0.6,
     shadowRadius: 14,

--- a/app/src/components/DiffAnnotation.tsx
+++ b/app/src/components/DiffAnnotation.tsx
@@ -16,6 +16,7 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { DIFF_TYPE_COLORS, DIFF_TYPE_BG } from './GospelColors';
 import { gospelColor, GOSPEL_SHORT } from './GospelColors';
 
 export interface DiffAnnotationData {
@@ -50,22 +51,6 @@ const DIFF_TYPE_LABELS: Record<string, string> = {
   reordering: 'Reordering',
   wording: 'Wording',
   theological_emphasis: 'Theological Emphasis',
-};
-
-const DIFF_TYPE_COLORS: Record<string, string> = {
-  addition: '#4a8c5c', // data-color: intentional
-  omission: '#8c4a4a', // data-color: intentional
-  reordering: '#8a6e1a', // data-color: intentional
-  wording: '#8a6e1a', // data-color: intentional
-  theological_emphasis: '#8a6e1a', // data-color: intentional
-};
-
-const DIFF_TYPE_BG: Record<string, string> = {
-  addition: '#4a8c5c22', // data-color: intentional
-  omission: '#8c4a4a22', // data-color: intentional
-  reordering: '#bfa05022', // data-color: intentional
-  wording: '#bfa05022', // data-color: intentional
-  theological_emphasis: '#bfa05022', // data-color: intentional
 };
 
 interface Props {

--- a/app/src/components/DifficultyBadge.tsx
+++ b/app/src/components/DifficultyBadge.tsx
@@ -15,12 +15,12 @@ interface Props {
 }
 
 /** Map difficulty level to dot color. */
-function getDifficultyColor(level: number, base: { gold: string; textMuted: string; danger: string }): string {
+function getDifficultyColor(level: number, base: { gold: string; textMuted: string; danger: string; warning: string }): string {
   switch (level) {
     case 1: return base.textMuted;
     case 2: return base.gold + '90';
     case 3: return base.gold;
-    case 4: return '#e8a040'; // data-color: intentional
+    case 4: return base.warning;
     case 5: return base.danger;
     default: return base.textMuted;
   }

--- a/app/src/components/FeatureCard.tsx
+++ b/app/src/components/FeatureCard.tsx
@@ -11,7 +11,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import type { ExploreImage } from '../types';
 
 export interface FeatureCardData {
@@ -145,7 +145,7 @@ export function FeatureCard({
                   <View
                     key={i}
                     style={[styles.dot, {
-                      backgroundColor: i === activeIndex ? '#fff' : 'rgba(255,255,255,0.4)', // overlay-color: intentional
+                      backgroundColor: i === activeIndex ? overlay.white : 'rgba(255,255,255,0.4)', // overlay-color: intentional
                     }]}
                   />
                 ))}
@@ -246,7 +246,7 @@ const styles = StyleSheet.create({
     height: 32,
     backgroundColor: 'transparent',
     // Simulated gradient via layered shadow
-    shadowColor: '#000', // overlay-color: intentional
+    shadowColor: overlay.black,
     shadowOffset: { width: 0, height: -8 },
     shadowOpacity: 0.5,
     shadowRadius: 8,
@@ -256,7 +256,7 @@ const styles = StyleSheet.create({
     bottom: 4,
     left: 6,
     right: 24,
-    color: '#fff', // overlay-color: intentional (caption on image)
+    color: overlay.white, // caption on image — mode-invariant
     fontFamily: fontFamily.ui,
     fontSize: 11,
     textShadowColor: 'rgba(0,0,0,0.8)', // overlay-color: intentional

--- a/app/src/components/GospelColors.ts
+++ b/app/src/components/GospelColors.ts
@@ -26,6 +26,38 @@ export const GOSPEL_SHORT: Record<string, string> = {
   john: 'J',
 };
 
+/**
+ * Brighter dot/badge variants used by GospelDots and the Harmony/Parallel
+ * detail screens — tuned for small indicators on dark surfaces, so they
+ * deliberately diverge from GOSPEL_COLORS above.
+ */
+export const GOSPEL_DOT_COLORS: Record<string, string> = {
+  matthew: '#70b8e8', // data-color: intentional (dot blue)
+  mark: '#e86040',    // data-color: intentional (dot orange)
+  luke: '#81C784',    // data-color: intentional (dot green)
+  john: '#b090d0',    // data-color: intentional (dot purple)
+};
+
+/**
+ * Diff annotation colors (Harmony DiffAnnotation cards) — part of the
+ * Gospel identity system's comparison UI.
+ */
+export const DIFF_TYPE_COLORS: Record<string, string> = {
+  addition: '#4a8c5c', // data-color: intentional
+  omission: '#8c4a4a', // data-color: intentional
+  reordering: '#8a6e1a', // data-color: intentional
+  wording: '#8a6e1a', // data-color: intentional
+  theological_emphasis: '#8a6e1a', // data-color: intentional
+};
+
+export const DIFF_TYPE_BG: Record<string, string> = {
+  addition: '#4a8c5c22', // data-color: intentional
+  omission: '#8c4a4a22', // data-color: intentional
+  reordering: '#bfa05022', // data-color: intentional
+  wording: '#bfa05022', // data-color: intentional
+  theological_emphasis: '#bfa05022', // data-color: intentional
+};
+
 export const GOSPEL_ORDER = ['matthew', 'mark', 'luke', 'john'];
 
 export function gospelColor(bookId: string): string {

--- a/app/src/components/GospelDots.tsx
+++ b/app/src/components/GospelDots.tsx
@@ -6,12 +6,13 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme, fontFamily } from '../theme';
+import { GOSPEL_DOT_COLORS } from './GospelColors';
 
 export const GOSPEL_CONFIG: Record<string, { abbrev: string; color: string; name: string }> = {
-  matthew: { abbrev: 'M', color: '#70b8e8', name: 'Matthew' }, // data-color: intentional
-  mark:    { abbrev: 'Mk', color: '#e86040', name: 'Mark' }, // data-color: intentional
-  luke:    { abbrev: 'L', color: '#81C784', name: 'Luke' }, // data-color: intentional
-  john:    { abbrev: 'J', color: '#b090d0', name: 'John' }, // data-color: intentional
+  matthew: { abbrev: 'M', color: GOSPEL_DOT_COLORS.matthew, name: 'Matthew' },
+  mark:    { abbrev: 'Mk', color: GOSPEL_DOT_COLORS.mark, name: 'Mark' },
+  luke:    { abbrev: 'L', color: GOSPEL_DOT_COLORS.luke, name: 'Luke' },
+  john:    { abbrev: 'J', color: GOSPEL_DOT_COLORS.john, name: 'John' },
 };
 
 const GOSPEL_ORDER = ['matthew', 'mark', 'luke', 'john'];

--- a/app/src/components/HighlightColorPicker.tsx
+++ b/app/src/components/HighlightColorPicker.tsx
@@ -5,16 +5,16 @@
 
 import React from 'react';
 import { Alert, View, Text, TouchableOpacity, Modal, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay, userHighlightColors } from '../theme';
 import { selectionFeedback } from '../utils/haptics';
 
 export const HIGHLIGHT_COLORS = [
-  { name: 'gold', hex: '#bfa050', label: 'Key verses' }, // data-color: intentional
-  { name: 'blue', hex: '#5b8fb9', label: 'Commands' }, // data-color: intentional
-  { name: 'green', hex: '#5fa87a', label: 'Prayers' }, // data-color: intentional
-  { name: 'purple', hex: '#8b7cb8', label: 'Study later' }, // data-color: intentional
-  { name: 'coral', hex: '#c47a6a', label: 'Prophecy' }, // data-color: intentional
-  { name: 'teal', hex: '#5ba8a0', label: 'Themes' }, // data-color: intentional
+  { name: 'gold', hex: userHighlightColors.gold, label: 'Key verses' },
+  { name: 'blue', hex: userHighlightColors.blue, label: 'Commands' },
+  { name: 'green', hex: userHighlightColors.green, label: 'Prayers' },
+  { name: 'purple', hex: userHighlightColors.purple, label: 'Study later' },
+  { name: 'coral', hex: userHighlightColors.coral, label: 'Prophecy' },
+  { name: 'teal', hex: userHighlightColors.teal, label: 'Themes' },
 ];
 
 interface Props {
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
     borderWidth: 3,
   },
   checkmark: {
-    color: '#fff', // overlay-color: intentional (white checkmark on color swatch)
+    color: overlay.white, // white checkmark on color swatch — mode-invariant
     fontSize: 14,
   },
   removeButton: {

--- a/app/src/components/LensToggleBar.tsx
+++ b/app/src/components/LensToggleBar.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import type { HermeneuticLens } from '../types';
 
 interface Props {
@@ -42,7 +42,7 @@ function LensToggleBarInner({ lenses, activeLensId, onSelect }: Props) {
           <Text
             style={[
               styles.pillText,
-              { color: activeLensId === null ? '#000' : base.textMuted }, // data-color: intentional (dark text on gold active pill)
+              { color: activeLensId === null ? overlay.onGold : base.textMuted },
             ]}
           >
             Default
@@ -70,7 +70,7 @@ function LensToggleBarInner({ lenses, activeLensId, onSelect }: Props) {
               <Text
                 style={[
                   styles.pillText,
-                  { color: isActive ? '#000' : base.textMuted }, // data-color: intentional (dark text on gold active pill)
+                  { color: isActive ? overlay.onGold : base.textMuted },
                 ]}
               >
                 {lens.name}

--- a/app/src/components/LinkedJourneySheet.tsx
+++ b/app/src/components/LinkedJourneySheet.tsx
@@ -71,7 +71,7 @@ export function LinkedJourneySheet({
       backgroundStyle={{ backgroundColor: base.bgElevated }}
       handleIndicatorStyle={{ backgroundColor: base.textMuted, width: 40 }}
     >
-      <View style={styles.header}>
+      <View style={[styles.header, { borderBottomColor: base.border }]}>
         <View style={styles.headerText}>
           {journey && (
             <>
@@ -164,7 +164,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingBottom: spacing.sm,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#3333',
   },
   headerText: {
     flex: 1,

--- a/app/src/components/MilestoneToast.tsx
+++ b/app/src/components/MilestoneToast.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useMemo } from 'react';
 import { Animated, Text, StyleSheet } from 'react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 
 interface Props {
   message: string | null;
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     paddingVertical: spacing.sm + 2,
     paddingHorizontal: spacing.md,
-    shadowColor: '#000', // overlay-color: intentional (RN shadow must be #000 on iOS)
+    shadowColor: overlay.black, // RN shadow must stay black on iOS
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.3,
     shadowRadius: 4,

--- a/app/src/components/RecommendedCard.tsx
+++ b/app/src/components/RecommendedCard.tsx
@@ -12,7 +12,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { ChevronRight } from 'lucide-react-native';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import type { ExploreImage } from '../types';
 import type { ExploreRecommendation } from '../hooks/useExploreRecommendations';
 
@@ -141,7 +141,7 @@ export function RecommendedCard({
                   <View
                     key={i}
                     style={[styles.dot, {
-                      backgroundColor: i === safeIndex ? '#fff' : 'rgba(255,255,255,0.4)', // overlay-color: intentional
+                      backgroundColor: i === safeIndex ? overlay.white : 'rgba(255,255,255,0.4)', // overlay-color: intentional
                     }]}
                   />
                 ))}
@@ -204,7 +204,7 @@ const styles = StyleSheet.create({
     right: 0,
     height: 40,
     backgroundColor: 'transparent',
-    shadowColor: '#000', // overlay-color: intentional
+    shadowColor: overlay.black,
     shadowOffset: { width: 0, height: -10 },
     shadowOpacity: 0.5,
     shadowRadius: 10,

--- a/app/src/components/StreakBadge.tsx
+++ b/app/src/components/StreakBadge.tsx
@@ -24,7 +24,7 @@ function StreakBadge({ streak }: Props) {
   return (
     <View style={styles.wrapper}>
       {/* Subtle gold glow halo rendered behind the badge. */}
-      <View style={[styles.glow, { backgroundColor: base.gold }]} pointerEvents="none" />
+      <View style={[styles.glow, { backgroundColor: base.gold, shadowColor: base.gold }]} pointerEvents="none" />
       <TouchableOpacity
         onPress={() => shareStreak(streak)}
         activeOpacity={0.7}
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
     opacity: 0.12,
     // iOS shadow for the glow halo. RN shadows must originate from a solid
     // background, so this semi-opaque pill provides the substrate.
-    shadowColor: '#bfa050', // overlay-color: intentional (gold halo)
+    // shadowColor (base.gold) is applied inline so it tracks the theme.
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.8,
     shadowRadius: 8,

--- a/app/src/components/TrustBadge.tsx
+++ b/app/src/components/TrustBadge.tsx
@@ -4,13 +4,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { spacing, radii, fontFamily } from '../theme';
-
-const LEVEL_COLORS: Record<0 | 1 | 2, string> = {
-  0: '#888888', // data-color: intentional
-  1: '#bfa050', // data-color: intentional
-  2: '#50b060', // data-color: intentional
-};
+import { useTheme, spacing, radii, fontFamily } from '../theme';
 
 const LEVEL_LABELS: Record<0 | 1 | 2, string> = {
   0: 'New',
@@ -24,7 +18,8 @@ interface Props {
 }
 
 function TrustBadge({ level, label }: Props) {
-  const color = LEVEL_COLORS[level];
+  const { trustLevels } = useTheme();
+  const color = trustLevels[level];
   const text = label ?? LEVEL_LABELS[level];
 
   return (

--- a/app/src/components/UpgradePrompt.tsx
+++ b/app/src/components/UpgradePrompt.tsx
@@ -18,7 +18,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import type { NavigationProp } from '@react-navigation/native';
 import type { TabParamList } from '../navigation/types';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import type { UpgradeVariant } from '../hooks/usePremium';
 
 interface Props {
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   ctaText: {
-    color: '#1a1a1a', // data-color: intentional (dark text on gold CTA button)
+    color: overlay.onGold,
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 15,
   },

--- a/app/src/components/amicus/AmicusFab.tsx
+++ b/app/src/components/amicus/AmicusFab.tsx
@@ -11,7 +11,7 @@ import { Platform, Pressable, StyleSheet, View, type ViewStyle } from 'react-nat
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, type NavigationProp, type ParamListBase } from '@react-navigation/native';
 import { Lock, MessageSquare } from 'lucide-react-native';
-import { useTheme } from '../../theme';
+import { useTheme, overlay } from '../../theme';
 import { useAmicusFab } from '../../contexts/AmicusFabContext';
 import { useAmicusChapterStudyThread } from '../../hooks/useAmicusChapterStudyThread';
 import { useAmicusAccess } from '../../hooks/useAmicusAccess';
@@ -221,7 +221,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     ...Platform.select({
       ios: {
-        shadowColor: '#000',
+        shadowColor: overlay.black,
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.25,
         shadowRadius: 4,

--- a/app/src/components/explore/FullWidthImageCard.tsx
+++ b/app/src/components/explore/FullWidthImageCard.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
-import { useTheme, spacing, radii, fontFamily } from '../../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../../theme';
 import type { ExploreImage } from '../../types';
 
 const IMAGE_HEIGHT = 85;
@@ -107,7 +107,7 @@ const styles = StyleSheet.create({
     right: 0,
     height: 32,
     backgroundColor: 'transparent', // overlay-color: intentional
-    shadowColor: '#000', // overlay-color: intentional
+    shadowColor: overlay.black,
     shadowOffset: { width: 0, height: -8 },
     shadowOpacity: 0.5,
     shadowRadius: 8,

--- a/app/src/components/map/AncientBorderLayer.tsx
+++ b/app/src/components/map/AncientBorderLayer.tsx
@@ -15,7 +15,7 @@
 import React, { memo } from 'react';
 import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
 import { useAncientBorders } from '../../hooks/useAncientBorders';
-import { eras } from '../../theme';
+import { eras, mapColors } from '../../theme';
 
 interface Props {
   /** Currently-selected era id — 'all' or null disables the layer. */
@@ -32,7 +32,7 @@ export const AncientBorderLayer = memo(function AncientBorderLayer({
   if (showModern) return null;
   if (!era || era === 'all') return null;
 
-  const eraColor = (era && eras[era]) || '#bfa050'; // data-color: intentional (gold fallback for unknown era — MapLibre GL)
+  const eraColor = (era && eras[era]) || mapColors.storyGold;
 
   return (
     <GeoJSONSource

--- a/app/src/components/map/PersonArcLayer.tsx
+++ b/app/src/components/map/PersonArcLayer.tsx
@@ -12,6 +12,7 @@
 
 import React, { memo, useMemo } from 'react';
 import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
+import { mapColors } from '../../theme';
 import type { PersonArcStop } from '../../hooks/usePersonArc';
 
 interface Props {
@@ -20,8 +21,8 @@ interface Props {
   color?: string;
 }
 
-/** Amber, distinct from story-path gold (#bfa050). */
-const ARC_COLOR = '#e09050'; // data-color: intentional (person arc amber — MapLibre GL)
+/** Amber, distinct from story-path gold — see theme/mapColors.ts. */
+const ARC_COLOR = mapColors.arcAmber;
 
 function arcLineFeatureCollection(stops: PersonArcStop[]): GeoJSON.FeatureCollection {
   if (stops.length < 2) return { type: 'FeatureCollection', features: [] };
@@ -94,7 +95,7 @@ export const PersonArcLayer = memo(function PersonArcLayer({
           style={{
             circleRadius: 10,
             circleColor: color,
-            circleStrokeColor: '#1a1610', // data-color: intentional (dark stroke against map bg — MapLibre GL)
+            circleStrokeColor: mapColors.darkHalo,
             circleStrokeWidth: 1.5,
           }}
         />
@@ -106,7 +107,7 @@ export const PersonArcLayer = memo(function PersonArcLayer({
             textField: ['get', 'label'] as any,
             textFont: ['Noto Sans Regular'],
             textSize: 11,
-            textColor: '#1a1610', // data-color: intentional (dark label on amber stop circle — MapLibre GL)
+            textColor: mapColors.darkHalo,
             textIgnorePlacement: true,
           }}
         />
@@ -121,7 +122,7 @@ export const PersonArcLayer = memo(function PersonArcLayer({
             textFont: ['Noto Sans Italic'],
             textSize: 11,
             textColor: color,
-            textHaloColor: '#1a1610', // data-color: intentional (dark halo against map bg — MapLibre GL)
+            textHaloColor: mapColors.darkHalo,
             textHaloWidth: 1.3,
             textOffset: [0, 1.4],
             textAnchor: 'top',

--- a/app/src/components/map/PlaceDetailCard.tsx
+++ b/app/src/components/map/PlaceDetailCard.tsx
@@ -26,6 +26,9 @@ import {
   eraNames,
   fontFamily,
   MIN_TOUCH_TARGET,
+  mapColors,
+  placeTypeColors,
+  testamentEra,
 } from '../../theme';
 import { lightImpact } from '../../utils/haptics';
 import { safeParse } from '../../utils/logger';
@@ -52,18 +55,9 @@ const TYPE_LABELS: Record<Place['type'], string> = {
   site: 'Site',
 };
 
-const TYPE_COLORS: Record<Place['type'], string> = {
-  city: '#d4b483',     // data-color: intentional (warm sand — built environment)
-  mountain: '#d4b483', // data-color: intentional (warm sand — terrain)
-  site: '#d4b483',     // data-color: intentional (warm sand — archaeological site)
-  water: '#90c8d8',    // data-color: intentional (steel blue — water body)
-  region: '#b8a070',   // data-color: intentional (muted gold — region boundary)
-};
+const TYPE_COLORS: Record<Place['type'], string> = placeTypeColors;
 
-const TESTAMENT_COLORS = {
-  OT: '#d4a05a', // data-color: intentional (amber — Old Testament era)
-  NT: '#5ea073', // data-color: intentional (green — New Testament era)
-};
+const TESTAMENT_COLORS = testamentEra;
 
 /** Format a coordinate to 2 decimals with N/S, E/W suffix. */
 export function formatCoord(value: number, axis: 'lat' | 'lon'): string {
@@ -283,11 +277,11 @@ export function PlaceDetailCard({
                 accessibilityLabel={`Show ${p.name}'s geographic arc`}
                 style={[
                   styles.storyChip,
-                  { backgroundColor: '#e09050' + '1A', borderColor: '#e09050' + '40' }, // data-color: intentional (amber arc — matches PersonArcLayer ARC_COLOR)
+                  { backgroundColor: mapColors.arcAmber + '1A', borderColor: mapColors.arcAmber + '40' }, // matches PersonArcLayer ARC_COLOR
                 ]}
               >
                 <Text
-                  style={[styles.storyChipText, { color: '#e09050' }]} // data-color: intentional (amber arc text — matches PersonArcLayer ARC_COLOR)
+                  style={[styles.storyChipText, { color: mapColors.arcAmber }]} // matches PersonArcLayer ARC_COLOR
                   numberOfLines={1}
                 >
                   {p.name}

--- a/app/src/components/map/PlaceMarkerList.tsx
+++ b/app/src/components/map/PlaceMarkerList.tsx
@@ -12,6 +12,7 @@
 
 import React, { memo, useMemo, useCallback } from 'react';
 import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
+import { mapColors } from '../../theme';
 import type { Place, MapStory } from '../../types';
 import { safeParse } from '../../utils/logger';
 
@@ -147,15 +148,15 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const circleColorExpr: any = [
     'case',
-    isActive, '#f5e6b8', // data-color: intentional (warm highlight — active place marker, MapLibre GL)
-    '#bfa050',           // data-color: intentional (gold — default place marker, MapLibre GL)
+    isActive, mapColors.markerActive,
+    mapColors.storyGold,
   ];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const circleStrokeColorExpr: any = [
     'case',
-    isActive, '#bfa050', // data-color: intentional (gold stroke on active — MapLibre GL)
-    '#1a1610',           // data-color: intentional (dark stroke on inactive — MapLibre GL)
+    isActive, mapColors.storyGold,
+    mapColors.darkHalo,
   ];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -211,11 +212,11 @@ export const PlaceMarkerList = memo(function PlaceMarkerList({
           textSize: ['match', ['get', 'priority'], 1, 13, 2, 12, 3, 11, 4, 10, 11] as any,
           textColor: [
             'case',
-            isActive, '#f5e6b8', // data-color: intentional (warm highlight label — active, MapLibre GL)
-            '#bfa050',           // data-color: intentional (gold label — default, MapLibre GL)
+            isActive, mapColors.markerActive,
+            mapColors.storyGold,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ] as any,
-          textHaloColor: '#1a1610', // data-color: intentional (dark halo against map bg — MapLibre GL)
+          textHaloColor: mapColors.darkHalo,
           textHaloWidth: 1.5,
           textOffset: [0, 1.1],
           textAnchor: 'top',

--- a/app/src/components/map/PlaceSearchBar.tsx
+++ b/app/src/components/map/PlaceSearchBar.tsx
@@ -18,19 +18,14 @@ import {
   radii,
   fontFamily,
   MIN_TOUCH_TARGET,
+  placeTypeColors,
 } from '../../theme';
 import type { Place } from '../../types';
 
 const MAX_RESULTS = 8;
 
 /** Colour of the leading dot in each result row. Mirrors PlaceLabel. */
-const TYPE_COLORS: Record<Place['type'], string> = {
-  city: '#d4b483',     // data-color: intentional (warm sand — built environment)
-  mountain: '#d4b483', // data-color: intentional (warm sand — terrain)
-  site: '#d4b483',     // data-color: intentional (warm sand — archaeological site)
-  water: '#90c8d8',    // data-color: intentional (steel blue — water body)
-  region: '#b8a070',   // data-color: intentional (muted gold — region boundary)
-};
+const TYPE_COLORS: Record<Place['type'], string> = placeTypeColors;
 
 export interface PlaceSearchBarProps {
   places: Place[];

--- a/app/src/components/map/StoryOverlays.tsx
+++ b/app/src/components/map/StoryOverlays.tsx
@@ -15,7 +15,7 @@
 
 import React, { memo, useMemo } from 'react';
 import { GeoJSONSource, Layer } from '@maplibre/maplibre-react-native';
-import { eras } from '../../theme';
+import { eras, mapColors } from '../../theme';
 import type { MapStory } from '../../types';
 import { safeParse } from '../../utils/logger';
 
@@ -125,7 +125,7 @@ function closeRing(coords: number[][]): number[][] {
 }
 
 export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
-  const eraColor = eras[story.era] ?? '#bfa050'; // data-color: intentional (gold fallback for unknown era — MapLibre GL)
+  const eraColor = eras[story.era] ?? mapColors.storyGold;
 
   const regionsFC = useMemo(() => {
     const regions = safeParse<RawRegion[]>(story.regions_json, []);
@@ -178,7 +178,7 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           filter={['!', ['get', 'dashed']] as any}
           style={{
-            lineColor: '#bfa050', // data-color: intentional (gold story path — MapLibre GL)
+            lineColor: mapColors.storyGold,
             lineWidth: 2,
             lineCap: 'round',
             lineJoin: 'round',
@@ -190,7 +190,7 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           filter={['get', 'dashed'] as any}
           style={{
-            lineColor: '#bfa050', // data-color: intentional (gold dashed path — MapLibre GL)
+            lineColor: mapColors.storyGold,
             lineWidth: 2,
             lineCap: 'round',
             lineJoin: 'round',
@@ -215,8 +215,8 @@ export const StoryOverlays = memo(function StoryOverlays({ story }: Props) {
             textRotate: ['get', 'bearing'] as any,
             textRotationAlignment: 'map',
             textPitchAlignment: 'map',
-            textColor: '#bfa050',   // data-color: intentional (gold arrowhead — MapLibre GL)
-            textHaloColor: '#1a1610', // data-color: intentional (dark halo against map bg — MapLibre GL)
+            textColor: mapColors.storyGold,
+            textHaloColor: mapColors.darkHalo,
             textHaloWidth: 1.5,
             textAllowOverlap: true,
             textIgnorePlacement: true,

--- a/app/src/components/moderation/FlagReasonPicker.tsx
+++ b/app/src/components/moderation/FlagReasonPicker.tsx
@@ -16,10 +16,10 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { useTheme, spacing, fontFamily, MIN_TOUCH_TARGET } from '../../theme';
+import { useTheme, spacing, fontFamily, MIN_TOUCH_TARGET, overlay } from '../../theme';
 import { submitFlag } from '../../services/engagementApi';
 
-const SUBMIT_BUTTON_TEXT = '#fff'; // overlay-color: intentional (white text on gold submit button)
+const SUBMIT_BUTTON_TEXT = overlay.white; // white text on gold submit button — mode-invariant
 
 const REASONS = [
   'Spam',

--- a/app/src/components/panels/DiscoursePanel.tsx
+++ b/app/src/components/panels/DiscoursePanel.tsx
@@ -46,23 +46,6 @@ interface Props {
   data: DiscourseData;
 }
 
-// ── Color mapping by node type ───────────────────────────────────────
-
-const NODE_TYPE_COLORS: Record<NodeType, string> = {
-  thesis: '#bfa050',       // data-color: intentional (gold)
-  premise: '#70b8e8',      // data-color: intentional (blue)
-  ground: '#70d098',       // data-color: intentional (green)
-  inference: '#c090e0',    // data-color: intentional (purple)
-  conclusion: '#e8a070',   // data-color: intentional (orange)
-  contrast: '#e07070',     // data-color: intentional (red)
-  concession: '#a0a0c0',   // data-color: intentional (gray-blue)
-  purpose: '#80c8c0',      // data-color: intentional (teal)
-  result: '#d8b870',       // data-color: intentional (warm gold)
-  illustration: '#b8a090', // data-color: intentional (taupe)
-  exhortation: '#e890b8',  // data-color: intentional (pink)
-  doxology: '#c8c080',     // data-color: intentional (olive gold)
-};
-
 const NODE_TYPE_LABELS: Record<NodeType, string> = {
   thesis: 'Thesis',
   premise: 'Premise',
@@ -86,10 +69,10 @@ interface NodeCardProps {
 }
 
 function NodeCard({ node, depth }: NodeCardProps) {
-  const { base } = useTheme();
+  const { base, discourseNodes } = useTheme();
   const [expanded, setExpanded] = useState(depth === 0);
   const hasChildren = node.children && node.children.length > 0;
-  const color = NODE_TYPE_COLORS[node.type] || base.gold;
+  const color = discourseNodes[node.type] || base.gold;
   const label = NODE_TYPE_LABELS[node.type] || node.type;
 
   const toggleExpand = useCallback(() => {

--- a/app/src/components/panels/EchoesView.tsx
+++ b/app/src/components/panels/EchoesView.tsx
@@ -24,15 +24,8 @@ const TYPE_LABELS: Record<EchoType, string> = {
   typological: 'Typological',
 };
 
-const TYPE_COLORS: Record<EchoType, string> = {
-  direct_quote: '#64B5F6', // data-color: intentional
-  allusion: '#81C784', // data-color: intentional
-  echo: '#FFB74D', // data-color: intentional
-  typological: '#BA68C8', // data-color: intentional
-};
-
 export function EchoesView({ entries, onRefPress }: Props) {
-  const { base, getPanelColors } = useTheme();
+  const { base, getPanelColors, echoTypes } = useTheme();
   const colors = getPanelColors('cross');
 
   const handleRefPress = (ref: string) => {
@@ -43,7 +36,7 @@ export function EchoesView({ entries, onRefPress }: Props) {
   return (
     <View style={styles.container}>
       {entries.map((entry, i) => {
-        const typeColor = TYPE_COLORS[entry.type] ?? base.textMuted;
+        const typeColor = echoTypes[entry.type] ?? base.textMuted;
         const typeLabel = TYPE_LABELS[entry.type] ?? entry.type;
 
         return (

--- a/app/src/components/study/LibrarySections.tsx
+++ b/app/src/components/study/LibrarySections.tsx
@@ -5,9 +5,9 @@
  *
  * Each section is a horizontal shelf (FlatList) of cards: art slot
  * (content_images via the explore image registry, tonal-wash fallback
- * inside FeatureCard when no image) + title + subtitle. The per-tool
- * `color` values in LIBRARY_SECTIONS are intentional data colors, not
- * theme leaks — everything else styles through useTheme() tokens.
+ * inside FeatureCard when no image) + title + subtitle. Per-tool accent
+ * colors come from the theme's `libraryAccents` record (keyed by screen
+ * name) so they transform with the active mode (#1898).
  *
  * Consumers own premium gating: pass `onNavigate` that checks
  * PREMIUM_SCREENS (exported here) and shows the upgrade prompt.
@@ -32,11 +32,15 @@ import type { ProphecyChain } from '../../types';
 
 // ── Section data ───────────────────────────────────────────────
 
+/** Card data minus `color` — the accent is injected from the theme's
+ *  `libraryAccents` record at render time. */
+export type LibraryFeature = Omit<FeatureCardData, 'color'>;
+
 export interface FeatureSection {
   id: string;
   label: string;
   subtitle: string;
-  features: FeatureCardData[];
+  features: LibraryFeature[];
 }
 
 /** Screens that require premium — consumers gate onNavigate with this. */
@@ -51,21 +55,21 @@ export const LIBRARY_SECTIONS: FeatureSection[] = [
   {
     id: 'biblical-world', label: 'The Biblical World', subtitle: 'Where, when, and who',
     features: [
-      { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                color: '#e86040', screen: 'GenealogyTree' }, // data-color: intentional
-      { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        color: '#70b8e8', screen: 'Timeline' }, // data-color: intentional
-      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              color: '#81C784', screen: 'Map' }, // data-color: intentional
-      { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    color: '#8a6e3a', screen: 'Periods', premium: true }, // data-color: intentional
-      { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          color: '#c8a040', screen: 'RedemptiveArc', premium: true }, // data-color: intentional
+      { title: 'People',    subtitle: '282 people on a zoomable family tree with bios',                screen: 'GenealogyTree' },
+      { title: 'Timeline',  subtitle: '543 events from creation to revelation',                        screen: 'Timeline' },
+      { title: 'Map',       subtitle: '28 journeys with route overlays across 73 places',              screen: 'Map' },
+      { title: 'Periods',   subtitle: '12 eras from creation to the apostolic age',                    screen: 'Periods', premium: true },
+      { title: 'Story',     subtitle: '8 acts in God\'s redemptive narrative',                          screen: 'RedemptiveArc', premium: true },
     ],
   },
   {
     id: 'themes', label: 'Themes & Connections', subtitle: 'Trace ideas across Scripture',
     features: [
-      { title: 'Guided Journeys',    subtitle: '60 journeys — people, concepts, themes',             color: '#bfa050', screen: 'JourneyBrowse' }, // data-color: intentional
-      { title: 'Topical Index',      subtitle: 'What does the Bible say about...?',                    color: '#c8a040', screen: 'TopicBrowse' }, // data-color: intentional
-      { title: 'Prophecy',           subtitle: '50 chains — OT to NT fulfillment',                color: '#e8a070', screen: 'ProphecyBrowse' }, // data-color: intentional
-      { title: 'Threads',            subtitle: 'One idea across 31 chains',                            color: '#9090e0', screen: 'ThreadBrowse', premium: true }, // data-color: intentional
-      { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                color: '#70d098', screen: 'HarmonyBrowse' }, // data-color: intentional
+      { title: 'Guided Journeys',    subtitle: '60 journeys — people, concepts, themes',             screen: 'JourneyBrowse' },
+      { title: 'Topical Index',      subtitle: 'What does the Bible say about...?',                    screen: 'TopicBrowse' },
+      { title: 'Prophecy',           subtitle: '50 chains — OT to NT fulfillment',                screen: 'ProphecyBrowse' },
+      { title: 'Threads',            subtitle: 'One idea across 31 chains',                            screen: 'ThreadBrowse', premium: true },
+      { title: 'Gospel Harmony',     subtitle: 'Parallel accounts across four Gospels',                screen: 'HarmonyBrowse' },
     ],
   },
   {
@@ -75,34 +79,34 @@ export const LIBRARY_SECTIONS: FeatureSection[] = [
   {
     id: 'language', label: 'Language & Reference', subtitle: 'Original words and definitions',
     features: [
-      { title: 'Word Studies', subtitle: 'Hebrew & Greek deep dives',                                  color: '#e890b8', screen: 'WordStudyBrowse' }, // data-color: intentional
-      { title: 'Concordance',  subtitle: 'Every occurrence of a word',                                 color: '#70b8e8', screen: 'Concordance', premium: true }, // data-color: intentional
-      { title: 'Dictionary',   subtitle: 'Definitions for every biblical term',                         color: '#c090e0', screen: 'DictionaryBrowse' }, // data-color: intentional
+      { title: 'Word Studies', subtitle: 'Hebrew & Greek deep dives',                                  screen: 'WordStudyBrowse' },
+      { title: 'Concordance',  subtitle: 'Every occurrence of a word',                                 screen: 'Concordance', premium: true },
+      { title: 'Dictionary',   subtitle: 'Definitions for every biblical term',                         screen: 'DictionaryBrowse' },
     ],
   },
   {
     id: 'scholarly', label: 'Scholarly Analysis', subtitle: 'Academic perspectives & debate',
     features: [
-      { title: 'Scholars',             subtitle: 'Browse all 54 by tradition',                            color: '#a0b8d0', screen: 'ScholarBrowse' }, // data-color: intentional
-      { title: 'Debates',              subtitle: '303 topics where scholars disagree',                    color: '#d08080', screen: 'DebateBrowse' }, // data-color: intentional
-      { title: 'Difficult Passages',   subtitle: '53 hard texts with multi-view responses',               color: '#FFB74D', screen: 'DifficultPassagesBrowse' }, // data-color: intentional
-      { title: 'How We Got The Bible', subtitle: 'Canon, manuscripts, translations, and the books Jude quoted', color: '#c89858', screen: 'HowWeGotTheBibleLanding', premium: true }, // data-color: intentional
-      { title: 'Content Library',      subtitle: 'Discourse, manuscripts & more',                          color: '#b8a0d0', screen: 'ContentLibrary', premium: true }, // data-color: intentional
+      { title: 'Scholars',             subtitle: 'Browse all 54 by tradition',                            screen: 'ScholarBrowse' },
+      { title: 'Debates',              subtitle: '303 topics where scholars disagree',                    screen: 'DebateBrowse' },
+      { title: 'Difficult Passages',   subtitle: '53 hard texts with multi-view responses',               screen: 'DifficultPassagesBrowse' },
+      { title: 'How We Got The Bible', subtitle: 'Canon, manuscripts, translations, and the books Jude quoted', screen: 'HowWeGotTheBibleLanding', premium: true },
+      { title: 'Content Library',      subtitle: 'Discourse, manuscripts & more',                          screen: 'ContentLibrary', premium: true },
     ],
   },
   {
     id: 'life', label: 'Life & Faith', subtitle: 'Biblical guidance for everyday life',
     features: [
-      { title: 'Life Topics', subtitle: 'Practical guidance from Scripture',                             color: '#81C784', screen: 'LifeTopics' }, // data-color: intentional
+      { title: 'Life Topics', subtitle: 'Practical guidance from Scripture',                             screen: 'LifeTopics' },
     ],
   },
   {
     id: 'deep-dive', label: 'Deep Dive', subtitle: 'Advanced study tools',
     features: [
-      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     color: '#BA68C8', screen: 'LensBrowse' }, // data-color: intentional
-      { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                color: '#b07d4f', screen: 'ArchaeologyBrowse' }, // data-color: intentional
-      { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   color: '#8a6a3a', screen: 'TimeTravelBrowse' }, // data-color: intentional
-      { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  color: '#7a9ab0', screen: 'GrammarBrowse' }, // data-color: intentional
+      { title: 'Hermeneutic Lenses', subtitle: 'Read Scripture through 8 interpretive frameworks',     screen: 'LensBrowse' },
+      { title: 'Archaeology',        subtitle: 'Real artifacts that illuminate the text',                screen: 'ArchaeologyBrowse' },
+      { title: 'Time-Travel Reader', subtitle: 'Augustine, Luther & modern scholars',                   screen: 'TimeTravelBrowse' },
+      { title: 'Grammar',            subtitle: 'Verb forms & syntax in plain English',                  screen: 'GrammarBrowse' },
     ],
   },
 ];
@@ -128,7 +132,7 @@ export function LibrarySections({
   onDeepLink,
   filterSectionId,
 }: LibrarySectionsProps) {
-  const { base } = useTheme();
+  const { base, libraryAccents } = useTheme();
   const { chains: prophecyChains } = useProphecyChains();
 
   const getScreenImages = useCallback(
@@ -137,11 +141,15 @@ export function LibrarySections({
   );
 
   const renderFeatureCard = useCallback(
-    ({ item, index }: { item: FeatureCardData; index: number }, compact: boolean) => {
+    ({ item, index }: { item: LibraryFeature; index: number }, compact: boolean) => {
       const imgData = getScreenImages(item.screen);
+      const feature: FeatureCardData = {
+        ...item,
+        color: libraryAccents[item.screen] ?? base.gold,
+      };
       return (
         <FeatureCard
-          feature={item}
+          feature={feature}
           onPress={() => onNavigate(item.screen)}
           isPremium={isPremium}
           images={imgData?.images}
@@ -153,10 +161,10 @@ export function LibrarySections({
         />
       );
     },
-    [getScreenImages, isPremium, onNavigate, onDeepLink],
+    [getScreenImages, isPremium, onNavigate, onDeepLink, libraryAccents, base.gold],
   );
 
-  const featureKey = useCallback((item: FeatureCardData) => item.screen, []);
+  const featureKey = useCallback((item: LibraryFeature) => item.screen, []);
   const chainKey = useCallback((item: ProphecyChain) => item.id, []);
 
   // ── Per-section content renderer ────────────────────────────

--- a/app/src/components/tree/TreeNode.tsx
+++ b/app/src/components/tree/TreeNode.tsx
@@ -34,10 +34,6 @@ const NAME_GAP = 8;            // circle bottom edge → name baseline
 // Accessibility — every interactive node should have a 44 pt touch target
 const MIN_TOUCH_H = 44;
 
-// Flat fills — match the wireframe's dark backgrounds
-const SPINE_FILL = '#1a1810'; // data-color: intentional (SVG spine node fill — warm-dark bg)
-const SAT_FILL = '#181612';   // data-color: intentional (SVG satellite node fill — warm-dark bg)
-
 interface Props {
   node: LayoutNode;
   dimmed: boolean;
@@ -111,9 +107,11 @@ export const TreeNode = memo(function TreeNode({
 
   // Fill — messianic uses the radial gradient defined on TreeCanvas;
   // everything else uses a flat dark colour.
+  // Flat fills track the theme (near-identical to the old wireframe
+  // constants in dark mode; adapt in sepia/light).
   const nodeFill = onMessianicLine
     ? 'url(#messianic-node-fill)'
-    : (isSpine ? SPINE_FILL : SAT_FILL);
+    : (isSpine ? base.bg3 : base.bgSurface);
 
   // Initial letter — first character of the person's name, uppercased
   const initial = (data.name?.[0] ?? '').toUpperCase();

--- a/app/src/screens/DebateBrowseScreen.tsx
+++ b/app/src/screens/DebateBrowseScreen.tsx
@@ -21,19 +21,6 @@ import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 type Nav = ScreenNavProp<'Explore', 'DebateBrowse'>;
 
-/**
- * Per-category accent colors kept as-is — they're used on the card's left
- * border + tradition dots to preserve at-a-glance category differentiation.
- * The filter bar itself uses the monochrome gold pills now (#1359).
- */
-const CATEGORY_COLORS: Record<string, string> = {
-  theological: '#64B5F6', // data-color: intentional
-  ethical: '#81C784', // data-color: intentional
-  historical: '#FFB74D', // data-color: intentional
-  textual: '#BA68C8', // data-color: intentional
-  interpretive: '#4FC3F7', // data-color: intentional
-};
-
 function getPositionTraditions(topic: DebateTopicSummary): string[] {
   try {
     const positions = JSON.parse(topic.positions_json || '[]');
@@ -48,7 +35,7 @@ function getPositionTraditions(topic: DebateTopicSummary): string[] {
 }
 
 function DebateBrowseScreen() {
-  const { base } = useTheme();
+  const { base, debateCategories } = useTheme();
   const navigation = useNavigation<Nav>();
   const {
     topics,
@@ -69,7 +56,9 @@ function DebateBrowseScreen() {
 
   const renderCard = useCallback(
     ({ item }: { item: DebateTopicSummary }) => {
-      const catColor = CATEGORY_COLORS[item.category] || base.textDim;
+      // Card left border + tradition dots keep per-category accents for
+      // at-a-glance differentiation; filter bar uses monochrome gold (#1359).
+      const catColor = debateCategories[item.category] || base.textDim;
       const traditions = getPositionTraditions(item);
 
       return (

--- a/app/src/screens/ForgotPasswordScreen.tsx
+++ b/app/src/screens/ForgotPasswordScreen.tsx
@@ -19,7 +19,7 @@ import type { ScreenNavProp } from '../navigation/types';
 import { useAuthStore } from '../stores';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { AuthInput } from '../components/AuthInput';
-import { useTheme, spacing, fontFamily, radii } from '../theme';
+import { useTheme, spacing, fontFamily, radii, overlay } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function ForgotPasswordScreen() {
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
   primaryButtonText: {
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 16,
-    color: '#1a1a1a', // data-color: intentional
+    color: overlay.onGold,
   },
   successText: {
     fontFamily: fontFamily.ui,

--- a/app/src/screens/LoginScreen.tsx
+++ b/app/src/screens/LoginScreen.tsx
@@ -21,7 +21,7 @@ import { useAuthStore } from '../stores';
 import { useAuth } from '../hooks/useAuth';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { AuthInput } from '../components/AuthInput';
-import { useTheme, spacing, fontFamily, radii } from '../theme';
+import { useTheme, spacing, fontFamily, radii, brand, overlay } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function LoginScreen() {
@@ -105,18 +105,18 @@ function LoginScreen() {
         {/* Social buttons */}
         <TouchableOpacity
           onPress={handleGoogle}
-          style={[styles.socialButton, { backgroundColor: '#fff' }]} // brand-color: intentional (Google white)
+          style={[styles.socialButton, { backgroundColor: brand.googleBg }]}
           activeOpacity={0.7}
         >
-          <Text style={[styles.socialButtonText, { color: '#1f1f1f' }]}>{/* brand-color: intentional (Google dark) */}Continue with Google</Text>
+          <Text style={[styles.socialButtonText, { color: brand.googleText }]}>Continue with Google</Text>
         </TouchableOpacity>
 
         <TouchableOpacity
           onPress={handleFacebook}
-          style={[styles.socialButton, { backgroundColor: '#1877F2', marginTop: spacing.sm }]} // brand-color: intentional (Facebook blue)
+          style={[styles.socialButton, { backgroundColor: brand.facebookBg, marginTop: spacing.sm }]}
           activeOpacity={0.7}
         >
-          <Text style={[styles.socialButtonText, { color: '#fff' }]}>{/* brand-color: intentional (Facebook white) */}Continue with Facebook</Text>
+          <Text style={[styles.socialButtonText, { color: brand.facebookText }]}>Continue with Facebook</Text>
         </TouchableOpacity>
 
         {/* Divider */}
@@ -270,7 +270,7 @@ const styles = StyleSheet.create({
   primaryButtonText: {
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 16,
-    color: '#1a1a1a', // data-color: intentional (dark text on gold button)
+    color: overlay.onGold,
   },
   magicLinkButton: {
     height: 48,

--- a/app/src/screens/MyStudyScreen.tsx
+++ b/app/src/screens/MyStudyScreen.tsx
@@ -8,7 +8,7 @@ import { usePremium, useReviewQueue } from '../hooks';
 import { UpgradePrompt } from '../components/UpgradePrompt';
 import { formatChapterRef, getGuidedStudyStepLabel } from '../services/guidedStudy';
 import { launchAmicusStudyThread } from '../services/amicus';
-import { fontFamily, radii, spacing, useTheme } from '../theme';
+import { fontFamily, overlay, radii, spacing, useTheme } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 import type { GuidedStudyQuestion, GuidedStudySession, GuidedStudyTakeawaySummary } from '../types';
 
@@ -508,7 +508,7 @@ const styles = StyleSheet.create({
     marginTop: spacing.md,
   },
   primaryText: {
-    color: '#111111',
+    color: overlay.onGold,
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 14,
   },

--- a/app/src/screens/RedemptiveArcScreen.tsx
+++ b/app/src/screens/RedemptiveArcScreen.tsx
@@ -22,7 +22,7 @@ import { ScreenHeader } from '../components/ScreenHeader';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { BadgeChip } from '../components/BadgeChip';
 import { UpgradePrompt } from '../components/UpgradePrompt';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 const FREE_ACT_COUNT = 2;
@@ -195,7 +195,7 @@ const styles = StyleSheet.create({
   actNumText: {
     fontFamily: fontFamily.displaySemiBold,
     fontSize: 14,
-    color: '#1a1a1a', // data-color: intentional (dark text on gold badge)
+    color: overlay.onGold,
   },
   actName: {
     fontFamily: fontFamily.displayMedium,

--- a/app/src/screens/SignUpScreen.tsx
+++ b/app/src/screens/SignUpScreen.tsx
@@ -20,7 +20,7 @@ import type { ScreenNavProp } from '../navigation/types';
 import { useAuthStore } from '../stores';
 import { ScreenHeader } from '../components/ScreenHeader';
 import { AuthInput } from '../components/AuthInput';
-import { useTheme, spacing, fontFamily, radii } from '../theme';
+import { useTheme, spacing, fontFamily, radii, brand, overlay } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
 function SignUpScreen() {
@@ -94,18 +94,18 @@ function SignUpScreen() {
         {/* Social buttons */}
         <TouchableOpacity
           onPress={handleGoogle}
-          style={[styles.socialButton, { backgroundColor: '#fff' }]} // brand-color: intentional (Google white)
+          style={[styles.socialButton, { backgroundColor: brand.googleBg }]}
           activeOpacity={0.7}
         >
-          <Text style={[styles.socialButtonText, { color: '#1f1f1f' }]}>{/* brand-color: intentional (Google dark) */}Continue with Google</Text>
+          <Text style={[styles.socialButtonText, { color: brand.googleText }]}>Continue with Google</Text>
         </TouchableOpacity>
 
         <TouchableOpacity
           onPress={handleFacebook}
-          style={[styles.socialButton, { backgroundColor: '#1877F2', marginTop: spacing.sm }]} // brand-color: intentional (Facebook blue)
+          style={[styles.socialButton, { backgroundColor: brand.facebookBg, marginTop: spacing.sm }]}
           activeOpacity={0.7}
         >
-          <Text style={[styles.socialButtonText, { color: '#fff' }]}>{/* brand-color: intentional (Facebook white) */}Continue with Facebook</Text>
+          <Text style={[styles.socialButtonText, { color: brand.facebookText }]}>Continue with Facebook</Text>
         </TouchableOpacity>
 
         {/* Divider */}
@@ -232,7 +232,7 @@ const styles = StyleSheet.create({
   primaryButtonText: {
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 16,
-    color: '#1a1a1a', // data-color: intentional (dark text on gold button)
+    color: overlay.onGold,
   },
   successText: {
     fontFamily: fontFamily.ui,

--- a/app/src/screens/StudySessionScreen.tsx
+++ b/app/src/screens/StudySessionScreen.tsx
@@ -87,7 +87,7 @@ import { useAmicusAccess } from '../hooks/useAmicusAccess';
 import type { CapturedInputs } from '../services/guidedStudy/capturedInputs';
 import { launchAmicusStudyThread } from '../services/amicus';
 import { useSettingsStore } from '../stores';
-import { fontFamily, radii, spacing, useTheme } from '../theme';
+import { fontFamily, overlay, radii, spacing, useTheme } from '../theme';
 import type {
   Book,
   Chapter,
@@ -1166,7 +1166,7 @@ const styles = StyleSheet.create({
     marginTop: spacing.sm,
   },
   primaryText: {
-    color: '#111111',
+    color: overlay.onGold,
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 14,
   },

--- a/app/src/screens/SubscriptionScreen.tsx
+++ b/app/src/screens/SubscriptionScreen.tsx
@@ -30,10 +30,10 @@ import {
   restorePurchases,
   type PlanInfo,
 } from '../services/purchases';
-import { useTheme, spacing, radii, fontFamily } from '../theme';
+import { useTheme, spacing, radii, fontFamily, overlay } from '../theme';
 import { withErrorBoundary } from '../components/ScreenErrorBoundary';
 
-const GOLD_BUTTON_DARK = '#1a1a1a'; // data-color: intentional (dark text/elements on gold CTA button)
+const GOLD_BUTTON_DARK = overlay.onGold; // dark text/elements on gold CTA button
 
 interface PartnerCapability {
   Icon: typeof BookOpen;
@@ -414,7 +414,7 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 9,
     letterSpacing: 0.8,
-    color: '#1a1a1a', // data-color: intentional — dark text on gold badge
+    color: overlay.onGold,
   },
   planCard: {
     borderWidth: 1.5,
@@ -446,7 +446,7 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
   },
   purchaseBtnText: {
-    color: '#1a1a1a', // data-color: intentional (dark text on gold button)
+    color: overlay.onGold,
     fontFamily: fontFamily.uiSemiBold,
     fontSize: 16,
   },

--- a/app/src/screens/UserProfileScreen.tsx
+++ b/app/src/screens/UserProfileScreen.tsx
@@ -38,10 +38,10 @@ import { logger } from '../utils/logger';
 
 /* ── Trust level helpers ──────────────────────────────────────────── */
 
-const TRUST_LEVELS: Record<number, { label: string; color: string }> = {
-  0: { label: 'New Member', color: '#888' }, // data-color: intentional
-  1: { label: 'Contributor', color: '#bfa050' }, // data-color: intentional
-  2: { label: 'Trusted', color: '#50b060' }, // data-color: intentional
+const TRUST_LEVEL_LABELS: Record<number, string> = {
+  0: 'New Member',
+  1: 'Contributor',
+  2: 'Trusted',
 };
 
 function getTrustLevel(_user: { app_metadata?: Record<string, unknown> }): number {
@@ -51,7 +51,7 @@ function getTrustLevel(_user: { app_metadata?: Record<string, unknown> }): numbe
 /* ── Component ────────────────────────────────────────────────────── */
 
 function UserProfileScreen() {
-  const { base } = useTheme();
+  const { base, trustLevels } = useTheme();
   const navigation = useNavigation<ScreenNavProp<'More', 'UserProfile'>>();
   const user = useAuthStore((s) => s.user);
   const signOut = useAuthStore((s) => s.signOut);
@@ -73,7 +73,10 @@ function UserProfileScreen() {
   /* ── Derived values ────────────────────────────────────────────── */
 
   const trustLevel = user ? getTrustLevel(user) : 0;
-  const trustInfo = TRUST_LEVELS[trustLevel] ?? TRUST_LEVELS[0];
+  const trustInfo = {
+    label: TRUST_LEVEL_LABELS[trustLevel] ?? TRUST_LEVEL_LABELS[0],
+    color: trustLevels[trustLevel] ?? trustLevels[0],
+  };
 
   const email = profile?.email ?? user?.email ?? '';
   const providerRaw = profile?.provider ?? user?.app_metadata?.provider ?? 'email';
@@ -260,14 +263,6 @@ function getInitials(name: string): string {
 
 /* ── Sub-components ───────────────────────────────────────────────── */
 
-const STATUS_COLORS: Record<SubmissionStatus, string> = {
-  draft: '#888', // data-color: intentional
-  pending: '#d4a843', // data-color: intentional
-  approved: '#50b060', // data-color: intentional
-  rejected: '#cc4444', // data-color: intentional
-  flagged: '#cc6633', // data-color: intentional
-};
-
 function StatusBadge({
   status,
   base: _base,
@@ -275,7 +270,8 @@ function StatusBadge({
   status: SubmissionStatus;
   base: ReturnType<typeof useTheme>['base'];
 }) {
-  const color = STATUS_COLORS[status] ?? '#888'; // data-color: intentional (fallback)
+  const { contributionStatus, trustLevels } = useTheme();
+  const color = contributionStatus[status] ?? trustLevels[0];
   return (
     <View style={[styles.statusBadge, { backgroundColor: color + '20' }]}>
       <Text style={[styles.statusText, { color }]}>

--- a/app/src/screens/settings/__tests__/AmicusSettingsSection.test.tsx
+++ b/app/src/screens/settings/__tests__/AmicusSettingsSection.test.tsx
@@ -25,6 +25,7 @@ const base = {
   verseNum: '#999',
   navText: '#fff',
   danger: '#c00',
+    warning: '#e8a040',
   success: '#0c0',
   redLetter: '#c33',
   tintWarm: '#333',

--- a/app/src/theme/colors.ts
+++ b/app/src/theme/colors.ts
@@ -244,6 +244,148 @@ export const timelineSvg = {
   tick: '#5a4a28',
 } as const;
 
+// ── Discourse Node Colors (DiscoursePanel argument trees) ─────────
+// Keyed by discourse node type. Transformed per mode via buildPalette.
+
+export const discourseNodes: Record<string, string> = {
+  thesis: '#bfa050',
+  premise: '#70b8e8',
+  ground: '#70d098',
+  inference: '#c090e0',
+  conclusion: '#e8a070',
+  contrast: '#e07070',
+  concession: '#a0a0c0',
+  purpose: '#80c8c0',
+  result: '#d8b870',
+  illustration: '#b8a090',
+  exhortation: '#e890b8',
+  doxology: '#c8c080',
+} as const;
+
+// ── Echo Type Colors (Connections hub EchoesView) ─────────────────
+
+export const echoTypes = {
+  direct_quote: '#64B5F6',
+  allusion: '#81C784',
+  echo: '#FFB74D',
+  typological: '#BA68C8',
+} as const;
+
+// ── Debate Topic Category Colors (DebateBrowseScreen) ─────────────
+// Distinct from `categories` (difficult passages) — same hues, different
+// key set, tuned independently. Do not merge without a visual pass.
+
+export const debateCategories = {
+  theological: '#64B5F6',
+  ethical: '#81C784',
+  historical: '#FFB74D',
+  textual: '#BA68C8',
+  interpretive: '#4FC3F7',
+} as const;
+
+// ── Debate Position Analysis Colors (DebatePositionCard) ──────────
+
+export const debatePosition = {
+  strengths: '#4CAF50',
+  weaknesses: '#F44336',
+} as const;
+
+// ── Trust Level Colors (TrustBadge, UserProfileScreen) ────────────
+
+export const trustLevels: Record<number, string> = {
+  0: '#888888',
+  1: '#bfa050',
+  2: '#50b060',
+} as const;
+
+// ── Contribution Status Colors (UserProfileScreen) ────────────────
+
+export const contributionStatus: Record<string, string> = {
+  draft: '#888888',
+  pending: '#d4a843',
+  approved: '#50b060',
+  rejected: '#cc4444',
+  flagged: '#cc6633',
+} as const;
+
+// ── Library Shelf Accents (LibrarySections feature cards) ─────────
+// Keyed by destination screen name.
+
+export const libraryAccents: Record<string, string> = {
+  GenealogyTree: '#e86040',
+  Timeline: '#70b8e8',
+  Map: '#81C784',
+  Periods: '#8a6e3a',
+  RedemptiveArc: '#c8a040',
+  JourneyBrowse: '#bfa050',
+  TopicBrowse: '#c8a040',
+  ProphecyBrowse: '#e8a070',
+  ThreadBrowse: '#9090e0',
+  HarmonyBrowse: '#70d098',
+  WordStudyBrowse: '#e890b8',
+  Concordance: '#70b8e8',
+  DictionaryBrowse: '#c090e0',
+  ScholarBrowse: '#a0b8d0',
+  DebateBrowse: '#d08080',
+  DifficultPassagesBrowse: '#FFB74D',
+  HowWeGotTheBibleLanding: '#c89858',
+  ContentLibrary: '#b8a0d0',
+  LifeTopics: '#81C784',
+  LensBrowse: '#BA68C8',
+  ArchaeologyBrowse: '#b07d4f',
+  TimeTravelBrowse: '#8a6a3a',
+  GrammarBrowse: '#7a9ab0',
+} as const;
+
+// ── Overlay Colors (mode-invariant by design — never transformed) ──
+// For content rendered over photos, dark gradients, gold fills, or as
+// RN shadows. These deliberately do NOT change with the theme.
+
+export const overlay = {
+  /** RN shadowColor — must stay black for iOS shadows to render correctly. */
+  black: '#000000',
+  /** Text/dots/icons over photos and dark image gradients. */
+  white: '#ffffff',
+  /** Dark text on gold buttons/badges — readable on gold in every mode. */
+  onGold: '#1a1a1a',
+} as const;
+
+// ── Third-Party Brand Colors (auth provider buttons) ──────────────
+// Fixed by each provider's brand guidelines — never themed.
+
+export const brand = {
+  googleBg: '#ffffff',
+  googleText: '#1f1f1f',
+  facebookBg: '#1877F2',
+  facebookText: '#ffffff',
+} as const;
+
+// ── User Highlight Palette (HighlightColorPicker) ──────────────────
+// The `name` key is persisted to user.db (verse_highlights.color); the hex
+// is presentation. Mode-invariant so saved highlights look stable.
+
+export const userHighlightColors: Record<string, string> = {
+  gold: '#bfa050',
+  blue: '#5b8fb9',
+  green: '#5fa87a',
+  purple: '#8b7cb8',
+  coral: '#c47a6a',
+  teal: '#5ba8a0',
+} as const;
+
+// ── Collection Preset Colors (CollectionPicker) ────────────────────
+// Persisted verbatim to user.db (highlight_collections.color) — never
+// transformed, or saved collections would drift between modes.
+
+export const collectionPresetColors: string[] = [
+  '#bfa050', // gold
+  '#70b8e8', // blue
+  '#70d098', // green
+  '#e890b8', // pink
+  '#c090e0', // purple
+  '#e8a070', // orange
+];
+
 // ── Church History Era Colors (Time-Travel Reader) ────────────
 
 export const churchEras: Record<string, string> = {

--- a/app/src/theme/index.ts
+++ b/app/src/theme/index.ts
@@ -6,7 +6,8 @@
  *   const { base } = useTheme();  // theme-aware colors
  */
 
-export { panels, scholars, eras, eraNames, eraPillLabels, categoryColors, categories, severity, families, prophecyCategories, roles, testament, timelineSvg, churchEras, churchEraLabels } from './colors';
+export { panels, scholars, eras, eraNames, eraPillLabels, categoryColors, categories, severity, families, prophecyCategories, roles, testament, timelineSvg, churchEras, churchEraLabels, overlay, brand, userHighlightColors, collectionPresetColors } from './colors';
+export { mapColors, placeTypeColors, testamentEra } from './mapColors';
 export type { PanelColors } from './colors';
 export { fontFamily, typography, scaledTypography, buildTypography } from './typography';
 export type { TypographyPreset, TypographyMap, BuiltTypography } from './typography';

--- a/app/src/theme/mapColors.ts
+++ b/app/src/theme/mapColors.ts
@@ -1,0 +1,34 @@
+/**
+ * mapColors.ts — Mode-invariant colors for MapLibre GL layers and map chrome.
+ *
+ * The map renders fixed dark-styled tiles, so overlay colors (paths, markers,
+ * halos, labels) are tuned against the tile art and deliberately do NOT
+ * respond to the app theme. Everything drawn on top of the map imports from
+ * here instead of hardcoding hex literals (#1898).
+ */
+
+export const mapColors = {
+  /** Gold story journey paths, arrowheads, and default place markers. */
+  storyGold: '#bfa050',
+  /** Amber person-arc line + stop circles — distinct from story gold (#1324). */
+  arcAmber: '#e09050',
+  /** Warm highlight for the active place marker / label. */
+  markerActive: '#f5e6b8',
+  /** Dark stroke/halo against the map background. */
+  darkHalo: '#1a1610',
+} as const;
+
+/** Place-type accents used by PlaceDetailCard and PlaceSearchBar. */
+export const placeTypeColors: Record<string, string> = {
+  city: '#d4b483', // warm sand — built environment
+  mountain: '#d4b483', // warm sand — terrain
+  site: '#d4b483', // warm sand — archaeological site
+  water: '#90c8d8', // steel blue — water body
+  region: '#b8a070', // muted gold — region boundary
+} as const;
+
+/** Testament era chip colors (PlaceDetailCard key-verse chips). */
+export const testamentEra = {
+  OT: '#d4a05a', // amber — Old Testament era
+  NT: '#5ea073', // green — New Testament era
+} as const;

--- a/app/src/theme/palettes.ts
+++ b/app/src/theme/palettes.ts
@@ -6,7 +6,7 @@
  * Panel, scholar, and era colors are generated via transforms.ts.
  */
 
-import { panels, scholars, eras, categoryColors, categories, severity, families, prophecyCategories, roles, testament, timelineSvg } from './colors';
+import { panels, scholars, eras, categoryColors, categories, severity, families, prophecyCategories, roles, testament, timelineSvg, discourseNodes, echoTypes, debateCategories, debatePosition, trustLevels, contributionStatus, libraryAccents } from './colors';
 import type { PanelColors } from './colors';
 import { transformPanelColors, transformAccentColor } from './transforms';
 
@@ -30,6 +30,7 @@ export interface BaseColors {
   navText: string;
   danger: string;
   success: string;
+  warning: string;
   redLetter: string;
   // ── Subtle section tints (Explore redesign) ───────────────────────
   tintWarm: string;
@@ -52,6 +53,13 @@ export interface ThemePalette {
   roles: Record<string, string>;
   testament: Record<string, string>;
   timelineSvg: Record<string, string>;
+  discourseNodes: Record<string, string>;
+  echoTypes: Record<string, string>;
+  debateCategories: Record<string, string>;
+  debatePosition: Record<string, string>;
+  trustLevels: Record<number, string>;
+  contributionStatus: Record<string, string>;
+  libraryAccents: Record<string, string>;
   statusBarStyle: 'light-content' | 'dark-content';
 }
 
@@ -75,6 +83,7 @@ const darkBase: BaseColors = {
   navText: '#d8ccb0',
   danger: '#e05a6a',
   success: '#81C784',
+  warning: '#e8a040',
   redLetter: '#d4847a',
   tintWarm: 'rgba(191,160,80,0.04)',
   tintEmber: 'rgba(160,100,50,0.05)',
@@ -99,6 +108,7 @@ const sepiaBase: BaseColors = {
   navText: '#4a3e2c',
   danger: '#c04848',
   success: '#4a8a4a',
+  warning: '#9a6420',          // darkened for light bg, matches gold treatment
   redLetter: '#9a3a2a',        // WCAG AA: 5.7:1 on bg
   tintWarm: 'rgba(136,104,24,0.04)',
   tintEmber: 'rgba(120,80,40,0.05)',
@@ -123,6 +133,7 @@ const lightBase: BaseColors = {
   navText: '#333333',
   danger: '#d04040',
   success: '#388e38',
+  warning: '#8a5818',
   redLetter: '#9e3a30',
   tintWarm: 'rgba(138,106,24,0.03)',
   tintEmber: 'rgba(120,80,40,0.04)',
@@ -190,6 +201,13 @@ export function buildPalette(mode: ThemeMode): ThemePalette {
     roles: transformRecord(roles as unknown as Record<string, string>, mode),
     testament: transformRecord(testament as unknown as Record<string, string>, mode),
     timelineSvg: transformRecord(timelineSvg as unknown as Record<string, string>, mode),
+    discourseNodes: transformRecord(discourseNodes, mode),
+    echoTypes: transformRecord(echoTypes as unknown as Record<string, string>, mode),
+    debateCategories: transformRecord(debateCategories as unknown as Record<string, string>, mode),
+    debatePosition: transformRecord(debatePosition as unknown as Record<string, string>, mode),
+    trustLevels: transformRecord(trustLevels as unknown as Record<string, string>, mode),
+    contributionStatus: transformRecord(contributionStatus, mode),
+    libraryAccents: transformRecord(libraryAccents, mode),
     statusBarStyle: mode === 'dark' ? 'light-content' : 'dark-content',
   };
 }


### PR DESCRIPTION
Closes #1898

## What

1. **Sweep** — every hardcoded hex color literal in `app/src/screens/` and `app/src/components/` (162 true AST-level violations across 42 files) now comes from the theme system.
2. **The actual deliverable** — an eslint `no-restricted-syntax` override (error severity) blocking hex literals (string **and** template literals) in those two trees, plus a new hard-failing **Hex color guard** CI step (`npx eslint src/screens src/components --quiet`). The existing ESLint step swallows failures (`|| echo ::warning`), so the guard gets its own step that actually fails the job.

## Note on the issue's counts

The audit grep from #1224 counts issue references in comments (`#1836` is valid hex), so the per-file counts in the issue are inflated — e.g. StudySessionScreen's "22" was 21 comment refs + 1 real literal. The AST-based eslint rule is now the authoritative audit; it found 162 real literals, almost all self-annotated `// data-color: intentional` under the old comment convention, which an AST rule can't honor. Each got a real home instead:

| Category | Destination | Rationale |
|---|---|---|
| Semantic accent maps (discourse node types, echo types, debate categories, debate strengths/weaknesses, trust levels, contribution statuses, library shelf accents) | Records in `theme/colors.ts`, wired through `buildPalette` + `transformRecord`, consumed via `useTheme()` | Same architecture as existing `eras`/`categories`/`prophecyCategories`. Identity transform in dark mode (zero visual change); sepia/light now get the same contrast-corrected transforms as sibling records — previously these were raw dark-palette values in all modes. |
| Overlay colors (`#000` iOS shadows, white text/dots over photos & dark gradients, dark text on gold buttons) | `overlay` export in `theme/colors.ts` — deliberately mode-invariant | A shadow must stay black and a caption over a photo must stay white regardless of theme. `overlay.onGold` unifies the previous `#1a1a1a`/`#111111`/`#000` dark-on-gold text values to `#1a1a1a` (imperceptible on gold fills). |
| Google/Facebook auth button colors | `brand` export — mode-invariant | Fixed by provider brand guidelines. |
| Highlight + collection palettes | `userHighlightColors` / `collectionPresetColors` exports — mode-invariant | These values are persisted to `user.db` (`verse_highlights.color` stores the name; `highlight_collections.color` stores the hex verbatim). Transforming them would drift saved user data between modes. |
| MapLibre overlay colors (story paths, person arcs, markers, halos, place-type dots, testament chips) | New `theme/mapColors.ts` — mode-invariant | The map renders fixed dark-styled tiles; overlay colors are tuned against the tile art, not the app theme. Also deduplicates the place-type palette that PlaceDetailCard and PlaceSearchBar each carried. |
| Gospel identity system (GospelDots config, Harmony DiffAnnotation colors) | Consolidated into `components/GospelColors.ts` | See allowlist judgment below. |

Two literal regressions with no annotation (`LinkedJourneySheet` `#3333` border → `base.border`, `TreeNode` SVG wireframe fills → `base.bg3`/`base.bgSurface`, near-identical in dark mode) are now theme-correct.

## Allowlist judgment (as requested in the issue)

- **`src/theme/`** — allowlisted implicitly (the rule only targets `src/screens/**` + `src/components/**`).
- **`src/components/GospelColors.ts`** — **allowlisted, judged genuinely data.** It is a pure constants module (no styling, no components) defining the Gospel identity system: canonical per-Gospel colors used consistently across Harmony screens, GospelDots, passage cards, and diff annotations. These are identity colors keyed to books — the same class of data as scholar colors, which DEV_GUIDE §5 already blesses in `colors.ts`. GospelDots' brighter dot variants and DiffAnnotation's diff-type colors were folded in so the whole identity system lives in one audited file.
- **`src/screens/dev/`** — allowlisted. `SentrySmokeScreen`/`AmicusSmokeScreen` are developer-only smoke harnesses, never user-facing; theming them adds risk for zero user value.
- **Test files** (`__tests__`, `*.test.*`) — excluded, matching the original audit command.

## Verification

- `npx eslint src/screens src/components --quiet` → **0 errors** (the same command CI now runs)
- `npx tsc --noEmit` → clean
- `npx jest` → 546 suites / 4091 tests / 24 snapshots, all passing
- Prettier: the 43 pre-existing formatting warnings on touched files also fail on master (advisory CI step); left untouched to keep this diff reviewable.

## Visual impact

- **Dark mode: zero change** (all transforms are identity in dark; the only value unifications are `#111111`→`#1a1a1a` dark-on-gold text and TreeNode's `#1a1810`/`#181612`→`#1a1508`/`#1f1b14` SVG fills, both imperceptible).
- **Sepia/Light:** the moved accent records now receive the standard contrast-correcting transforms instead of rendering raw dark-palette values — deliberate, and consistent with how `eras`/`categories`/`scholars` already behave.

## Rollback plan

Single revert of this PR restores the previous state — no data migrations, no content changes, no dependency changes. If only the guard misbehaves (false positives on a legitimate pattern), delete the `overrides` block in `app/.eslintrc.json` and the "Hex color guard" step in `.github/workflows/lint.yml` without reverting the sweep.

---
Kanban note: this session's environment has no GraphQL access to the project board, so #1898 could not be moved to **In Progress → In Review** automatically — please drag the card when triaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe)_