### PR TITLE
feat: chapter item model — flatten reader render tree (#1871)

### DIFF
--- a/app/src/utils/__tests__/chapterItems.test.ts
+++ b/app/src/utils/__tests__/chapterItems.test.ts
@@ -1,0 +1,355 @@
+/**
+ * chapterItems.test.ts — Unit tests for the chapter item model (#1871).
+ *
+ * Covers: read/study/deep modes, lens filtering, verseIndexMap correctness,
+ * coaching gating, stable keys.
+ */
+
+import {
+  buildChapterItems,
+  type BuildChapterItemsOpts,
+  type ChapterListItem,
+} from '../chapterItems';
+import type { Section, SectionPanel, ChapterPanel, CoachingTip } from '../../types';
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+function section(num: number, verseStart: number, verseEnd: number): Section {
+  return {
+    id: `genesis_1_s${num}`,
+    chapter_id: 'genesis_1',
+    section_num: num,
+    header: `Section ${num}`,
+    verse_start: verseStart,
+    verse_end: verseEnd,
+  };
+}
+
+function sectionPanel(sectionId: string, panelType: string, id = 1): SectionPanel {
+  return { id, section_id: sectionId, panel_type: panelType, content_json: '{}' };
+}
+
+function chapterPanel(panelType: string, id = 1): ChapterPanel {
+  return { id, chapter_id: 'genesis_1', panel_type: panelType, content_json: '{}' };
+}
+
+const SECTIONS = [
+  { ...section(1, 1, 5), panels: ['heb', 'hist', 'cross'].map((t, i) => sectionPanel('genesis_1_s1', t, i)) },
+  { ...section(2, 6, 13), panels: ['ctx', 'mac'].map((t, i) => sectionPanel('genesis_1_s2', t, i)) },
+  { ...section(3, 14, 25), panels: [] as SectionPanel[] },
+];
+
+const CHAPTER_PANELS = [
+  chapterPanel('lit', 1),
+  chapterPanel('themes', 2),
+  chapterPanel('discourse', 3),
+];
+
+const TIPS: CoachingTip[] = [
+  { after_section: 1, tip: 'Notice the refrain.', genre_tag: 'narrative', tone: 'observation' },
+  { after_section: 3, tip: 'What pattern completes here?', genre_tag: 'narrative', tone: 'question' },
+];
+
+const CHAPTER_COACHING = {
+  questions: ['Why days?'],
+  observations: ['Sevens everywhere.'],
+  reflections: ['Rest as gift.'],
+};
+
+function opts(overrides: Partial<BuildChapterItemsOpts> = {}): BuildChapterItemsOpts {
+  return {
+    mode: 'study',
+    lensKeys: [],
+    coaching: {
+      studyCoachEnabled: true,
+      sectionTips: TIPS,
+      chapterCoaching: CHAPTER_COACHING,
+      dismissedTips: new Set<number>(),
+    },
+    genre: { label: 'Narrative', guidance: 'Read for plot and pattern.' },
+    prayerPrompt: 'Thank God for order out of chaos.',
+    relatedLifeTopicsJson: '["creation-care"]',
+    mapStoryLinkId: 'creation_story',
+    ...overrides,
+  };
+}
+
+function types(items: ChapterListItem[]): string[] {
+  return items.map((i) => i.type);
+}
+
+function byType<T extends ChapterListItem['type']>(items: ChapterListItem[], type: T) {
+  return items.filter((i): i is Extract<ChapterListItem, { type: T }> => i.type === type);
+}
+
+// ── Mode: study ────────────────────────────────────────────────────
+
+describe('buildChapterItems — study mode', () => {
+  const { items, verseIndexMap } = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts());
+
+  it('emits the full ordered item sequence', () => {
+    expect(types(items)).toEqual([
+      'chapterHeader',
+      'genreBanner',
+      // section 1 (+ tip after_section 1)
+      'sectionHeader', 'verseBlock', 'panelRow', 'coachingCard',
+      // section 2 (no tip)
+      'sectionHeader', 'verseBlock', 'panelRow',
+      // section 3 (+ tip after_section 3)
+      'sectionHeader', 'verseBlock', 'panelRow', 'coachingCard',
+      'scholarlyBlock',
+      'coachingCard', // chapter-level
+      'relatedContent', // lifeTopics
+      'prayerPrompt',
+      'mapChip',
+      'relatedContent', // carousel
+      'footer',
+    ]);
+  });
+
+  it('starts with chapterHeader and ends with footer', () => {
+    expect(items[0].type).toBe('chapterHeader');
+    expect(items[items.length - 1].type).toBe('footer');
+  });
+
+  it('only the first section hides its separator', () => {
+    const headers = byType(items, 'sectionHeader');
+    expect(headers.map((h) => h.showSeparator)).toEqual([false, true, true]);
+  });
+
+  it('panelRow carries the section panel keys in order', () => {
+    const rows = byType(items, 'panelRow');
+    expect(rows.map((r) => r.panelKeys)).toEqual([
+      ['heb', 'hist', 'cross'],
+      ['ctx', 'mac'],
+      [],
+    ]);
+  });
+
+  it('scholarlyBlock carries chapter panel keys and the disclaimer', () => {
+    const [block] = byType(items, 'scholarlyBlock');
+    expect(block.panelKeys).toEqual(['lit', 'themes', 'discourse']);
+    expect(block.showDisclaimer).toBe(true);
+  });
+
+  it('emits section tips and the chapter coaching card', () => {
+    const cards = byType(items, 'coachingCard');
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toMatchObject({ variant: 'section', tip: TIPS[0] });
+    expect(cards[1]).toMatchObject({ variant: 'section', tip: TIPS[1] });
+    expect(cards[2]).toMatchObject({ variant: 'chapter', coaching: CHAPTER_COACHING });
+  });
+
+  it('emits both relatedContent variants in order', () => {
+    const related = byType(items, 'relatedContent');
+    expect(related.map((r) => r.variant)).toEqual(['lifeTopics', 'carousel']);
+    expect(related[0].relatedLifeTopicsJson).toBe('["creation-care"]');
+  });
+
+  it('emits the mapChip slot with the story id', () => {
+    const [chip] = byType(items, 'mapChip');
+    expect(chip.storyId).toBe('creation_story');
+  });
+
+  it('uses stable ${type}:${sectionNum}:${panelKey ?? verseStart} keys, all unique', () => {
+    const keys = items.map((i) => i.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toContain('sectionHeader:2:6');
+    expect(keys).toContain('verseBlock:2:6');
+    expect(keys).toContain('panelRow:2:6');
+    expect(keys).toContain('coachingCard:1:tip');
+    expect(keys).toContain('coachingCard:0:chapter');
+    expect(keys).toContain('scholarlyBlock:0:0');
+    expect(keys).toContain('mapChip:0:creation_story');
+  });
+
+  it('keys are stable across rebuilds with equal inputs', () => {
+    const rebuilt = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts());
+    expect(rebuilt.items.map((i) => i.key)).toEqual(items.map((i) => i.key));
+  });
+
+  describe('verseIndexMap', () => {
+    it('maps every verse in every section to its verseBlock index', () => {
+      expect(verseIndexMap.size).toBe(25);
+      for (let v = 1; v <= 5; v++) expect(verseIndexMap.get(v)).toBe(3);
+      for (let v = 6; v <= 13; v++) expect(verseIndexMap.get(v)).toBe(7);
+      for (let v = 14; v <= 25; v++) expect(verseIndexMap.get(v)).toBe(10);
+    });
+
+    it('every mapped index points at a verseBlock covering that verse', () => {
+      for (const [verseNum, idx] of verseIndexMap) {
+        const item = items[idx];
+        expect(item.type).toBe('verseBlock');
+        if (item.type === 'verseBlock') {
+          expect(verseNum).toBeGreaterThanOrEqual(item.verseStart);
+          expect(verseNum).toBeLessThanOrEqual(item.verseEnd);
+        }
+      }
+    });
+
+    it('has no entry for verses outside every section', () => {
+      expect(verseIndexMap.get(0)).toBeUndefined();
+      expect(verseIndexMap.get(26)).toBeUndefined();
+    });
+  });
+});
+
+// ── Mode: read ─────────────────────────────────────────────────────
+
+describe('buildChapterItems — read mode', () => {
+  const { items, verseIndexMap } = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts({ mode: 'read' }));
+
+  it('hides study chrome: no banner, panels, coaching, scholarly, mapChip, carousel', () => {
+    expect(types(items)).toEqual([
+      'chapterHeader',
+      'sectionHeader', 'verseBlock',
+      'sectionHeader', 'verseBlock',
+      'sectionHeader', 'verseBlock',
+      'relatedContent', // lifeTopics renders in read mode today
+      'prayerPrompt',
+      'footer',
+    ]);
+    expect(byType(items, 'relatedContent').map((r) => r.variant)).toEqual(['lifeTopics']);
+  });
+
+  it('verseIndexMap tracks the read-mode indices', () => {
+    expect(verseIndexMap.get(1)).toBe(2);
+    expect(verseIndexMap.get(13)).toBe(4);
+    expect(verseIndexMap.get(25)).toBe(6);
+  });
+});
+
+// ── Mode: deep ─────────────────────────────────────────────────────
+
+describe('buildChapterItems — deep mode', () => {
+  it('currently renders identically to study (PR-1 parity bridge)', () => {
+    const study = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts({ mode: 'study' }));
+    const deep = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts({ mode: 'deep' }));
+    expect(deep.items).toEqual(study.items);
+    expect([...deep.verseIndexMap]).toEqual([...study.verseIndexMap]);
+  });
+});
+
+// ── Lens filtering ─────────────────────────────────────────────────
+
+describe('buildChapterItems — lens filtering', () => {
+  it('filters section and chapter panel keys to the lens allowlist', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({ lensKeys: ['heb', 'ctx', 'lit'] }),
+    );
+    const rows = byType(items, 'panelRow');
+    expect(rows.map((r) => r.panelKeys)).toEqual([['heb'], ['ctx'], []]);
+    const [block] = byType(items, 'scholarlyBlock');
+    expect(block.panelKeys).toEqual(['lit']);
+  });
+
+  it('an empty lensKeys array means no filtering (authoring-bug safety net)', () => {
+    const { items } = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts({ lensKeys: [] }));
+    const rows = byType(items, 'panelRow');
+    expect(rows[0].panelKeys).toEqual(['heb', 'hist', 'cross']);
+  });
+
+  it('a lens matching nothing empties the rows but keeps the items', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({ lensKeys: ['nonexistent'] }),
+    );
+    expect(byType(items, 'panelRow').every((r) => r.panelKeys.length === 0)).toBe(true);
+    expect(byType(items, 'scholarlyBlock')[0].panelKeys).toEqual([]);
+  });
+
+  it('lens filtering never touches read mode (no panel items exist)', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({ mode: 'read', lensKeys: ['heb'] }),
+    );
+    expect(byType(items, 'panelRow')).toHaveLength(0);
+  });
+});
+
+// ── Coaching gating ────────────────────────────────────────────────
+
+describe('buildChapterItems — coaching gating', () => {
+  it('drops dismissed section tips but keeps the rest', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({
+        coaching: {
+          studyCoachEnabled: true,
+          sectionTips: TIPS,
+          chapterCoaching: CHAPTER_COACHING,
+          dismissedTips: new Set([1]),
+        },
+      }),
+    );
+    const cards = byType(items, 'coachingCard');
+    expect(cards.map((c) => c.key)).toEqual(['coachingCard:3:tip', 'coachingCard:0:chapter']);
+  });
+
+  it('emits no coaching items when the study coach is disabled', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({
+        coaching: {
+          studyCoachEnabled: false,
+          sectionTips: TIPS,
+          chapterCoaching: CHAPTER_COACHING,
+          dismissedTips: new Set<number>(),
+        },
+      }),
+    );
+    expect(byType(items, 'coachingCard')).toHaveLength(0);
+  });
+
+  it('emits no chapter card when chapterCoaching is null', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({
+        coaching: {
+          studyCoachEnabled: true,
+          sectionTips: [],
+          chapterCoaching: null,
+          dismissedTips: new Set<number>(),
+        },
+      }),
+    );
+    expect(byType(items, 'coachingCard')).toHaveLength(0);
+  });
+});
+
+// ── Optional slots ─────────────────────────────────────────────────
+
+describe('buildChapterItems — optional slots', () => {
+  it('omits genreBanner, prayerPrompt, lifeTopics, and mapChip when absent', () => {
+    const { items } = buildChapterItems(
+      SECTIONS,
+      CHAPTER_PANELS,
+      opts({
+        genre: null,
+        prayerPrompt: null,
+        relatedLifeTopicsJson: null,
+        mapStoryLinkId: null,
+      }),
+    );
+    const ts = types(items);
+    expect(ts).not.toContain('genreBanner');
+    expect(ts).not.toContain('prayerPrompt');
+    expect(ts).not.toContain('mapChip');
+    expect(byType(items, 'relatedContent').map((r) => r.variant)).toEqual(['carousel']);
+  });
+
+  it('handles an empty chapter (no sections, no panels)', () => {
+    const { items, verseIndexMap } = buildChapterItems([], [], opts({
+      genre: null, prayerPrompt: null, relatedLifeTopicsJson: null, mapStoryLinkId: null,
+    }));
+    expect(types(items)).toEqual(['chapterHeader', 'scholarlyBlock', 'coachingCard', 'relatedContent', 'footer']);
+    expect(verseIndexMap.size).toBe(0);
+  });
+});

--- a/app/src/utils/chapterItems.ts
+++ b/app/src/utils/chapterItems.ts
@@ -1,0 +1,334 @@
+/**
+ * utils/chapterItems.ts — Flat item model for the chapter reader (#1871).
+ *
+ * Epic D (#1866) step 1: express everything ChapterScreen/ChapterVerseList
+ * currently render as a flat, ordered list of discriminated-union items so
+ * the FlashList swap (#1872) is a pure rendering change.
+ *
+ * Pure module: no React, no hooks, no I/O. `buildChapterItems` is a
+ * deterministic function of its inputs.
+ *
+ * Coverage map (current render tree → items):
+ *   ChapterHeader                        → chapterHeader
+ *   GenreBanner (study/deep)             → genreBanner
+ *   per section:
+ *     GoldSeparator (between sections)   → sectionHeader.showSeparator
+ *     SectionHeader                      → sectionHeader
+ *     VerseBlock (section's verse run)   → verseBlock
+ *     ButtonRow (+ inline open panel)    → panelRow (study/deep)
+ *     StudyCoachCard after section       → coachingCard variant 'section'
+ *   ScholarlyBlock + scholar disclaimer  → scholarlyBlock (study/deep)
+ *   ChapterCoachingCard                  → coachingCard variant 'chapter'
+ *   RelatedLifeTopics                    → relatedContent variant 'lifeTopics'
+ *   PrayerPromptCard                     → prayerPrompt
+ *   MapChip (#1322)                      → mapChip (study/deep)
+ *   RelatedContentCarousel               → relatedContent variant 'carousel'
+ *   next-chapter hint                    → footer
+ *
+ * Ephemeral UI state (which panel is open, TTS highlight, dismissed-tip
+ * animation) stays with the renderer — the model only carries what exists
+ * for the chapter. The open panel renders inside its section's panelRow.
+ *
+ * Mode notes: 'study' and 'deep' currently render identically (the PR-2
+ * parity bridge in ChapterScreen only distinguishes 'read'); the model
+ * mirrors that, so `deep` gates nothing extra yet.
+ */
+
+import type {
+  Section,
+  SectionPanel,
+  ChapterPanel,
+  CoachingTip,
+  ChapterCoaching,
+} from '../types';
+import type { ChapterMode } from '../stores/settingsStore';
+import { filterPanelKeys } from './lensPanelFilter';
+
+export type { ChapterMode };
+
+// ── Item union ─────────────────────────────────────────────────────
+
+interface ItemBase {
+  /** Stable list key: `${type}:${sectionNum}:${panelKey ?? verseStart}` (0 for chapter-level items). */
+  key: string;
+}
+
+export interface ChapterHeaderItem extends ItemBase {
+  type: 'chapterHeader';
+}
+
+export interface GenreBannerItem extends ItemBase {
+  type: 'genreBanner';
+  genreLabel: string;
+  genreGuidance: string;
+}
+
+export interface SectionHeaderItem extends ItemBase {
+  type: 'sectionHeader';
+  sectionId: string;
+  sectionNum: number;
+  header: string;
+  /** Gold separator above this section (every section but the first). */
+  showSeparator: boolean;
+}
+
+export interface VerseBlockItem extends ItemBase {
+  type: 'verseBlock';
+  sectionId: string;
+  sectionNum: number;
+  /** Inclusive verse range this block renders (the section's run). */
+  verseStart: number;
+  verseEnd: number;
+}
+
+export interface PanelRowItem extends ItemBase {
+  type: 'panelRow';
+  sectionId: string;
+  sectionNum: number;
+  /** Panel keys for the ButtonRow, post-lens-filter, in render order. */
+  panelKeys: string[];
+}
+
+export interface CoachingCardItem extends ItemBase {
+  type: 'coachingCard';
+  variant: 'section' | 'chapter';
+  /** Present when variant === 'section'. */
+  tip?: CoachingTip;
+  /** Present when variant === 'chapter'. */
+  coaching?: ChapterCoaching;
+}
+
+export interface PrayerPromptItem extends ItemBase {
+  type: 'prayerPrompt';
+  prompt: string;
+}
+
+export interface ScholarlyBlockItem extends ItemBase {
+  type: 'scholarlyBlock';
+  /** Chapter panel keys, post-lens-filter, in render order. */
+  panelKeys: string[];
+  /** Scholar-paraphrase disclaimer rendered beneath the block. */
+  showDisclaimer: boolean;
+}
+
+export interface RelatedContentItem extends ItemBase {
+  type: 'relatedContent';
+  variant: 'lifeTopics' | 'carousel';
+  /** Present when variant === 'lifeTopics'. */
+  relatedLifeTopicsJson?: string | null;
+}
+
+export interface MapChipItem extends ItemBase {
+  type: 'mapChip';
+  storyId: string;
+}
+
+export interface FooterItem extends ItemBase {
+  type: 'footer';
+}
+
+export type ChapterListItem =
+  | ChapterHeaderItem
+  | GenreBannerItem
+  | SectionHeaderItem
+  | VerseBlockItem
+  | PanelRowItem
+  | CoachingCardItem
+  | PrayerPromptItem
+  | ScholarlyBlockItem
+  | RelatedContentItem
+  | MapChipItem
+  | FooterItem;
+
+// ── Inputs ─────────────────────────────────────────────────────────
+
+export interface ChapterCoachingOpts {
+  /** Settings toggle — when false, no coaching items are emitted. */
+  studyCoachEnabled: boolean;
+  /** Per-section tips (parsed from coaching_json). */
+  sectionTips: CoachingTip[];
+  /** Chapter-level coaching (parsed from coaching_json). */
+  chapterCoaching: ChapterCoaching | null;
+  /** after_section values the user dismissed this visit. */
+  dismissedTips: ReadonlySet<number>;
+}
+
+export interface BuildChapterItemsOpts {
+  mode: ChapterMode;
+  /**
+   * Active lens panel-key allowlist (parsed panel_filter). Empty array =
+   * no filtering, mirroring filterPanelKeys' authoring-bug safety net.
+   */
+  lensKeys: string[];
+  coaching: ChapterCoachingOpts;
+  /** Genre banner content (resolveGenre output), study/deep only. */
+  genre?: { label: string; guidance: string } | null;
+  prayerPrompt?: string | null;
+  relatedLifeTopicsJson?: string | null;
+  /** map_story_link_id — emits the mapChip slot in study/deep. */
+  mapStoryLinkId?: string | null;
+}
+
+export interface BuildChapterItemsResult {
+  items: ChapterListItem[];
+  /** verse_num → index (in `items`) of the verseBlock that renders it. */
+  verseIndexMap: Map<number, number>;
+}
+
+// ── Builder ────────────────────────────────────────────────────────
+
+function makeKey(type: ChapterListItem['type'], sectionNum: number, tail: string | number): string {
+  return `${type}:${sectionNum}:${tail}`;
+}
+
+/**
+ * Flatten a chapter into the ordered list of reader items.
+ *
+ * @param sections       Sections with their panels (pre- or post-lens; the
+ *                       lens filter is re-applied here idempotently).
+ * @param chapterPanels  Chapter-level panels for the ScholarlyBlock.
+ */
+export function buildChapterItems(
+  sections: Array<Section & { panels: SectionPanel[] }>,
+  chapterPanels: ChapterPanel[],
+  opts: BuildChapterItemsOpts,
+): BuildChapterItemsResult {
+  const { mode, lensKeys, coaching } = opts;
+  // PR-1 parity bridge semantics: only 'read' hides study chrome.
+  const isRead = mode === 'read';
+  const lensFilter = lensKeys.length > 0 ? lensKeys : undefined;
+
+  const items: ChapterListItem[] = [];
+  const verseIndexMap = new Map<number, number>();
+
+  // Chapter header — always first, all modes.
+  items.push({ type: 'chapterHeader', key: makeKey('chapterHeader', 0, 0) });
+
+  // Genre banner — study/deep only.
+  if (!isRead && opts.genre) {
+    items.push({
+      type: 'genreBanner',
+      key: makeKey('genreBanner', 0, 0),
+      genreLabel: opts.genre.label,
+      genreGuidance: opts.genre.guidance,
+    });
+  }
+
+  // Sections.
+  sections.forEach((sec, secIdx) => {
+    items.push({
+      type: 'sectionHeader',
+      key: makeKey('sectionHeader', sec.section_num, sec.verse_start),
+      sectionId: sec.id,
+      sectionNum: sec.section_num,
+      header: sec.header,
+      showSeparator: secIdx > 0,
+    });
+
+    const verseBlockIndex = items.length;
+    items.push({
+      type: 'verseBlock',
+      key: makeKey('verseBlock', sec.section_num, sec.verse_start),
+      sectionId: sec.id,
+      sectionNum: sec.section_num,
+      verseStart: sec.verse_start,
+      verseEnd: sec.verse_end,
+    });
+    for (let v = sec.verse_start; v <= sec.verse_end; v++) {
+      verseIndexMap.set(v, verseBlockIndex);
+    }
+
+    if (!isRead) {
+      const panelKeys = filterPanelKeys(
+        sec.panels.map((p) => p.panel_type),
+        lensFilter,
+      );
+      items.push({
+        type: 'panelRow',
+        key: makeKey('panelRow', sec.section_num, sec.verse_start),
+        sectionId: sec.id,
+        sectionNum: sec.section_num,
+        panelKeys,
+      });
+
+      // Coaching tip after this section.
+      if (coaching.studyCoachEnabled) {
+        const tip = coaching.sectionTips.find((t) => t.after_section === sec.section_num);
+        if (tip && !coaching.dismissedTips.has(tip.after_section)) {
+          items.push({
+            type: 'coachingCard',
+            key: makeKey('coachingCard', sec.section_num, 'tip'),
+            variant: 'section',
+            tip,
+          });
+        }
+      }
+    }
+  });
+
+  if (!isRead) {
+    // Chapter-level scholarly block + disclaimer.
+    items.push({
+      type: 'scholarlyBlock',
+      key: makeKey('scholarlyBlock', 0, 0),
+      panelKeys: filterPanelKeys(
+        chapterPanels.map((p) => p.panel_type),
+        lensFilter,
+      ),
+      showDisclaimer: true,
+    });
+
+    // Chapter-level coaching card.
+    if (coaching.studyCoachEnabled && coaching.chapterCoaching) {
+      items.push({
+        type: 'coachingCard',
+        key: makeKey('coachingCard', 0, 'chapter'),
+        variant: 'chapter',
+        coaching: coaching.chapterCoaching,
+      });
+    }
+  }
+
+  // Related life topics — all modes (renderer no-ops on empty JSON).
+  if (opts.relatedLifeTopicsJson) {
+    items.push({
+      type: 'relatedContent',
+      key: makeKey('relatedContent', 0, 'lifeTopics'),
+      variant: 'lifeTopics',
+      relatedLifeTopicsJson: opts.relatedLifeTopicsJson,
+    });
+  }
+
+  // Prayer prompt — all modes.
+  if (opts.prayerPrompt) {
+    items.push({
+      type: 'prayerPrompt',
+      key: makeKey('prayerPrompt', 0, 0),
+      prompt: opts.prayerPrompt,
+    });
+  }
+
+  if (!isRead) {
+    // Inline map chip (#1322) — slot exists when the chapter links a story;
+    // the renderer hides it if the story fails to hydrate (as today).
+    if (opts.mapStoryLinkId) {
+      items.push({
+        type: 'mapChip',
+        key: makeKey('mapChip', 0, opts.mapStoryLinkId),
+        storyId: opts.mapStoryLinkId,
+      });
+    }
+
+    // Related-content carousel — data loads in the renderer's hook.
+    items.push({
+      type: 'relatedContent',
+      key: makeKey('relatedContent', 0, 'carousel'),
+      variant: 'carousel',
+    });
+  }
+
+  // Footer — next-chapter hint slot, all modes.
+  items.push({ type: 'footer', key: makeKey('footer', 0, 0) });
+
+  return { items, verseIndexMap };
+}


### PR DESCRIPTION
Closes #1871 · Parent epic #1866

## What

New `app/src/utils/chapterItems.ts`: a pure, React-free item model that expresses everything `ChapterScreen`/`ChapterVerseList` currently render as a flat ordered list, so the FlashList swap (#1872) becomes a pure rendering change.

- **`ChapterListItem`** — discriminated union: `chapterHeader | genreBanner | sectionHeader | verseBlock | panelRow | coachingCard | prayerPrompt | scholarlyBlock | relatedContent | mapChip | footer`
- **`buildChapterItems(sections, chapterPanels, opts)`** → `{ items, verseIndexMap }`
- Stable keys `${type}:${sectionNum}:${panelKey ?? verseStart}` (chapter-level singletons use `0` for the section slot)

## Design decisions (from studying the current render tree)

- **verseBlock = a section's contiguous verse run** (`verseStart..verseEnd`), mirroring today's one-`VerseBlock`-per-section rendering; `verseIndexMap` maps *every* verse number to its block's index, so scroll-to-verse works at any granularity #1872 chooses. The range fields let #1872 split blocks later without a model change.
- **Coverage completeness**: gold separators fold into `sectionHeader.showSeparator`; the scholar disclaimer folds into `scholarlyBlock.showDisclaimer`; `coachingCard` carries a `variant` for section tips vs the chapter-level card; `relatedContent` carries a `variant` for `RelatedLifeTopics` (renders in **all** modes today, including read) vs the `RelatedContentCarousel` (study/deep only). The inline open panel renders inside its section's `panelRow` — which panel is open is ephemeral UI state and deliberately stays with the renderer.
- **Modes**: only `read` hides study chrome, matching the PR-1 parity bridge (`isFocus = tier === 'read'`); `study` and `deep` currently emit identical items — tested and documented, so PR 2's `utils/chapterMode.ts` helpers slot in without surprises.
- **Lens filtering**: `opts.lensKeys` is the parsed `panel_filter` allowlist, applied through the existing `filterPanelKeys` (empty array = no filtering, same authoring-bug safety net). Idempotent when fed already-filtered sections.
- **Coaching**: the model consumes the parsed tips + `dismissedTips` set so the item list is a deterministic function of inputs — dismissal state lives outside, as today.
- Screen chrome that scrolls **above** the list but isn't chapter content (lens guidance box, `ContextGuardBanner`, `StudySessionCTA`, compare bar) is intentionally outside the model; #1872 can mount those as list header components.

## Tests

`app/src/utils/__tests__/chapterItems.test.ts` — 25 tests: full ordered sequence in study mode; read-mode chrome hiding; deep≡study parity; lens filtering (allowlist, empty-array safety net, match-nothing, read-mode no-op); `verseIndexMap` correctness (every verse mapped to a covering block, no out-of-range entries, read-mode indices); coaching gating (dismissed tips, toggle off, null chapter coaching); key uniqueness + rebuild stability; empty-chapter edge.

## Verification

- `npx tsc --noEmit` clean, `npx eslint` clean on both new files, full jest suite green (previous 4091 + 25 new).
- **No UI changes** — no existing file is touched; this PR adds the model + tests only.

## Rollback plan

Revert deletes two new files; nothing imports them yet, so rollback is zero-risk.

---
Kanban note: no GraphQL access to the project board from this environment — please drag #1871 to **In Review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe)_