### PR TITLE
feat: semantic verse lane + RRF merge in useSearch (#1876)

### DIFF
--- a/app/__tests__/hooks/useSearch.test.ts
+++ b/app/__tests__/hooks/useSearch.test.ts
@@ -40,6 +40,31 @@ jest.mock('@/utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
+// ── Semantic lane mocks (#1876) ──
+const mockIsPremium = { value: false };
+const mockIsConnected = jest.fn(() => true);
+const mockGetAmicusAuthToken: jest.Mock = jest.fn(async () => 'receipt-token-1234567890');
+const mockSearchVersesSemantic: jest.Mock = jest.fn(async () => [] as any[]);
+
+jest.mock('@/hooks/usePremium', () => ({
+  usePremium: () => ({
+    isPremium: mockIsPremium.value,
+    upgradeRequest: null,
+    showUpgrade: jest.fn(),
+    dismissUpgrade: jest.fn(),
+  }),
+}));
+jest.mock('@/services/connectivity', () => ({
+  isConnected: () => mockIsConnected(),
+}));
+jest.mock('@/services/amicus/authToken', () => ({
+  getAmicusAuthToken: (...args: any[]) => mockGetAmicusAuthToken(...args),
+}));
+jest.mock('@/services/search/semanticVerses', () => ({
+  ...jest.requireActual('@/services/search/semanticVerses'),
+  searchVersesSemantic: (...args: any[]) => mockSearchVersesSemantic(...args),
+}));
+
 import { useSearch, buildOrderedGroups } from '@/hooks/useSearch';
 import type { UniversalSearchResults } from '@/hooks/useSearch';
 
@@ -56,6 +81,10 @@ describe('useSearch', () => {
     mockGetAllDifficultPassages.mockResolvedValue([]);
     mockSearchLifeTopics.mockResolvedValue([]);
     mockSearchDiscoveries.mockResolvedValue([]);
+    mockIsPremium.value = false;
+    mockIsConnected.mockReturnValue(true);
+    mockGetAmicusAuthToken.mockResolvedValue('receipt-token-1234567890');
+    mockSearchVersesSemantic.mockResolvedValue([]);
   });
 
   afterEach(() => jest.useRealTimers());
@@ -228,6 +257,99 @@ describe('useSearch', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(mockSearchVerses).toHaveBeenCalledWith('exodus', 50);
+  });
+
+  // ── Semantic verse lane (#1876) ──
+
+  const ftsVerse = (bookId: string, ch: number, v: number) => ({
+    id: ch * 1000 + v,
+    book_id: bookId,
+    chapter_num: ch,
+    verse_num: v,
+    translation: 'kjv',
+    text: `${bookId} ${ch}:${v}`,
+  });
+
+  describe('semantic verse lane', () => {
+    it('does not run for free users', async () => {
+      mockIsPremium.value = false;
+      const { result } = renderHook(() => useSearch('steadfast love'));
+      await jest.advanceTimersByTimeAsync(600);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(mockSearchVersesSemantic).not.toHaveBeenCalled();
+    });
+
+    it('does not run offline', async () => {
+      mockIsPremium.value = true;
+      mockIsConnected.mockReturnValue(false);
+      const { result } = renderHook(() => useSearch('steadfast love'));
+      await jest.advanceTimersByTimeAsync(600);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(mockSearchVersesSemantic).not.toHaveBeenCalled();
+    });
+
+    it('skips silently when no auth token is available', async () => {
+      mockIsPremium.value = true;
+      mockGetAmicusAuthToken.mockResolvedValue(null);
+      const ftsRows = [ftsVerse('genesis', 1, 1)];
+      mockSearchVerses.mockResolvedValue(ftsRows);
+
+      const { result } = renderHook(() => useSearch('steadfast love'));
+      await jest.advanceTimersByTimeAsync(600);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockSearchVersesSemantic).not.toHaveBeenCalled();
+      expect(result.current.results.verses).toEqual(ftsRows);
+    });
+
+    it('waits the extra lane debounce (500ms total) before embedding', async () => {
+      mockIsPremium.value = true;
+      const { result } = renderHook(() => useSearch('steadfast love'));
+
+      // Main debounce fired, lane-local 200ms not yet elapsed.
+      await jest.advanceTimersByTimeAsync(400);
+      expect(mockSearchVersesSemantic).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(200);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(mockSearchVersesSemantic).toHaveBeenCalledWith(
+        'steadfast love',
+        'receipt-token-1234567890',
+      );
+    });
+
+    it('merges semantic hits with FTS via RRF (both-lanes verse first)', async () => {
+      mockIsPremium.value = true;
+      const g11 = ftsVerse('genesis', 1, 1);
+      const j316 = ftsVerse('john', 3, 16);
+      const p231 = ftsVerse('psalms', 23, 1);
+      mockSearchVerses.mockResolvedValue([g11, j316]);
+      mockSearchVersesSemantic.mockResolvedValue([j316, p231]);
+
+      const { result } = renderHook(() => useSearch('steadfast love'));
+      await jest.advanceTimersByTimeAsync(600);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // j316 appears in both lanes → outranks the FTS #1.
+      expect(result.current.results.verses.map((v) => v.id)).toEqual([
+        j316.id, g11.id, p231.id,
+      ]);
+    });
+
+    it('falls back to FTS-only on AmicusError without surfacing a failure', async () => {
+      mockIsPremium.value = true;
+      const ftsRows = [ftsVerse('genesis', 1, 1), ftsVerse('genesis', 1, 2)];
+      mockSearchVerses.mockResolvedValue(ftsRows);
+      mockSearchVersesSemantic.mockRejectedValue(new Error('AmicusError: OFFLINE'));
+
+      const { result } = renderHook(() => useSearch('steadfast love'));
+      await jest.advanceTimersByTimeAsync(600);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.results.verses).toEqual(ftsRows);
+      // Other lanes unaffected
+      expect(result.current.results.people).toEqual([]);
+    });
   });
 });
 

--- a/app/src/hooks/useSearch.ts
+++ b/app/src/hooks/useSearch.ts
@@ -3,6 +3,13 @@
  * Debounced at 300ms. Searches verses, people, books, concepts,
  * map stories, timeline events, life topics, and difficult passages.
  *
+ * Premium + online adds a semantic verse lane (#1876): the query is
+ * embedded via the Amicus proxy, vector-matched against the chunk index,
+ * and the resulting verses merge with FTS hits via Reciprocal Rank
+ * Fusion. Any semantic failure degrades silently to FTS-only. The
+ * semantic lane debounces at 500ms total (embed round-trip) — 300ms
+ * shared + 200ms lane-local.
+ *
  * Includes reference parsing: typing "Gen 3:15" or "Romans 8" produces
  * a direct-navigation result at the top of the list.
  *
@@ -17,8 +24,18 @@ import {
   searchLifeTopics, searchDiscoveries,
 } from '../db/content';
 import { getBookByName } from '../utils/verseResolver';
+import { searchVersesSemantic, mergeVersesRRF } from '../services/search/semanticVerses';
+import { getAmicusAuthToken } from '../services/amicus/authToken';
+import { isConnected } from '../services/connectivity';
 import type { Verse, Person, Book, MapStory, TimelineEntry, DifficultPassage, Concept, LifeTopic, ArchaeologicalDiscovery } from '../types';
 import { logger } from '../utils/logger';
+import { usePremium } from './usePremium';
+
+/**
+ * Extra debounce for the semantic lane only: 300ms shared timer + this
+ * = 500ms before the embed round-trip fires (#1876).
+ */
+const SEMANTIC_EXTRA_DEBOUNCE_MS = 200;
 
 // ── Result types ────────────────────────────────────────────────────
 
@@ -189,6 +206,7 @@ export function useSearch(query: string) {
   const [isLoading, setIsLoading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cacheRef = useRef<StaticCaches | null>(null);
+  const { isPremium } = usePremium();
 
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -210,13 +228,37 @@ export function useSearch(query: string) {
 
         const caches = await loadCaches(cacheRef);
 
+        // Semantic verse lane (#1876) — premium + online only. Waits its
+        // lane-local debounce, then embeds via the proxy. Any failure
+        // (AmicusError: offline, unauthorized, embed/vec failure) degrades
+        // silently to FTS-only — never a user-facing error.
+        const semanticPromise: Promise<Verse[]> =
+          isPremium && isConnected()
+            ? (async () => {
+                await new Promise((r) => setTimeout(r, SEMANTIC_EXTRA_DEBOUNCE_MS));
+                const authToken = await getAmicusAuthToken();
+                if (!authToken) return [];
+                return searchVersesSemantic(trimmed, authToken);
+              })().catch((err) => {
+                logger.warn('Search', 'Semantic verse lane failed — FTS only', err);
+                return [] as Verse[];
+              })
+            : Promise.resolve([] as Verse[]);
+
         // FTS queries + client-side filters in parallel
-        const [verses, rawPeople, lifeTopics, archaeology] = await Promise.all([
+        const [ftsVerses, rawPeople, lifeTopics, archaeology, semanticVerses] = await Promise.all([
           searchVerses(trimmed, 50),
           searchPeople(trimmed),
           searchLifeTopics(trimmed).catch(() => [] as LifeTopic[]),
           searchDiscoveries(trimmed).catch(() => [] as ArchaeologicalDiscovery[]),
+          semanticPromise,
         ]);
+
+        // RRF merge (k=60), deduped by verse ref. No semantic hits → FTS
+        // list passes through untouched.
+        const verses = semanticVerses.length > 0
+          ? mergeVersesRRF(ftsVerses, semanticVerses)
+          : ftsVerses;
 
         // Sort people by relevance
         const people = rawPeople.sort(
@@ -249,7 +291,7 @@ export function useSearch(query: string) {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [query]);
+  }, [query, isPremium]);
 
   return { results, isLoading };
 }

--- a/app/src/services/search/__tests__/semanticVerses.test.ts
+++ b/app/src/services/search/__tests__/semanticVerses.test.ts
@@ -1,0 +1,201 @@
+/**
+ * semanticVerses.test.ts — Semantic verse lane + RRF merge (#1876).
+ *
+ * embedQuery / searchByVector / getVerse are mocked; the tests exercise
+ * the composition (embed → vector → hydration), dedupe/cap behavior, RRF
+ * merge ordering, and error propagation for the FTS-only fallback.
+ */
+
+const mockEmbedQuery = jest.fn();
+const mockSearchByVector = jest.fn();
+const mockGetVerse = jest.fn();
+
+jest.mock('@/services/amicus/embed', () => ({
+  embedQuery: (...args: unknown[]) => mockEmbedQuery(...args),
+}));
+jest.mock('@/services/amicus/vectorSearch', () => ({
+  searchByVector: (...args: unknown[]) => mockSearchByVector(...args),
+}));
+jest.mock('@/db/content', () => ({
+  getVerse: (...args: unknown[]) => mockGetVerse(...args),
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import {
+  searchVersesSemantic,
+  mergeVersesRRF,
+  RRF_K,
+  _internal,
+} from '@/services/search/semanticVerses';
+import { AmicusError } from '@/services/amicus/types';
+import type { Verse } from '@/types';
+
+// ── Fixtures ───────────────────────────────────────────────────────
+
+const VECTOR = Array.from({ length: 1536 }, () => 0.01);
+
+function chunk(bookId: string | undefined, ch: number | undefined, vs: number | undefined, id = 'c1') {
+  return {
+    chunk_id: id,
+    source_type: 'section_panel',
+    source_id: 's1',
+    text: 'chunk text',
+    score: 0.9,
+    metadata: { book_id: bookId, chapter_num: ch, verse_start: vs },
+  };
+}
+
+function verse(bookId: string, ch: number, v: number): Verse {
+  return {
+    id: ch * 1000 + v,
+    book_id: bookId,
+    chapter_num: ch,
+    verse_num: v,
+    translation: 'kjv',
+    text: `${bookId} ${ch}:${v} text`,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEmbedQuery.mockResolvedValue(VECTOR);
+  mockGetVerse.mockImplementation((bookId: string, ch: number, v: number) =>
+    Promise.resolve(verse(bookId, ch, v)),
+  );
+});
+
+// ── searchVersesSemantic ───────────────────────────────────────────
+
+describe('searchVersesSemantic', () => {
+  it('composes embed → vector search → verse hydration', async () => {
+    mockSearchByVector.mockResolvedValue([
+      chunk('genesis', 1, 3, 'a'),
+      chunk('john', 1, 1, 'b'),
+    ]);
+
+    const result = await searchVersesSemantic('light and creation', 'token-123');
+
+    expect(mockEmbedQuery).toHaveBeenCalledWith(
+      'light and creation',
+      expect.objectContaining({ authToken: 'token-123' }),
+    );
+    expect(mockSearchByVector).toHaveBeenCalledWith(VECTOR, { limit: _internal.CHUNK_LIMIT });
+    expect(mockGetVerse).toHaveBeenCalledWith('genesis', 1, 3);
+    expect(mockGetVerse).toHaveBeenCalledWith('john', 1, 1);
+    // Vector-rank order preserved
+    expect(result.map((v) => `${v.book_id} ${v.chapter_num}:${v.verse_num}`)).toEqual([
+      'genesis 1:3',
+      'john 1:1',
+    ]);
+  });
+
+  it('dedupes chunks anchored to the same verse ref', async () => {
+    mockSearchByVector.mockResolvedValue([
+      chunk('genesis', 1, 3, 'a'),
+      chunk('genesis', 1, 3, 'b'), // different chunk, same anchor
+      chunk('psalms', 23, 1, 'c'),
+    ]);
+
+    const result = await searchVersesSemantic('shepherd', 't');
+    expect(result).toHaveLength(2);
+    expect(mockGetVerse).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips chunks without a complete verse anchor', async () => {
+    mockSearchByVector.mockResolvedValue([
+      chunk(undefined, undefined, undefined, 'meta'), // e.g. meta_faq chunk
+      chunk('romans', 8, undefined, 'partial'),
+      chunk('romans', 8, 28, 'ok'),
+    ]);
+
+    const result = await searchVersesSemantic('hope', 't');
+    expect(result).toHaveLength(1);
+    expect(result[0].book_id).toBe('romans');
+  });
+
+  it('caps results at MAX_RESULTS', async () => {
+    mockSearchByVector.mockResolvedValue(
+      Array.from({ length: _internal.CHUNK_LIMIT }, (_, i) =>
+        chunk('psalms', 119, i + 1, `c${i}`),
+      ),
+    );
+
+    const result = await searchVersesSemantic('law', 't');
+    expect(result).toHaveLength(_internal.MAX_RESULTS);
+  });
+
+  it('drops anchors whose verse row does not hydrate', async () => {
+    mockSearchByVector.mockResolvedValue([
+      chunk('genesis', 1, 3, 'a'),
+      chunk('genesis', 99, 1, 'stale'), // no such row
+    ]);
+    mockGetVerse.mockImplementation((bookId: string, ch: number, v: number) =>
+      Promise.resolve(ch === 99 ? null : verse(bookId, ch, v)),
+    );
+
+    const result = await searchVersesSemantic('beginnings', 't');
+    expect(result).toHaveLength(1);
+  });
+
+  it('propagates AmicusError from embed (caller owns the FTS fallback)', async () => {
+    mockEmbedQuery.mockRejectedValue(new AmicusError('OFFLINE', 'network down'));
+    await expect(searchVersesSemantic('grace', 't')).rejects.toBeInstanceOf(AmicusError);
+    expect(mockSearchByVector).not.toHaveBeenCalled();
+  });
+
+  it('propagates AmicusError from vector search', async () => {
+    mockSearchByVector.mockRejectedValue(new AmicusError('EXTENSION_NOT_LOADED', 'no vec0'));
+    await expect(searchVersesSemantic('grace', 't')).rejects.toBeInstanceOf(AmicusError);
+  });
+});
+
+// ── mergeVersesRRF ─────────────────────────────────────────────────
+
+describe('mergeVersesRRF', () => {
+  const g13 = verse('genesis', 1, 3);
+  const j11 = verse('john', 1, 1);
+  const p231 = verse('psalms', 23, 1);
+  const r828 = verse('romans', 8, 28);
+
+  it('a verse in both lanes outranks single-lane leaders', () => {
+    // j11: FTS #2 + semantic #1 → 1/62 + 1/61
+    // g13: FTS #1 only         → 1/61
+    const merged = mergeVersesRRF([g13, j11], [j11, p231]);
+    expect(merged[0]).toBe(j11);
+    expect(merged[1]).toBe(g13); // 1/61 > 1/63 (p231 at semantic #2)
+    expect(merged[2]).toBe(p231);
+  });
+
+  it('dedupes by ref, keeping the FTS row instance', () => {
+    const j11Semantic = { ...j11, id: 999 }; // same ref, different instance
+    const merged = mergeVersesRRF([j11], [j11Semantic]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toBe(j11);
+  });
+
+  it('uses k=60 (documented RRF constant)', () => {
+    expect(RRF_K).toBe(60);
+    // Sanity: with k=60, both-lanes rank (2,2) beats single-lane rank 1:
+    // 2/(60+2) ≈ 0.0323 > 1/61 ≈ 0.0164
+    const merged = mergeVersesRRF([g13, j11], [p231, j11]);
+    expect(merged[0]).toBe(j11);
+  });
+
+  it('preserves FTS order among FTS-only results (stable ties)', () => {
+    const merged = mergeVersesRRF([g13, j11, p231, r828], []);
+    expect(merged).toEqual([g13, j11, p231, r828]);
+  });
+
+  it('handles empty lanes', () => {
+    expect(mergeVersesRRF([], [])).toEqual([]);
+    expect(mergeVersesRRF([g13], [])).toEqual([g13]);
+    expect(mergeVersesRRF([], [j11])).toEqual([j11]);
+  });
+
+  it('ignores duplicate refs within a single lane', () => {
+    const merged = mergeVersesRRF([g13, { ...g13 }], [j11, { ...j11 }]);
+    expect(merged).toHaveLength(2);
+  });
+});

--- a/app/src/services/search/semanticVerses.ts
+++ b/app/src/services/search/semanticVerses.ts
@@ -1,0 +1,147 @@
+/**
+ * services/search/semanticVerses.ts — Semantic verse lane for universal
+ * search (#1876, Epic E #1867).
+ *
+ * Composes the existing Amicus retrieval primitives — embedQuery (proxy
+ * /ai/embed) → searchByVector (sqlite-vec) — then hydrates the chunks'
+ * verse anchors into real Verse rows. Chunks index panel/word-study/debate
+ * content, not raw verse text, so a chunk's (book_id, chapter_num,
+ * verse_start) anchor is the semantic pointer back into Scripture.
+ *
+ * Also exports mergeVersesRRF, the Reciprocal Rank Fusion merge used by
+ * useSearch to combine this lane with FTS verse results.
+ *
+ * Errors: embedQuery/searchByVector throw AmicusError (OFFLINE,
+ * PROXY_UNAUTHORIZED, EMBED_FAILED, EXTENSION_NOT_LOADED). Callers treat
+ * any failure as "semantic lane unavailable" and fall back to FTS-only.
+ */
+
+import { embedQuery } from '../amicus/embed';
+import { searchByVector } from '../amicus/vectorSearch';
+import { getVerse } from '../../db/content';
+import { formatVerseRef } from '../../utils/verseRef';
+import type { Verse } from '../../types';
+
+/** Chunk candidates to pull from sqlite-vec before verse hydration. */
+const CHUNK_LIMIT = 24;
+
+/** Maximum verses the semantic lane contributes to the merge. */
+const MAX_RESULTS = 12;
+
+/**
+ * Reciprocal Rank Fusion constant. k=60 is the standard from the original
+ * RRF paper — small enough that top ranks dominate, large enough that a
+ * result appearing in both lanes beats a lone #1.
+ */
+export const RRF_K = 60;
+
+export interface SearchVersesSemanticOptions {
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Per-attempt embed timeout. Tighter than embed's 5s default because
+   * this lane sits inside the search Promise.all — a slow proxy should
+   * degrade to FTS-only, not stall the whole result set.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Semantic verse search: embed the query, vector-search the chunk index,
+ * hydrate each chunk's verse anchor. Results keep vector-rank order and
+ * are deduped by verse ref.
+ *
+ * Throws AmicusError on embed/vector failure — callers own the fallback.
+ */
+export async function searchVersesSemantic(
+  query: string,
+  authToken: string,
+  opts: SearchVersesSemanticOptions = {},
+): Promise<Verse[]> {
+  const vector = await embedQuery(query, {
+    authToken,
+    fetchImpl: opts.fetchImpl,
+    timeoutMs: opts.timeoutMs ?? 2500,
+  });
+
+  const chunks = await searchByVector(vector, { limit: CHUNK_LIMIT });
+
+  // Chunk anchors → unique verse refs, preserving vector-rank order.
+  const seen = new Set<string>();
+  const anchors: Array<{ bookId: string; ch: number; v: number }> = [];
+  for (const chunk of chunks) {
+    const { book_id, chapter_num, verse_start } = chunk.metadata;
+    if (!book_id || !chapter_num || !verse_start) continue;
+    const ref = formatVerseRef(book_id, chapter_num, verse_start);
+    if (seen.has(ref)) continue;
+    seen.add(ref);
+    anchors.push({ bookId: book_id, ch: chapter_num, v: verse_start });
+    if (anchors.length >= MAX_RESULTS) break;
+  }
+
+  // Hydrate to Verse rows (default translation, matching the FTS lane).
+  const rows = await Promise.all(anchors.map((a) => getVerse(a.bookId, a.ch, a.v)));
+  return rows.filter((r): r is Verse => r !== null);
+}
+
+/**
+ * Merge FTS and semantic verse lists with Reciprocal Rank Fusion:
+ *   score(ref) = Σ over lanes containing ref of 1 / (k + rank)
+ * (rank is 1-based within each lane). Deduped by verse ref; the FTS row
+ * instance wins when both lanes carry the same ref. Ties break toward
+ * the FTS lane's original order, keeping the merge stable.
+ */
+export function mergeVersesRRF(
+  ftsVerses: Verse[],
+  semanticVerses: Verse[],
+  k: number = RRF_K,
+): Verse[] {
+  interface Entry {
+    verse: Verse;
+    score: number;
+    ftsRank: number;
+    semanticRank: number;
+  }
+  const entries = new Map<string, Entry>();
+
+  ftsVerses.forEach((verse, i) => {
+    const ref = formatVerseRef(verse.book_id, verse.chapter_num, verse.verse_num);
+    const rank = i + 1;
+    const existing = entries.get(ref);
+    if (existing) return; // duplicate ref within the FTS lane itself
+    entries.set(ref, {
+      verse,
+      score: 1 / (k + rank),
+      ftsRank: rank,
+      semanticRank: Number.POSITIVE_INFINITY,
+    });
+  });
+
+  semanticVerses.forEach((verse, i) => {
+    const ref = formatVerseRef(verse.book_id, verse.chapter_num, verse.verse_num);
+    const rank = i + 1;
+    const existing = entries.get(ref);
+    if (existing) {
+      if (Number.isFinite(existing.semanticRank)) return; // dup within lane
+      existing.score += 1 / (k + rank);
+      existing.semanticRank = rank;
+    } else {
+      entries.set(ref, {
+        verse,
+        score: 1 / (k + rank),
+        ftsRank: Number.POSITIVE_INFINITY,
+        semanticRank: rank,
+      });
+    }
+  });
+
+  return [...entries.values()]
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.ftsRank !== b.ftsRank) return a.ftsRank - b.ftsRank;
+      return a.semanticRank - b.semanticRank;
+    })
+    .map((e) => e.verse);
+}
+
+export const _internal = { CHUNK_LIMIT, MAX_RESULTS };


### PR DESCRIPTION
Closes #1876 · Parent epic #1867

## What

**New `app/src/services/search/semanticVerses.ts`** — reuses the existing Amicus retrieval primitives rather than reimplementing anything:

- `searchVersesSemantic(query, authToken)` composes `embedQuery` (proxy `/ai/embed`) → `searchByVector` (sqlite-vec) → verse hydration. The chunk index stores panel/word-study/debate content (there is no `verse` chunk type), so each chunk's `(book_id, chapter_num, verse_start)` anchor is the semantic pointer back into Scripture; anchors hydrate to real `Verse` rows via `getVerse` in the default translation, matching the FTS lane. Deduped by ref, vector-rank order preserved, capped at 12.
- `mergeVersesRRF(fts, semantic, k = 60)` — Reciprocal Rank Fusion: `score(ref) = Σ 1/(k + rank)`, deduped by `formatVerseRef` (FTS row instance wins), ties break toward FTS order so the merge is stable.

**`useSearch` integration:**
- The semantic lane joins the **existing `Promise.all`**, gated on `usePremium()` + `isConnected()`; a missing RevenueCat token (`getAmicusAuthToken` → null) skips the lane silently.
- **500ms semantic debounce**: the lane waits a 200ms lane-local delay on top of the shared 300ms debounce before firing the embed round-trip — FTS and the other lanes keep their existing 300ms timing when the lane is off.
- Any `AmicusError` (offline, unauthorized, embed failure, missing vec extension) → `logger.warn` + FTS-only results. Never a user-facing failure; the catch sits on the lane promise so the surrounding `Promise.all` can't reject from it.
- Embed timeout tightened to 2.5s/attempt for this lane (vs embed's 5s default) — since the lane sits inside the `Promise.all` per the spec, a slow proxy should degrade to FTS-only rather than stall the result set.

## Out of scope (per issue)

- **No `ai-proxy/` changes** — `/ai/embed`'s existing RevenueCat gate is the premium gate.
- **No UI changes** — result presentation is #1877. Merged verses flow through the existing `results.verses` group.

## Tests

- `src/services/search/__tests__/semanticVerses.test.ts` (12): embed→vector→hydration composition with mocked embed; anchor dedupe; skipping anchor-less chunks (e.g. `meta_faq`); result cap; hydration misses dropped; `AmicusError` propagation from both embed and vector stages; RRF ordering (both-lanes beats single-lane #1), ref dedupe keeping the FTS instance, k=60, stable ties, empty lanes, intra-lane duplicates.
- `__tests__/hooks/useSearch.test.ts` (+6): lane never fires for free users / offline / token-less; fires only after the 500ms lane debounce (asserted at 400ms vs 600ms); RRF-merged ordering lands in `results.verses`; silent FTS-only fallback on lane rejection.

## Verification

`npx tsc --noEmit` clean · `npx eslint` clean · full jest suite: **547 suites / 4110 tests green**.

## Rollback plan

Revert the PR: `useSearch` returns to FTS-only verses; the new service module has no other consumers. No schema, proxy, or dependency changes.

---
Kanban note: no GraphQL access to the project board from this environment — please drag #1876 to **In Review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe)_