### PR TITLE
feat: scroll API migration — scrollToIndex everywhere (#1873)

### DIFF
--- a/app/__tests__/hooks/chapter/useChapterScroll.test.ts
+++ b/app/__tests__/hooks/chapter/useChapterScroll.test.ts
@@ -9,15 +9,44 @@ jest.mock('@/db/user', () => ({
 }));
 
 const mockClearActivePanel = jest.fn();
+const mockActivePanel: { value: { sectionId: string; panelType: string } | null } = { value: null };
 jest.mock('@/stores', () => ({
   useReaderStore: (selector: any) =>
     selector({
-      activePanel: null,
+      activePanel: mockActivePanel.value,
       clearActivePanel: mockClearActivePanel,
     }),
 }));
 
 import { useChapterScroll } from '@/hooks/chapter/useChapterScroll';
+import type { ChapterListItem } from '@/utils/chapterItems';
+import type { ReaderScrollable } from '@/components/ChapterVerseList';
+
+// Two sections: verses 1-5 (items[1]=header, items[2]=verseBlock,
+// items[3]=panelRow) and 6-10 (items[4..6]); footer last.
+const ITEMS: ChapterListItem[] = [
+  { type: 'chapterHeader', key: 'chapterHeader:0:0' },
+  { type: 'sectionHeader', key: 'sectionHeader:1:1', sectionId: 'sec1', sectionNum: 1, header: 'One', showSeparator: false },
+  { type: 'verseBlock', key: 'verseBlock:1:1', sectionId: 'sec1', sectionNum: 1, verseStart: 1, verseEnd: 5 },
+  { type: 'panelRow', key: 'panelRow:1:1', sectionId: 'sec1', sectionNum: 1, panelKeys: ['heb'] },
+  { type: 'sectionHeader', key: 'sectionHeader:2:6', sectionId: 'sec2', sectionNum: 2, header: 'Two', showSeparator: true },
+  { type: 'verseBlock', key: 'verseBlock:2:6', sectionId: 'sec2', sectionNum: 2, verseStart: 6, verseEnd: 10 },
+  { type: 'panelRow', key: 'panelRow:2:6', sectionId: 'sec2', sectionNum: 2, panelKeys: [] },
+  { type: 'footer', key: 'footer:0:0' },
+];
+
+const VERSE_INDEX_MAP = new Map<number, number>([
+  [1, 2], [2, 2], [3, 2], [4, 2], [5, 2],
+  [6, 5], [7, 5], [8, 5], [9, 5], [10, 5],
+]);
+
+function mockScrollable() {
+  return {
+    scrollTo: jest.fn(),
+    scrollToEnd: jest.fn(),
+    scrollToIndex: jest.fn(),
+  } satisfies ReaderScrollable;
+}
 
 function createOptions(overrides = {}) {
   return {
@@ -25,6 +54,8 @@ function createOptions(overrides = {}) {
     chapterNum: 1,
     isLoading: false,
     versesLength: 31,
+    items: ITEMS,
+    verseIndexMap: VERSE_INDEX_MAP,
     ...overrides,
   };
 }
@@ -39,38 +70,82 @@ describe('useChapterScroll', () => {
     expect(result.current.scrollProgress).toBe(0);
   });
 
-  it('returns scroll and layout refs', () => {
+  it('returns the scroll ref and scrollToVerse', () => {
     const { result } = renderHook(() => useChapterScroll(createOptions()));
     expect(result.current.scrollRef).toBeDefined();
-    expect(result.current.sectionYMap).toBeDefined();
-    expect(result.current.verseYMap).toBeDefined();
+    expect(result.current.scrollToVerse).toBeDefined();
   });
 
-  it('handleSectionLayout stores section Y position', () => {
+  it('scrollToVerse targets the verse block index (#1873)', () => {
     const { result } = renderHook(() => useChapterScroll(createOptions()));
+    const scrollable = mockScrollable();
+    result.current.scrollRef.current = scrollable;
 
     act(() => {
-      result.current.handleSectionLayout('sec1', 100);
+      result.current.scrollToVerse(7);
     });
 
-    expect(result.current.sectionYMap.current['sec1']).toBe(100);
+    // Verse 7 lives in the second verseBlock (index 5); no cell offset
+    // captured yet → anchored at the block top, 80px from viewport top.
+    expect(scrollable.scrollToIndex).toHaveBeenCalledWith({
+      index: 5,
+      viewOffset: 80,
+      animated: true,
+    });
   });
 
-  it('handleVerseLayout stores absolute verse Y position', () => {
+  it('scrollToVerse refines with the cell-relative offset once laid out', () => {
     const { result } = renderHook(() => useChapterScroll(createOptions()));
+    const scrollable = mockScrollable();
+    result.current.scrollRef.current = scrollable;
 
-    // First set the section Y
+    // Verse 7 laid out 150px into its block cell.
     act(() => {
-      result.current.handleSectionLayout('sec1', 200);
+      result.current.handleVerseLayout(7, 150, 'sec2');
+    });
+    act(() => {
+      result.current.scrollToVerse(7);
     });
 
-    // Then set the verse Y relative to section
+    // viewOffset = topOffset (80) - cellOffset (150) = -70:
+    // final offset = blockTop + 150 - 80.
+    expect(scrollable.scrollToIndex).toHaveBeenCalledWith({
+      index: 5,
+      viewOffset: -70,
+      animated: true,
+    });
+  });
+
+  it('scrollToVerse is a no-op for verses outside the map', () => {
+    const { result } = renderHook(() => useChapterScroll(createOptions()));
+    const scrollable = mockScrollable();
+    result.current.scrollRef.current = scrollable;
+
     act(() => {
-      result.current.handleVerseLayout(5, 50, 'sec1');
+      result.current.scrollToVerse(999);
     });
 
-    // Absolute Y = sectionY (200) + relativeVerseY (50) = 250
-    expect(result.current.verseYMap.current[5]).toBe(250);
+    expect(scrollable.scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('initialVerseNum triggers the deep-link jump once loaded', () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(() =>
+      useChapterScroll(createOptions({ initialVerseNum: 6 })),
+    );
+    const scrollable = mockScrollable();
+    result.current.scrollRef.current = scrollable;
+
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+
+    expect(scrollable.scrollToIndex).toHaveBeenCalledWith({
+      index: 5,
+      viewOffset: 80,
+      animated: true,
+    });
+    jest.useRealTimers();
   });
 
   it('handleScroll updates scrollProgress', () => {
@@ -175,21 +250,12 @@ describe('useChapterScroll', () => {
     expect(mockCompletePlanDay).not.toHaveBeenCalled();
   });
 
-  it('handleBtnRowLayout stores button row Y position', () => {
+  it('layout callbacks are safe no-ops for section/button-row (D5 removes them)', () => {
     const { result } = renderHook(() => useChapterScroll(createOptions()));
-
-    // Set section Y first
     act(() => {
       result.current.handleSectionLayout('sec1', 300);
-    });
-
-    act(() => {
       result.current.handleBtnRowLayout('sec1', 300, 150);
     });
-
-    // The function stores secY + rowY where secY is read from sectionYMap
-    // handleBtnRowLayout ignores the _sectionY param and reads from sectionYMap
-    // So it's sectionYMap['sec1'] (300) + rowY (150) = 450
   });
 
   it('does not complete plan day when already completed for that chapter', () => {
@@ -255,24 +321,24 @@ describe('useChapterScroll', () => {
     expect(mockClearActivePanel).toHaveBeenCalled();
   });
 
-  it('handleVerseLayout uses 0 when section not found', () => {
+  it('opens panel → scrolls to the section panelRow index', () => {
+    jest.useFakeTimers();
+    mockActivePanel.value = { sectionId: 'sec2', panelType: 'heb' };
     const { result } = renderHook(() => useChapterScroll(createOptions()));
-
-    // Don't set section layout, then set verse layout
-    act(() => {
-      result.current.handleVerseLayout(1, 50, 'unknown_section');
-    });
-
-    // Should use 0 + 50 = 50
-    expect(result.current.verseYMap.current[1]).toBe(50);
-  });
-
-  it('handleBtnRowLayout uses 0 when section not found', () => {
-    const { result } = renderHook(() => useChapterScroll(createOptions()));
+    const scrollable = mockScrollable();
+    result.current.scrollRef.current = scrollable;
 
     act(() => {
-      result.current.handleBtnRowLayout('unknown_section', 0, 100);
+      jest.advanceTimersByTime(120);
     });
-    // Should use 0 (no section in sectionYMap) + 100 = 100
+
+    // sec2's panelRow item sits at index 6.
+    expect(scrollable.scrollToIndex).toHaveBeenCalledWith({
+      index: 6,
+      viewOffset: 80,
+      animated: true,
+    });
+    mockActivePanel.value = null;
+    jest.useRealTimers();
   });
 });

--- a/app/__tests__/hooks/chapter/useChapterTTS.test.ts
+++ b/app/__tests__/hooks/chapter/useChapterTTS.test.ts
@@ -1,6 +1,4 @@
 import { renderHook, act } from '@testing-library/react-native';
-import { createRef } from 'react';
-import type { ReaderScrollable } from '@/components/ChapterVerseList';
 
 const mockPlay = jest.fn();
 const mockStop = jest.fn();
@@ -29,17 +27,12 @@ const mockVerses = [
   { id: 3, book_id: 'genesis', chapter_num: 1, verse_num: 3, translation: 'esv', text: 'Let there be light' },
 ];
 
-const mockSections = [
-  { id: 'sec1', chapter_id: 'ch1', section_num: 1, header: 'Creation', verse_start: 1, verse_end: 3 },
-];
+const mockScrollToVerse = jest.fn();
 
 function createOptions(overrides = {}) {
   return {
     verses: mockVerses as any,
-    sections: mockSections as any,
-    scrollRef: createRef<ReaderScrollable>(),
-    sectionYMap: { current: {} as Record<string, number> },
-    verseYMap: { current: {} as Record<number, number> },
+    scrollToVerse: mockScrollToVerse,
     bookId: 'genesis',
     chapterNum: 1,
     ...overrides,
@@ -51,6 +44,22 @@ describe('useChapterTTS', () => {
     jest.clearAllMocks();
     mockTTSState.currentVerse = 0;
     mockTTSState.isPlaying = false;
+  });
+
+  it('auto-follows the active verse via scrollToVerse while playing (#1873)', () => {
+    const { result } = renderHook(() => useChapterTTS(createOptions()));
+
+    act(() => {
+      result.current.toggleTTS();
+    });
+
+    // currentVerse 0 → verse_num 1, anchored 120px from the top.
+    expect(mockScrollToVerse).toHaveBeenCalledWith(1, 120, true);
+  });
+
+  it('does not auto-scroll when TTS is inactive', () => {
+    renderHook(() => useChapterTTS(createOptions()));
+    expect(mockScrollToVerse).not.toHaveBeenCalled();
   });
 
   it('starts with ttsActive false and no activeVerseNum', () => {

--- a/app/src/components/ChapterVerseList.tsx
+++ b/app/src/components/ChapterVerseList.tsx
@@ -32,7 +32,7 @@ import type { Section, SectionPanel, ChapterPanel } from '../types';
 import { useRelatedContent } from '../hooks/useRelatedContent';
 import { useMapChipData } from '../hooks/useMapChipData';
 import { useTheme, spacing, fontFamily } from '../theme';
-import { buildChapterItems, type ChapterListItem } from '../utils/chapterItems';
+import type { ChapterListItem } from '../utils/chapterItems';
 import { useChapterReader } from './ChapterReaderContext';
 import { SectionHeader } from './SectionHeader';
 import { VerseBlock } from './VerseBlock';
@@ -70,10 +70,11 @@ export interface ReaderScrollable {
 type SectionWithPanels = Section & { panels: SectionPanel[] };
 
 interface Props {
+  /** Flat reader items — built by ChapterScreen via buildChapterItems
+   *  (#1871/#1873) so scroll anchoring shares the same indices. */
+  items: ChapterListItem[];
   sections: SectionWithPanels[];
   chapterPanels: ChapterPanel[];
-  prayerPrompt?: string | null;
-  relatedLifeTopicsJson?: string | null;
   chapterMeta?: ChapterMeta | null;
   /** Pre-section chrome (lens guidance, ChapterHeader, banners) — rendered
    *  for the model's chapterHeader item so it scrolls with the list. */
@@ -86,10 +87,9 @@ interface Props {
 
 const ChapterVerseList = forwardRef<ReaderScrollable, Props>(function ChapterVerseList(
   {
+    items,
     sections,
     chapterPanels,
-    prayerPrompt,
-    relatedLifeTopicsJson,
     chapterMeta,
     header,
     footer,
@@ -126,40 +126,6 @@ const ChapterVerseList = forwardRef<ReaderScrollable, Props>(function ChapterVer
       (navigation as any).navigate('ExploreTab', { screen: 'ScholarBio', params: { scholarId } });
     },
     [navigation],
-  );
-
-  // ── Flat item model (#1871) ─────────────────────────────────
-  // Lens filtering already ran upstream in ChapterScreen, so lensKeys is
-  // empty (the builder's filter is idempotent either way). The genre
-  // banner stays in `header` chrome until D4 (#1874) moves it to its item.
-  const { items } = useMemo(
-    () =>
-      buildChapterItems(sections, chapterPanels, {
-        mode: display.tier,
-        lensKeys: [],
-        coaching: {
-          studyCoachEnabled: coaching.studyCoachEnabled,
-          sectionTips: coaching.coachingTips,
-          chapterCoaching: coaching.chapterCoaching ?? null,
-          dismissedTips: coaching.dismissedTips,
-        },
-        genre: null,
-        prayerPrompt,
-        relatedLifeTopicsJson,
-        mapStoryLinkId: chapterMeta?.map_story_link_id,
-      }),
-    [
-      sections,
-      chapterPanels,
-      display.tier,
-      coaching.studyCoachEnabled,
-      coaching.coachingTips,
-      coaching.chapterCoaching,
-      coaching.dismissedTips,
-      prayerPrompt,
-      relatedLifeTopicsJson,
-      chapterMeta?.map_story_link_id,
-    ],
   );
 
   const sectionById = useMemo(() => {

--- a/app/src/hooks/chapter/useChapterScroll.ts
+++ b/app/src/hooks/chapter/useChapterScroll.ts
@@ -1,15 +1,28 @@
 /**
- * useChapterScroll — Scroll refs, progress tracking, layout callbacks,
- * and auto-scroll to panel/verse behaviors.
+ * useChapterScroll — Scroll ref, progress tracking, and index-based
+ * auto-scroll behaviors for the FlashList reader.
  *
- * Extracted from ChapterScreen (#970).
+ * Extracted from ChapterScreen (#970); rewritten for virtualization in
+ * D3 (#1873): all anchor jumps go through scrollToIndex against the
+ * ChapterListItem model (#1871) instead of accumulated onLayout y-maps,
+ * which report cell-relative coordinates under FlashList (#1872).
+ *
+ * Verse precision: verseIndexMap targets the verse's verseBlock item
+ * (a section's verse run). For verses deeper in a block we refine with
+ * the verse's cell-relative offset captured by handleVerseLayout — a
+ * two-phase jump when the block isn't mounted yet (scrollToIndex mounts
+ * it, the verse's onLayout then triggers the precise follow-up).
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 import type { ReaderScrollable } from '../../components/ChapterVerseList';
+import type { ChapterListItem } from '../../utils/chapterItems';
 import { useReaderStore } from '../../stores';
 import { completePlanDay } from '../../db/user';
+
+/** Gap between the viewport top and an anchored verse/panel row. */
+const ANCHOR_TOP_OFFSET = 80;
 
 interface UseChapterScrollOptions {
   bookId: string;
@@ -19,6 +32,10 @@ interface UseChapterScrollOptions {
   versesLength: number;
   planId?: string;
   planDayNum?: number;
+  /** Flat reader items (#1871) — drives index lookup for anchor jumps. */
+  items: ChapterListItem[];
+  /** verse_num → index of its verseBlock item, from buildChapterItems. */
+  verseIndexMap: Map<number, number>;
 }
 
 export function useChapterScroll({
@@ -29,20 +46,29 @@ export function useChapterScroll({
   versesLength,
   planId,
   planDayNum,
+  items,
+  verseIndexMap,
 }: UseChapterScrollOptions) {
   const activePanel = useReaderStore((s) => s.activePanel);
   const clearActivePanel = useReaderStore((s) => s.clearActivePanel);
 
-  // FlashList-backed scroll surface (#1872); scrollTo maps to scrollToOffset.
   const scrollRef = useRef<ReaderScrollable>(null);
-  const sectionYMap = useRef<Record<string, number>>({});
-  const verseYMap = useRef<Record<number, number>>({});
-  const btnRowYMap = useRef<Record<string, number>>({});
+  /** verse_num → y within its verseBlock cell (cell-relative, #1872). */
+  const verseCellOffsets = useRef<Record<number, number>>({});
   const [scrollProgress, setScrollProgress] = useState(0);
   const planDayCompletedRef = useRef(false);
 
+  /** sectionId → index of the section's panelRow item. */
+  const panelRowIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    items.forEach((item, index) => {
+      if (item.type === 'panelRow') map.set(item.sectionId, index);
+    });
+    return map;
+  }, [items]);
+
   // Track pending scroll timers so they can be cleared on chapter change /
-  // unmount, preventing scrollTo from firing against a stale chapter.
+  // unmount, preventing scrollToIndex from firing against a stale chapter.
   const timersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
   const schedule = useCallback((fn: () => void, ms: number) => {
     const id = setTimeout(() => {
@@ -73,7 +99,7 @@ export function useChapterScroll({
     clearActivePanel();
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setScrollProgress(0);
-    verseYMap.current = {};
+    verseCellOffsets.current = {};
   }, [bookId, chapterNum, clearActivePanel, clearTimers]);
 
   // Scroll progress tracking
@@ -85,103 +111,95 @@ export function useChapterScroll({
     }
   }, []);
 
-  // Auto-scroll to button row when a panel opens
+  /**
+   * Anchor a verse near the top of the viewport. Uses the verse's
+   * verseBlock index plus its cell-relative offset when the block has
+   * laid out (0 until then — i.e. the block's top).
+   */
+  const scrollToVerse = useCallback(
+    (verseNum: number, topOffset: number = ANCHOR_TOP_OFFSET, animated: boolean = true) => {
+      const index = verseIndexMap.get(verseNum);
+      if (index == null) return;
+      const cellOffset = verseCellOffsets.current[verseNum] ?? 0;
+      // FlatList/FlashList semantics: final offset = itemOffset - viewOffset,
+      // so viewOffset = topOffset - cellOffset lands the verse at topOffset.
+      scrollRef.current?.scrollToIndex({
+        index,
+        viewOffset: topOffset - cellOffset,
+        animated,
+      });
+    },
+    [verseIndexMap],
+  );
+
+  // Auto-scroll to the section's button row when a panel opens
   useEffect(() => {
     if (activePanel && activePanel.sectionId !== '__chapter__') {
-      const btnY = btnRowYMap.current[activePanel.sectionId];
-      const secY = sectionYMap.current[activePanel.sectionId];
-      const y = btnY ?? secY;
-      if (y !== undefined) {
+      const index = panelRowIndexMap.get(activePanel.sectionId);
+      if (index != null) {
         schedule(() => {
-          scrollRef.current?.scrollTo({ y: Math.max(0, y - 80), animated: true });
+          scrollRef.current?.scrollToIndex({
+            index,
+            viewOffset: ANCHOR_TOP_OFFSET,
+            animated: true,
+          });
         }, 100);
       }
     }
-  }, [activePanel, schedule]);
+  }, [activePanel, panelRowIndexMap, schedule]);
 
-  // Auto-scroll to a specific verse when navigated with verseNum param.
+  // Auto-scroll to a specific verse when navigated with verseNum param
+  // (deep links, note/highlight anchors, plan days).
   //
-  // RACE NOTES:
-  //   1. The previous version only scrolled via an effect that ran when
-  //      isLoading flipped to false. At that moment, React Native's onLayout
-  //      callbacks haven't fired yet, so verseYMap is empty and the scroll
-  //      was silently dropped. Layout callbacks don't trigger a re-render,
-  //      so the effect never retried.
-  //   2. onLayout order across nested views is not guaranteed — a verse's
-  //      onLayout can fire before its enclosing section's onLayout. If we
-  //      scrolled immediately using sectionY + verseY, sectionY might still
-  //      be 0 and the computed target would be wrong.
-  //
-  // Fix: track scroll as *pending* when the target is set. Attempt to flush
-  // from both handleVerseLayout and handleSectionLayout — whichever completes
-  // the picture last triggers the actual scroll. We require a non-zero
-  // sectionY to flush (scrolling to y=0 is what a zero-offset target looks
-  // like, and would be indistinguishable from an uninitialised section at
-  // the very top; we treat the top-of-chapter case as already-scrolled so
-  // flushing it is a no-op anyway).
+  // Two-phase under virtualization: the first jump targets the verse's
+  // block (scrollToIndex estimates offsets for unmounted cells and mounts
+  // the block); once the verse's own onLayout reports its cell-relative
+  // offset, a second jump lands it exactly. Verses at a block's top need
+  // no refinement — phase one is already exact.
   const scrolledToInitialVerse = useRef(false);
+  const refinePending = useRef(false);
   useEffect(() => {
     scrolledToInitialVerse.current = false;
+    refinePending.current = false;
   }, [bookId, chapterNum]);
 
-  const tryFlushInitialScroll = useCallback((sectionId: string) => {
-    if (!initialVerseNum || scrolledToInitialVerse.current) return;
-    const sectionY = sectionYMap.current[sectionId];
-    const verseY = verseYMap.current[initialVerseNum];
-    // Need both pieces. verseYMap values are stored as (sectionY + verseRelative),
-    // so if section wasn't known at store time, verseY here is effectively just
-    // verseRelative. We re-derive from the refs rather than trusting a stale sum.
-    if (sectionY == null || verseY == null) return;
-    scrolledToInitialVerse.current = true;
-    const targetY = Math.max(0, verseY - 80);
-    // 50ms delay lets any remaining sibling layouts settle before animating.
-    schedule(() => {
-      scrollRef.current?.scrollTo({ y: targetY, animated: true });
-    }, 50);
-  }, [initialVerseNum, schedule]);
-
-  // Fast-path: if layout already happened (e.g. cached chapter), scroll now.
   useEffect(() => {
     if (!initialVerseNum || scrolledToInitialVerse.current || isLoading) return;
-    // We don't know which section the verse is in; iterate and try each.
-    // Ref map is small (one key per section), so this is cheap.
-    for (const sectionId of Object.keys(sectionYMap.current)) {
-      tryFlushInitialScroll(sectionId);
-      if (scrolledToInitialVerse.current) break;
+    if (!verseIndexMap.has(initialVerseNum)) return;
+    scrolledToInitialVerse.current = true;
+    refinePending.current = verseCellOffsets.current[initialVerseNum] == null;
+    // 50ms delay lets the first layout pass settle before jumping.
+    schedule(() => scrollToVerse(initialVerseNum, ANCHOR_TOP_OFFSET, true), 50);
+  }, [initialVerseNum, isLoading, versesLength, verseIndexMap, schedule, scrollToVerse]);
+
+  // Layout callbacks — wired from the item renderers (#1872).
+  // Section/button-row positions are no longer used for scroll math
+  // (indices replaced them); the callbacks remain in the context contract
+  // until the D5 (#1875) cleanup pass.
+  const handleSectionLayout = useCallback((_sectionId: string, _y: number) => {}, []);
+
+  const handleVerseLayout = useCallback((verseNum: number, y: number, _sectionId: string) => {
+    verseCellOffsets.current[verseNum] = y;
+
+    // Phase-two refinement: the deep-link target just laid out inside its
+    // block — re-anchor with the now-known offset (no-op when y === 0).
+    if (verseNum === initialVerseNum && refinePending.current) {
+      refinePending.current = false;
+      if (y !== 0) {
+        schedule(() => scrollToVerse(verseNum, ANCHOR_TOP_OFFSET, true), 50);
+      }
     }
-  }, [initialVerseNum, isLoading, versesLength, tryFlushInitialScroll]);
+  }, [initialVerseNum, schedule, scrollToVerse]);
 
-  // Layout callbacks
-  const handleSectionLayout = useCallback((sectionId: string, y: number) => {
-    sectionYMap.current[sectionId] = y;
-    // A section's position became known — if we were waiting on it for
-    // the initial verse scroll, try to flush now.
-    tryFlushInitialScroll(sectionId);
-  }, [tryFlushInitialScroll]);
-
-  const handleVerseLayout = useCallback((verseNum: number, y: number, sectionId: string) => {
-    const sectionY = sectionYMap.current[sectionId] ?? 0;
-    verseYMap.current[verseNum] = sectionY + y;
-
-    // The target verse just laid out — try to flush.
-    if (initialVerseNum === verseNum) {
-      tryFlushInitialScroll(sectionId);
-    }
-  }, [initialVerseNum, tryFlushInitialScroll]);
-
-  const handleBtnRowLayout = useCallback((sectionId: string, _sectionY: number, rowY: number) => {
-    const secY = sectionYMap.current[sectionId] ?? 0;
-    btnRowYMap.current[sectionId] = secY + rowY;
-  }, []);
+  const handleBtnRowLayout = useCallback((_sectionId: string, _sectionY: number, _rowY: number) => {}, []);
 
   return {
     scrollRef,
-    sectionYMap,
-    verseYMap,
     scrollProgress,
     handleScroll,
     handleSectionLayout,
     handleVerseLayout,
     handleBtnRowLayout,
+    scrollToVerse,
   };
 }

--- a/app/src/hooks/chapter/useChapterTTS.ts
+++ b/app/src/hooks/chapter/useChapterTTS.ts
@@ -1,38 +1,36 @@
 /**
  * useChapterTTS — Encapsulates text-to-speech state and auto-scroll behavior.
  *
- * Extracted from ChapterScreen (#970).
+ * Extracted from ChapterScreen (#970). D3 (#1873): auto-follow goes
+ * through useChapterScroll's scrollToVerse (scrollToIndex under the
+ * hood) instead of onLayout y-maps — scrollToIndex estimates offsets
+ * for unmounted blocks, so the old font-size position estimation is
+ * gone with it.
  */
 
-import { useState, useEffect, useCallback, type RefObject } from 'react';
-import type { ReaderScrollable } from '../../components/ChapterVerseList';
+import { useState, useEffect, useCallback } from 'react';
 import { useTTS } from '../useTTS';
 import { useSettingsStore } from '../../stores';
-import { useTypography } from '../../theme';
-import type { Verse, Section } from '../../types';
+import type { Verse } from '../../types';
+
+/** Anchored a little deeper than deep-link jumps so context stays visible. */
+const TTS_TOP_OFFSET = 120;
 
 interface UseChapterTTSOptions {
   verses: Verse[];
-  sections: Section[];
-  scrollRef: RefObject<ReaderScrollable | null>;
-  sectionYMap: RefObject<Record<string, number>>;
-  verseYMap: RefObject<Record<number, number>>;
+  /** Index-based verse anchor from useChapterScroll (#1873). */
+  scrollToVerse: (verseNum: number, topOffset?: number, animated?: boolean) => void;
   bookId: string;
   chapterNum: number;
 }
 
 export function useChapterTTS({
   verses,
-  sections,
-  scrollRef,
-  sectionYMap,
-  verseYMap,
+  scrollToVerse,
   bookId,
   chapterNum,
 }: UseChapterTTSOptions) {
   const ttsVoice = useSettingsStore((s) => s.ttsVoice);
-  const { content } = useTypography();
-  const verseFontSize = content.bodyLg.fontSize;
   const tts = useTTS(verses, ttsVoice || undefined);
   const [ttsActive, setTtsActive] = useState(false);
 
@@ -41,33 +39,8 @@ export function useChapterTTS({
     if (!ttsActive || verses.length === 0) return;
     const verseNum = verses[tts.currentVerse]?.verse_num;
     if (verseNum == null) return;
-
-    const verseY = verseYMap.current[verseNum];
-    if (verseY != null) {
-      scrollRef.current?.scrollTo({
-        y: Math.max(0, verseY - 120),
-        animated: true,
-      });
-      return;
-    }
-
-    // Fallback: estimate position if layout hasn't fired yet
-    const sec = sections.find(
-      (s) => verseNum >= s.verse_start && verseNum <= s.verse_end,
-    );
-    if (!sec) return;
-    const sectionY = sectionYMap.current[sec.id];
-    if (sectionY == null) return;
-    const verseIndex = verseNum - sec.verse_start;
-    const estimatedVerseHeight = verseFontSize * 1.6 + 16;
-    const verseOffsetY = 52 + verseIndex * estimatedVerseHeight;
-
-    scrollRef.current?.scrollTo({
-      y: Math.max(0, sectionY + verseOffsetY - 120),
-      animated: true,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- scrollRef, sectionYMap, verseYMap are stable refs
-  }, [ttsActive, tts.currentVerse, verses, sections, verseFontSize]);
+    scrollToVerse(verseNum, TTS_TOP_OFFSET, true);
+  }, [ttsActive, tts.currentVerse, verses, scrollToVerse]);
 
   // Stop TTS on chapter change
   useEffect(() => {

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -42,6 +42,7 @@ import { useBookmarkedVerses } from '../hooks/useBookmarkedVerses';
 import { useAvailableLenses, useChapterLensContent } from '../hooks/useHermeneuticLens';
 import { LensToggleBar } from '../components/LensToggleBar';
 import { parseLensJson, applyLensToKeys } from '../utils/lensPanelFilter';
+import { buildChapterItems } from '../utils/chapterItems';
 import { TRANSLATION_MAP } from '../db/translationRegistry';
 import { useTheme, spacing, radii, fontFamily } from '../theme';
 import { usePremium } from '../hooks/usePremium';
@@ -124,26 +125,6 @@ function ChapterScreen() {
   } = useChapterData(bookId, chapterNum);
 
   // ─��� Extracted hooks ──
-  const scroll = useChapterScroll({
-    bookId,
-    chapterNum,
-    initialVerseNum,
-    isLoading,
-    versesLength: verses.length,
-    planId,
-    planDayNum,
-  });
-
-  const ttsHook = useChapterTTS({
-    verses,
-    sections,
-    bookId,
-    chapterNum,
-    scrollRef: scroll.scrollRef,
-    sectionYMap: scroll.sectionYMap,
-    verseYMap: scroll.verseYMap,
-  });
-
   const { highlights, highlightMap, loadHighlights } = useChapterHighlights(bookId, chapterNum);
 
   const { coachingTips, chapterCoaching, dismissedTips, handleDismissTip } = useChapterCoaching(
@@ -199,6 +180,56 @@ function ChapterScreen() {
       .map((k) => byType.get(k))
       .filter((p): p is (typeof chapterPanels)[number] => p !== undefined);
   }, [chapterPanels, lensIsActive, lensPanelFilter, lensPanelOrder]);
+
+  // Flat reader item model (#1871) — built once here so scroll anchoring
+  // (#1873) and the FlashList renderer (#1872) share the same indices.
+  // GenreBanner stays header chrome until D4 (#1874), hence genre: null.
+  const { items: chapterItems, verseIndexMap } = useMemo(
+    () =>
+      buildChapterItems(lensFilteredSections, lensFilteredChapterPanels, {
+        mode: chapterMode,
+        lensKeys: [],
+        coaching: {
+          studyCoachEnabled,
+          sectionTips: coachingTips,
+          chapterCoaching: chapterCoaching ?? null,
+          dismissedTips,
+        },
+        genre: null,
+        prayerPrompt: chapter?.prayer_prompt,
+        mapStoryLinkId: chapter?.map_story_link_id,
+      }),
+    [
+      lensFilteredSections,
+      lensFilteredChapterPanels,
+      chapterMode,
+      studyCoachEnabled,
+      coachingTips,
+      chapterCoaching,
+      dismissedTips,
+      chapter?.prayer_prompt,
+      chapter?.map_story_link_id,
+    ],
+  );
+
+  const scroll = useChapterScroll({
+    bookId,
+    chapterNum,
+    initialVerseNum,
+    isLoading,
+    versesLength: verses.length,
+    planId,
+    planDayNum,
+    items: chapterItems,
+    verseIndexMap,
+  });
+
+  const ttsHook = useChapterTTS({
+    verses,
+    bookId,
+    chapterNum,
+    scrollToVerse: scroll.scrollToVerse,
+  });
 
   const panels = useChapterPanels({
     chapterId: chapter?.id,
@@ -614,9 +645,9 @@ function ChapterScreen() {
           <ChapterVerseList
             // eslint-disable-next-line react-hooks/refs -- passing ref to component is idiomatic
             ref={scroll.scrollRef}
+            items={chapterItems}
             sections={lensFilteredSections}
             chapterPanels={lensFilteredChapterPanels}
-            prayerPrompt={chapter?.prayer_prompt}
             header={readerHeader}
             footer={readerFooter}
             // eslint-disable-next-line react-hooks/refs -- stable handler from hook


### PR DESCRIPTION
Closes #1873 · Parent epic #1866 · **Stacked on #1904 (D2)**, which stacks on #1902 (D1). Base is `feat/flashlist-swap`; review only the top commit.

## What

Restores (and improves) precise anchor jumps that D2 flagged as degraded, by rewriting the scroll layer against `scrollToIndex` + the D1 `verseIndexMap`:

- **Model lifts to ChapterScreen.** `buildChapterItems` runs once at screen level; the FlashList renderer (`items` prop) and the scroll hooks share the same indices — no possibility of drift between what's rendered and what's targeted.
- **`useChapterScroll` rewrite:**
  - `scrollToVerse(verseNum, topOffset?, animated?)` — targets the verse's `verseBlock` index, refined by the verse's **cell-relative** `onLayout` offset (exactly what those callbacks report under virtualization). For unmounted blocks it's a two-phase jump: `scrollToIndex` mounts the block (FlashList estimates offsets), then the target verse's `onLayout` triggers the precise follow-up. Verses at a block top are exact in one phase.
  - **Deep-link `initialVerseNum`** goes through the same path — and unlike the old y-map flush dance (which needed both section and verse layouts to have fired and silently dropped scrolls otherwise), the first jump can't be dropped: the index always exists.
  - **Panel-open auto-scroll** targets the section's `panelRow` item index (map derived from `items`), same 80px top anchor as before.
  - Section/button-row layout callbacks are now documented no-ops — kept in the context contract so D5 (#1875) can remove the plumbing in the dead-code pass.
- **`useChapterTTS`** consumes `scrollToVerse` (120px anchor, unchanged depth). The font-size-based position-estimation fallback is deleted — `scrollToIndex` estimating unmounted offsets does that job for real.

## Acceptance mapping

- *Deep links with verseNum land on the verse* — two-phase `scrollToIndex` + refinement; tested at the hook level (block targeting, cell-offset math `viewOffset = topOffset − cellOffset`, out-of-range no-op, timer-gated jump).
- *TTS follow works* — auto-follow test asserts `scrollToVerse(verseNum, 120, true)` per active verse; sequential playback keeps the current block mounted so refinement data is always warm.
- *`useSwipeNavigation` regression* — handlers unchanged since D2 (wrapper View), no new gesture surface introduced here; needs the on-device pass alongside D2's parity check.

## Verification

`npx tsc --noEmit` clean · eslint clean · **full jest: 547 suites / 4119 tests green** (scroll/TTS hook suites rewritten for the new API — the old y-map arithmetic tests died with the y-maps).

## Rollback plan

Revert restores D2's compat-shim behavior (everything compiles and scrolls, anchoring imprecise). No native, schema, or data changes.

---
Kanban note: no board API access from this environment — please drag #1873 to **In Review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe)_