### PR TITLE
feat: interleaved-card parity — guard/CTA/genre as list items (#1874)

### DIFF
--- a/app/src/components/ChapterVerseList.tsx
+++ b/app/src/components/ChapterVerseList.tsx
@@ -46,6 +46,8 @@ import { RelatedContentCarousel } from './RelatedContentCarousel';
 import { MapChip } from './map/MapChip';
 import { PanelInfoSheet } from './PanelInfoSheet';
 import RelatedLifeTopics from './RelatedLifeTopics';
+import { GenreBanner } from './GenreBanner';
+import { ContextGuardBanner } from './guidedStudy';
 import { GoldSeparator } from './GoldSeparator';
 
 export interface ChapterMeta {
@@ -81,6 +83,10 @@ interface Props {
   header?: React.ReactElement | null;
   /** Post-list chrome (next-chapter hint) — rendered for the footer item. */
   footer?: React.ReactElement | null;
+  /** Context-guard CTA (D4 #1874) — navigate to the suggested chapter. */
+  onReadContext?: (guard: import('../types').ProofTextGuard) => void;
+  /** Guided-study CTA renderer (D4 #1874) — element built by ChapterScreen. */
+  renderStudyCta?: () => React.ReactElement | null;
   onScroll?: (e: NativeSyntheticEvent<NativeScrollEvent>) => void;
   contentContainerStyle?: StyleProp<ViewStyle>;
 }
@@ -93,6 +99,8 @@ const ChapterVerseList = forwardRef<ReaderScrollable, Props>(function ChapterVer
     chapterMeta,
     header,
     footer,
+    onReadContext,
+    renderStudyCta,
     onScroll,
     contentContainerStyle,
   }: Props,
@@ -143,9 +151,21 @@ const ChapterVerseList = forwardRef<ReaderScrollable, Props>(function ChapterVer
         case 'chapterHeader':
           return header ?? null;
 
+        case 'contextGuard':
+          return (
+            <ContextGuardBanner
+              guard={item.guard}
+              onReadContext={() => onReadContext?.(item.guard)}
+            />
+          );
+
+        case 'studySessionCta':
+          return renderStudyCta?.() ?? null;
+
         case 'genreBanner':
-          // Emitted only when opts.genre is set — D4 (#1874) territory.
-          return null;
+          return (
+            <GenreBanner genreLabel={item.genreLabel} genreGuidance={item.genreGuidance} />
+          );
 
         case 'sectionHeader': {
           const depth = isFocus ? undefined : panel.depthMap.get(item.sectionId);
@@ -256,6 +276,8 @@ const ChapterVerseList = forwardRef<ReaderScrollable, Props>(function ChapterVer
     [
       header,
       footer,
+      onReadContext,
+      renderStudyCta,
       isFocus,
       sectionById,
       panel,

--- a/app/src/screens/ChapterScreen.tsx
+++ b/app/src/screens/ChapterScreen.tsx
@@ -22,7 +22,6 @@ import { useSwipeNavigation } from '../hooks/useSwipeNavigation';
 import { useNotedVerses } from '../hooks/useNotedVerses';
 import { useSettingsStore, useReaderStore } from '../stores';
 import { recordVisit } from '../db/user';
-import { GenreBanner } from '../components/GenreBanner';
 import { resolveGenre } from '../utils/genre';
 import { useTranslationSwitch } from '../hooks/useTranslationSwitch';
 import { useStoreReview } from '../hooks/useStoreReview';
@@ -58,7 +57,7 @@ import { useChapterScroll } from '../hooks/chapter/useChapterScroll';
 import { useChapterPanels } from '../hooks/chapter/useChapterPanels';
 import { useProofTextGuard } from '../hooks/useProofTextGuard';
 import { getStudyDepthEstimate } from '../services/guidedStudy';
-import { ContextGuardBanner, StudySessionCTA } from '../components/guidedStudy';
+import { StudySessionCTA } from '../components/guidedStudy';
 import { useGuidedStudyChapterState } from '../hooks';
 
 interface CrossTabNavigation {
@@ -181,9 +180,14 @@ function ChapterScreen() {
       .filter((p): p is (typeof chapterPanels)[number] => p !== undefined);
   }, [chapterPanels, lensIsActive, lensPanelFilter, lensPanelOrder]);
 
+  const proofTextGuard = useProofTextGuard(bookId, chapterNum, initialVerseNum);
   // Flat reader item model (#1871) — built once here so scroll anchoring
   // (#1873) and the FlashList renderer (#1872) share the same indices.
-  // GenreBanner stays header chrome until D4 (#1874), hence genre: null.
+  const genre = useMemo(
+    () => (chapter ? resolveGenre(bookData, chapter) : null),
+    [bookData, chapter],
+  );
+
   const { items: chapterItems, verseIndexMap } = useMemo(
     () =>
       buildChapterItems(lensFilteredSections, lensFilteredChapterPanels, {
@@ -195,11 +199,15 @@ function ChapterScreen() {
           chapterCoaching: chapterCoaching ?? null,
           dismissedTips,
         },
-        genre: null,
+        genre,
+        proofTextGuard,
+        showStudyCta: true,
         prayerPrompt: chapter?.prayer_prompt,
         mapStoryLinkId: chapter?.map_story_link_id,
       }),
     [
+      genre,
+      proofTextGuard,
       lensFilteredSections,
       lensFilteredChapterPanels,
       chapterMode,
@@ -246,7 +254,6 @@ function ChapterScreen() {
   const redLetterVerses = useRedLetter(bookId, chapterNum);
   const notedVerses = useNotedVerses(bookId, chapterNum);
   const { bookmarked, toggleBookmark } = useBookmarkedVerses(bookId, chapterNum);
-  const proofTextGuard = useProofTextGuard(bookId, chapterNum, initialVerseNum);
   const guidedStudyState = useGuidedStudyChapterState(chapter?.id);
   const allSectionPanels = useMemo(
     () => lensFilteredSections.flatMap((section) => section.panels),
@@ -471,43 +478,32 @@ function ChapterScreen() {
         }
       />
 
-      {!isFocus && proofTextGuard ? (
-        <ContextGuardBanner
-          guard={proofTextGuard}
-          onReadContext={() =>
-            navigation.navigate('Chapter', {
-              bookId: proofTextGuard.suggested_book_id,
-              chapterNum: proofTextGuard.suggested_chapter_num,
-            })
-          }
-        />
-      ) : null}
-
-      {!isFocus ? (
-        <StudySessionCTA
-          estimate={studyEstimate}
-          mode={guidedStudyState.mode}
-          currentStep={guidedStudyState.activeSession?.current_step}
-          dueCount={guidedStudyState.dueCount}
-          onPress={() =>
-            navigation.navigate('StudySession', {
-              bookId,
-              chapterNum,
-              initialStep: guidedStudyState.initialStep,
-              verseNum: initialVerseNum,
-            })
-          }
-        />
-      ) : null}
-
-      {(() => {
-        if (isFocus) return null;
-        const genre = resolveGenre(bookData, chapter);
-        return genre ? (
-          <GenreBanner genreLabel={genre.label} genreGuidance={genre.guidance} />
-        ) : null;
-      })()}
     </>
+  );
+
+  // Context guard CTA target (contextGuard item, D4 #1874).
+  const handleReadContext = (guard: (typeof proofTextGuard) & object) =>
+    navigation.navigate('Chapter', {
+      bookId: guard.suggested_book_id,
+      chapterNum: guard.suggested_chapter_num,
+    });
+
+  // Guided-study CTA (studySessionCta item, D4 #1874).
+  const renderStudyCta = () => (
+    <StudySessionCTA
+      estimate={studyEstimate}
+      mode={guidedStudyState.mode}
+      currentStep={guidedStudyState.activeSession?.current_step}
+      dueCount={guidedStudyState.dueCount}
+      onPress={() =>
+        navigation.navigate('StudySession', {
+          bookId,
+          chapterNum,
+          initialStep: guidedStudyState.initialStep,
+          verseNum: initialVerseNum,
+        })
+      }
+    />
   );
 
   const readerFooter = (
@@ -648,6 +644,8 @@ function ChapterScreen() {
             items={chapterItems}
             sections={lensFilteredSections}
             chapterPanels={lensFilteredChapterPanels}
+            onReadContext={handleReadContext}
+            renderStudyCta={renderStudyCta}
             header={readerHeader}
             footer={readerFooter}
             // eslint-disable-next-line react-hooks/refs -- stable handler from hook

--- a/app/src/utils/__tests__/chapterItems.test.ts
+++ b/app/src/utils/__tests__/chapterItems.test.ts
@@ -326,6 +326,48 @@ describe('buildChapterItems — coaching gating', () => {
 
 // ── Optional slots ─────────────────────────────────────────────────
 
+describe('buildChapterItems — contextGuard + studySessionCta (D4 #1874)', () => {
+  const GUARD = {
+    ref: 'jeremiah 29:11',
+    book_id: 'jeremiah',
+    chapter_num: 29,
+    verse_num: 11,
+    common_misreading: 'A personal promise of prosperity.',
+    actual_context_summary: 'Spoken to exiles facing 70 years in Babylon.',
+    suggested_book_id: 'jeremiah',
+    suggested_chapter_num: 29,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  it('emits guard, CTA, then genre banner after the chapter header', () => {
+    const { items } = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts({
+      proofTextGuard: GUARD,
+      showStudyCta: true,
+    }));
+    expect(types(items).slice(0, 4)).toEqual([
+      'chapterHeader', 'contextGuard', 'studySessionCta', 'genreBanner',
+    ]);
+    const [guard] = byType(items, 'contextGuard');
+    expect(guard.guard).toBe(GUARD);
+  });
+
+  it('hides both in read mode', () => {
+    const { items } = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts({
+      mode: 'read',
+      proofTextGuard: GUARD,
+      showStudyCta: true,
+    }));
+    expect(types(items)).not.toContain('contextGuard');
+    expect(types(items)).not.toContain('studySessionCta');
+  });
+
+  it('omits both when absent from opts', () => {
+    const { items } = buildChapterItems(SECTIONS, CHAPTER_PANELS, opts());
+    expect(types(items)).not.toContain('contextGuard');
+    expect(types(items)).not.toContain('studySessionCta');
+  });
+});
+
 describe('buildChapterItems — optional slots', () => {
   it('omits genreBanner, prayerPrompt, lifeTopics, and mapChip when absent', () => {
     const { items } = buildChapterItems(

--- a/app/src/utils/chapterItems.ts
+++ b/app/src/utils/chapterItems.ts
@@ -10,6 +10,8 @@
  *
  * Coverage map (current render tree → items):
  *   ChapterHeader                        → chapterHeader
+ *   ContextGuardBanner (study/deep)      → contextGuard (D4 #1874)
+ *   StudySessionCTA (study/deep)         → studySessionCta (D4 #1874)
  *   GenreBanner (study/deep)             → genreBanner
  *   per section:
  *     GoldSeparator (between sections)   → sectionHeader.showSeparator
@@ -40,6 +42,7 @@ import type {
   ChapterPanel,
   CoachingTip,
   ChapterCoaching,
+  ProofTextGuard,
 } from '../types';
 import type { ChapterMode } from '../stores/settingsStore';
 import { filterPanelKeys } from './lensPanelFilter';
@@ -61,6 +64,17 @@ export interface GenreBannerItem extends ItemBase {
   type: 'genreBanner';
   genreLabel: string;
   genreGuidance: string;
+}
+
+/** Proof-text context guard banner (D4 #1874) — study/deep only. */
+export interface ContextGuardItem extends ItemBase {
+  type: 'contextGuard';
+  guard: ProofTextGuard;
+}
+
+/** Guided-study session CTA slot (D4 #1874) — study/deep only. */
+export interface StudySessionCtaItem extends ItemBase {
+  type: 'studySessionCta';
 }
 
 export interface SectionHeaderItem extends ItemBase {
@@ -129,6 +143,8 @@ export interface FooterItem extends ItemBase {
 
 export type ChapterListItem =
   | ChapterHeaderItem
+  | ContextGuardItem
+  | StudySessionCtaItem
   | GenreBannerItem
   | SectionHeaderItem
   | VerseBlockItem
@@ -163,6 +179,10 @@ export interface BuildChapterItemsOpts {
   coaching: ChapterCoachingOpts;
   /** Genre banner content (resolveGenre output), study/deep only. */
   genre?: { label: string; guidance: string } | null;
+  /** Proof-text guard for the chapter (useProofTextGuard), study/deep only. */
+  proofTextGuard?: ProofTextGuard | null;
+  /** Emit the guided-study CTA slot (rendered via renderStudyCta), study/deep only. */
+  showStudyCta?: boolean;
   prayerPrompt?: string | null;
   relatedLifeTopicsJson?: string | null;
   /** map_story_link_id — emits the mapChip slot in study/deep. */
@@ -203,6 +223,19 @@ export function buildChapterItems(
 
   // Chapter header — always first, all modes.
   items.push({ type: 'chapterHeader', key: makeKey('chapterHeader', 0, 0) });
+
+  // Context guard + study CTA — study/deep only, in today's visual order:
+  // guard, CTA, then genre banner (D4 #1874).
+  if (!isRead && opts.proofTextGuard) {
+    items.push({
+      type: 'contextGuard',
+      key: makeKey('contextGuard', 0, 0),
+      guard: opts.proofTextGuard,
+    });
+  }
+  if (!isRead && opts.showStudyCta) {
+    items.push({ type: 'studySessionCta', key: makeKey('studySessionCta', 0, 0) });
+  }
 
   // Genre banner — study/deep only.
   if (!isRead && opts.genre) {


### PR DESCRIPTION
Closes #1874 · Parent epic #1866 · **Stacked on #1905 (D3)** ← #1904 (D2) ← #1902 (D1). Review only the top commit.

## What

Of the issue's list — `StudyCoachCard`, `ChapterCoachingCard`, `PrayerPromptCard`, `RelatedContentCarousel`, `MapChip`, `ContextGuardBanner` — the first five already became builder-emitted items in D2. This PR completes parity:

- **`contextGuard` + `studySessionCta` item types** added to the model, emitted study/deep-only in exactly today's visual order: chapter header → guard → CTA → genre banner → sections. (The CTA wasn't on the issue's list but sits *between* the guard and the genre banner — leaving it in header chrome would have reordered it above the guard, so it rides the model too.)
- **`genreBanner` now actually emits**: `resolveGenre` lifted to ChapterScreen and passed as the builder's `genre` opt; the list renders `GenreBanner` straight from the item payload.
- `ChapterVerseList` renders `ContextGuardBanner` from the item's `ProofTextGuard` payload with an `onReadContext` prop, and the guided-study CTA via a `renderStudyCta` render prop (its props are a bundle of screen-level state — a render prop keeps that wiring in ChapterScreen where it lives today).
- The chapterHeader chrome shrinks to lens guidance + `ChapterHeader` — every interleaved card below the header is now an item with its own recycling pool.

## Acceptance

Side-by-side parity on Genesis 1 / Psalm 23 / Romans 8 across read/study/deep is by construction (same components, same order, same gating — `read` mode emits none of the three, matching the old `!isFocus` conditions) — the on-device 3-chapter eyeball is Craig's half.

## Verification

`npx tsc --noEmit` clean · eslint clean · **full jest: 547 suites / 4122 tests green** (new model tests: emission order, read-mode hiding, absent-opts omission).

## Rollback

Revert restores D3 state (guard/CTA/genre in header chrome). No native/schema/data changes.

---
Kanban note: no board API access from this environment — please drag #1874 to **In Review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCSBeQZmTBjv121ZvHvfHe)_