### PR TITLE
feat: faith-vs-works debate topic + James 2:24 difficult passage

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1813,9 +1813,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2328,9 +2328,9 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5730,9 +5730,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/content/meta/debate-topics.json
+++ b/content/meta/debate-topics.json
@@ -22249,5 +22249,93 @@
       "textual-criticism",
       "hwgtb"
     ]
+  },
+  {
+    "id": "justification-faith-alone-or-faith-and-works",
+    "title": "Justification: Faith Alone or Faith and Works?",
+    "category": "theological",
+    "book_id": "james",
+    "chapters": [
+      2
+    ],
+    "passage": "James 2:14-26; Romans 3:28-4:8; Galatians 2:16; Ephesians 2:8-10",
+    "question": "Paul says a person is justified by faith apart from works (Romans 3:28); James says a person is justified by works and not by faith alone (James 2:24). Are they contradicting each other, and what role do works play in salvation?",
+    "context": "This is the defining debate of the Protestant Reformation and remains the central dividing line between Protestant and Catholic soteriology. Luther famously called James 'an epistle of straw' because James 2:24 appears to flatly deny sola fide. Both authors appeal to the same figure — Abraham — but to different moments: Paul cites Genesis 15:6 (belief credited as righteousness before any act), while James cites Genesis 22 (the offering of Isaac) as faith 'completed' by works. The interpretive question turns on whether Paul and James use 'works' and 'justified' in the same sense, and on whether justification is a one-time forensic declaration or a process in which faith and works cooperate.",
+    "positions": [
+      {
+        "id": "faith-alone-justifies-works-are-evidence",
+        "label": "Faith alone justifies; works are the necessary evidence",
+        "tradition_family": "reformed",
+        "scholar_ids": [
+          "calvin",
+          "schreiner"
+        ],
+        "proponents": "Reformation and Reformed tradition; confessional Protestantism",
+        "argument": "Justification is a forensic declaration received through faith alone, but justifying faith is never alone — it inevitably produces works as its fruit. James condemns a counterfeit faith of bare assent, not the Reformation's sola fide.",
+        "strengths": "Preserves Paul's emphatic exclusion of works from justification (Romans 4:4-5, Ephesians 2:8-9); Calvin's formulation ('faith alone justifies, but the faith that justifies is not alone') accounts for both corpora; James's target is demonstrably dead faith — even demons believe (James 2:19).",
+        "weaknesses": "Must read 'justified' in James 2:24 in a demonstrative sense ('shown to be righteous') that some argue the Greek does not require; risks making assurance dependent on introspection about the quality of one's works.",
+        "key_verses": [
+          "Romans 3:28",
+          "Romans 4:4-5",
+          "Ephesians 2:8-10",
+          "James 2:19"
+        ]
+      },
+      {
+        "id": "paul-and-james-use-terms-differently",
+        "label": "No contradiction: Paul and James answer different questions",
+        "tradition_family": "evangelical",
+        "scholar_ids": [
+          "moo",
+          "mccartney"
+        ],
+        "proponents": "Broad evangelical scholarship on James",
+        "argument": "Paul's polemic targets 'works of the law' — Torah observance claimed as grounds for right standing; James targets professed faith with no corresponding life. 'Faith' in James 2:14 means bare intellectual assent, which neither Paul nor James thinks saves. The two are allies against different errors.",
+        "strengths": "Attends closely to the distinct rhetorical situations (Judaizing legalism vs. antinomian presumption); explains why both can cite Abraham without conflict — Genesis 15 and Genesis 22 as root and fruit; majority position in modern commentaries on James.",
+        "weaknesses": "James 2:24 still uses dikaioo of Abraham's act, and some argue the semantic distinction is finer than the harmonization requires; critical scholars contend James may be responding to a garbled form of Paulinism, implying real tension in the early church.",
+        "key_verses": [
+          "Romans 3:28",
+          "Galatians 2:16",
+          "James 2:14",
+          "James 2:21-24"
+        ]
+      },
+      {
+        "id": "faith-formed-by-love-works-cooperate",
+        "label": "Faith working through love: works cooperate in justification",
+        "tradition_family": "patristic",
+        "scholar_ids": [
+          "augustine"
+        ],
+        "proponents": "Augustinian, Catholic, and Orthodox traditions",
+        "argument": "Justifying faith is faith formed by love (Galatians 5:6) — a living reality that works. Justification is not only an initial declaration but a transformative process in which grace-enabled works genuinely participate, which is why James can say a person is justified by works and not by faith alone.",
+        "strengths": "Takes James 2:24 in its plain sense without a demonstrative gloss; coheres with judgment-according-to-works texts (Matthew 25:31-46, Romans 2:6-13, 2 Corinthians 5:10); Augustine's insistence that even cooperating works are wholly gifts of grace guards against crude merit theology.",
+        "weaknesses": "Protestants argue it blurs Paul's justification/sanctification distinction and undercuts the gratuity of Romans 4:4-5; assurance becomes provisional in ways Paul's 'no condemnation' language (Romans 8:1) seems to resist.",
+        "key_verses": [
+          "James 2:24",
+          "Galatians 5:6",
+          "Romans 2:6-13",
+          "Matthew 25:31-46"
+        ]
+      }
+    ],
+    "synthesis": "Nearly all traditions agree on two boundary markers: salvation is by grace, and genuine faith transforms conduct. The disagreement concerns the grammar of 'justify' — one-time forensic verdict versus declarative-and-transformative process — and whether works function as evidence of justification or as grace-enabled participants in it. Read in context, Paul and James share more than the proof-texts suggest: Paul expects faith to work through love (Galatians 5:6) and warns the unrighteous will not inherit the kingdom (1 Corinthians 6:9-10), while James grounds everything in the 'implanted word' that saves (James 1:21). The choice between the positions ultimately tracks a reader's wider theology of grace, assurance, and final judgment.",
+    "related_passages": [
+      "Genesis 15:6",
+      "Genesis 22:1-19",
+      "Habakkuk 2:4",
+      "Galatians 5:6",
+      "Romans 2:6-13",
+      "Titus 3:5-8"
+    ],
+    "tags": [
+      "justification",
+      "faith",
+      "works",
+      "sola-fide",
+      "reformation",
+      "soteriology",
+      "paul-and-james"
+    ]
   }
 ]

--- a/content/meta/difficult-passages.json
+++ b/content/meta/difficult-passages.json
@@ -7361,5 +7361,122 @@
       "Edward Mack, 'Book of Jasher' in ISBE (1915)"
     ],
     "images": []
+  },
+  {
+    "id": "james-2-24-not-by-faith-alone",
+    "title": "James 2:24 — \"Not by Faith Alone\"",
+    "category": "contradiction",
+    "severity": "major",
+    "passage": "James 2:14-26; Romans 3:28",
+    "question": "James 2:24 states a person is justified by works and not by faith alone — the only place Scripture uses the phrase 'faith alone,' and it appears to deny it. How does this square with Paul's insistence that a person is justified by faith apart from works?",
+    "context": "Romans 3:28 and James 2:24 form the sharpest apparent contradiction in New Testament theology, sitting at the root of the Reformation divide. Luther's addition of 'allein' (alone) to his German translation of Romans 3:28, and his dismissal of James as 'an epistle of straw,' made this verse the flashpoint it remains. Both authors cite Abraham — Paul from Genesis 15:6, James from Genesis 22 — and both use the same verb, dikaioo. The resolution hinges on whether the two writers use 'faith,' 'works,' and 'justified' in the same sense, and on the distinct errors each was combating.",
+    "responses": [
+      {
+        "tradition": "Semantic Harmonization",
+        "tradition_family": "evangelical",
+        "scholar_id": "moo",
+        "summary": "Paul and James fight on different fronts with overlapping vocabulary. Paul excludes 'works of the law' — Torah observance offered as grounds of acceptance — from justification understood as God's initial verdict. James attacks a 'faith' that is bare assent (the demons of 2:19 qualify), arguing such faith is dead and cannot save. When James says Abraham was 'justified by works' in offering Isaac, he means Abraham's Genesis 15 faith was demonstrated and brought to completion in action (2:22). The two apostles would each affirm the other's actual claim: Paul agrees saving faith works (Galatians 5:6); James agrees salvation flows from the implanted word received in humility (James 1:18, 21).",
+        "key_verses": [
+          "James 2:19",
+          "James 2:22",
+          "Galatians 5:6",
+          "James 1:21"
+        ],
+        "strengths": "Explains the double appeal to Abraham without conflict; grounded in the distinct rhetorical situations of each letter; majority view across modern commentaries on James.",
+        "weaknesses": "Requires 'justified' to carry a demonstrative nuance in James that must be argued, not assumed; does not fully silence the suggestion that James responds to a distorted Paulinism circulating in the early church."
+      },
+      {
+        "tradition": "Reformed",
+        "tradition_family": "reformed",
+        "scholar_id": "calvin",
+        "summary": "Faith alone justifies, but the faith that justifies is never alone. Justification is a free forensic acquittal grounded in Christ's righteousness and received by faith without any contribution from works (Romans 4:4-5). Yet the same Spirit who gives faith necessarily produces good works, so a workless 'faith' is a corpse — precisely James's point. James speaks of the declaration of righteousness before other people and the proof of living faith, not of the ground of acceptance before God. The believer's assurance therefore rests wholly on Christ, while works serve as confirming fruit.",
+        "key_verses": [
+          "Romans 4:4-5",
+          "Romans 8:1",
+          "James 2:17",
+          "James 2:26"
+        ],
+        "strengths": "Preserves both the gratuity of justification and the moral seriousness of James; the fruit/root distinction has deep exegetical support in Jesus's own teaching (Matthew 7:16-20).",
+        "weaknesses": "The before-God/before-people distinction is imported into James rather than stated by him; critics note James says 'you see that' a person is justified by works, addressing what is true, not merely what is visible."
+      },
+      {
+        "tradition": "Augustinian / Catholic",
+        "tradition_family": "patristic",
+        "scholar_id": "augustine",
+        "summary": "The faith that justifies is faith working through love (Galatians 5:6); faith without love is the faith of demons. Justification begins as an unmerited gift and continues as a real transformation in which grace-enabled works participate — so James 2:24 may be taken in its plain sense. Crucially, the works that cooperate in justification are themselves gifts: when God crowns our merits, he crowns his own gifts. On this reading Paul excludes works done before and apart from grace as grounds of boasting, while James describes the working of grace in the justified life. The two texts describe one economy of grace from different vantage points.",
+        "key_verses": [
+          "James 2:24",
+          "Galatians 5:6",
+          "Philippians 2:12-13",
+          "Romans 2:6-7"
+        ],
+        "strengths": "Reads James 2:24 without semantic qualification; integrates the New Testament's judgment-according-to-works passages naturally; Augustine's grace-alone framing blocks the caricature of works-righteousness.",
+        "weaknesses": "Protestants argue it collapses Paul's justification/sanctification distinction and renders assurance provisional; Romans 4:5 ('to the one who does not work but believes') is difficult to fit within a cooperative model."
+      }
+    ],
+    "related_chapters": [
+      {
+        "book_dir": "james",
+        "chapter_num": 2
+      },
+      {
+        "book_dir": "romans",
+        "chapter_num": 3
+      },
+      {
+        "book_dir": "romans",
+        "chapter_num": 4
+      },
+      {
+        "book_dir": "galatians",
+        "chapter_num": 2
+      },
+      {
+        "book_dir": "genesis",
+        "chapter_num": 15
+      },
+      {
+        "book_dir": "genesis",
+        "chapter_num": 22
+      }
+    ],
+    "key_verses": [
+      "James 2:24",
+      "Romans 3:28",
+      "Genesis 15:6",
+      "Genesis 22:12",
+      "Galatians 5:6"
+    ],
+    "consensus": "Most scholars across traditions agree Paul and James are not addressing the same question: Paul excludes works as the ground of God's acceptance; James excludes workless assent as saving faith. The enduring divide is downstream — whether justification is a completed forensic verdict evidenced by works (Protestant) or a grace-initiated process in which works genuinely participate (Catholic/Orthodox). The 1999 Lutheran-Catholic Joint Declaration on the Doctrine of Justification narrowed but did not erase the difference.",
+    "further_reading": [
+      {
+        "author": "Douglas J. Moo",
+        "title": "The Letter of James (Pillar New Testament Commentary)",
+        "year": 2000
+      },
+      {
+        "author": "Thomas R. Schreiner",
+        "title": "Faith Alone: The Doctrine of Justification",
+        "year": 2015
+      },
+      {
+        "author": "Dan G. McCartney",
+        "title": "James (Baker Exegetical Commentary)",
+        "year": 2009
+      },
+      {
+        "author": "James D. G. Dunn, ed. contributors",
+        "title": "Justification: Five Views (eds. Beilby & Eddy)",
+        "year": 2011
+      }
+    ],
+    "tags": [
+      "justification",
+      "faith",
+      "works",
+      "sola-fide",
+      "paul-and-james",
+      "reformation"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Fills a discovery-layer gap: the app had strong James 2:14-26 section content (Moo, MacArthur, cross-refs) but no dedicated entry in either debate topics or difficult passages for the Paul-vs-James justification question.

**Adds:**
- Debate topic `justification-faith-alone-or-faith-and-works` (james/2) — 3 positions: Reformed evidence-of-faith (Calvin, Schreiner), semantic harmonization (Moo, McCartney), Augustinian/Catholic cooperative (Augustine). Synthesis + related passages + tags.
- Difficult passage `james-2-24-not-by-faith-alone` (category: contradiction, severity: major) — 3 responses mirroring the traditions, consensus note incl. 1999 Joint Declaration, further reading (Moo, Schreiner, McCartney, Beilby/Eddy).

**Verification:** schema_validator 0 failures; build_sqlite + validate_sqlite pass; both rows confirmed in scripture.db (debate_topics 318, difficult_passages 60). All scholar_ids exist in registry; attributions reflect published positions.

**Rollback:** revert commit; both entries are additive appends with no schema changes.

---
## Also: Dependabot #65 fix
Bumps transitive `brace-expansion` (via `minimatch` inside Expo CLI/config tooling) from 5.0.x to **5.0.7**, resolving CVE-2026-13149 (high — DoS via exponential-time expansion). Lockfile-only change (`npm update brace-expansion --package-lock-only`); no direct dependency, no version-range edits in `package.json`. The 1.x and 2.x instances present are outside the vulnerable range (>=3.0.0 <5.0.7). Rollback: revert this commit independently of the content commit.